### PR TITLE
Fix: Create task log callback map

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/payments",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Typescript SDK to interact with the Nevermined Payments Protocol",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -39,7 +39,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-tsdoc": "^0.2.17",
     "jest": "^29.7.0",
-    "ts-jest": "^29.2.5",    
+    "ts-jest": "^29.2.5",
     "@types/jest": "^29.5.13",
     "@types/ws": "^8.0.3",
     "prettier": "^3.2.5",

--- a/src/api/nvm-backend.ts
+++ b/src/api/nvm-backend.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { decodeJwt } from 'jose'
 import { io } from 'socket.io-client'
 import { sleep } from '../common/helper'
-import { AgentExecutionStatus, TaskLogMessage } from '../common/types'
+import { AgentExecutionStatus, TaskLogMessage, TaskCallback } from '../common/types'
 import { isEthereumAddress } from '../utils'
 import { PaymentsError } from '../common/payments.error'
 
@@ -91,7 +91,7 @@ export class NVMBackendApi {
   private opts: BackendApiOptions
   private socketClient: any
   private userRoomId: string | undefined = undefined
-  private taskCallbacks: Map<string, Function>
+  private taskCallbacks: Map<string, TaskCallback> = new Map()
   private hasKey = false
   private _defaultSocketOptions: BackendWebSocketOptions = {
     // path: '',
@@ -227,7 +227,7 @@ export class NVMBackendApi {
    * Parses the incoming data, retrieves the corresponding callback,
    * executes it, and removes the callback if the task is completed or failed.
    *
-   * @param {any} data - The data received from the websocket event.
+   * @param data - The data received from the websocket event.
    */
   private handleTaskLog(data: any): void {
     const parsedData = JSON.parse(data)
@@ -247,7 +247,7 @@ export class NVMBackendApi {
    * Removes the callback associated with the given task ID.
    * Logs the removal of the callback.
    *
-   * @param {string} taskId - The ID of the task whose callback is to be removed.
+   * @param taskId - The ID of the task whose callback is to be removed.
    */
   private removeTaskCallback(taskId: string) {
     if (this.taskCallbacks.has(taskId)) {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -192,6 +192,8 @@ export interface TaskLogMessage {
   step_id?: string
 }
 
+export type TaskCallback = (data: any) => void
+
 export interface CreateTaskDto {
   /**
    * The query parameter for the task


### PR DESCRIPTION
## Description

- Removed .on('_connect') handler when adding callback handlers to task log. 
- Added callback map (one callback for each task id, if it is needed)
- Removed callbacks once task is completed or failed.

## Is this PR related with an open issue?

No

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] Follows the code style of this project.
- [X] Tests Cover Changes
- [X] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()
