### PR TITLE
Remove the need for a user to provide an helicone api key

### DIFF
--- a/src/api/base-payments.ts
+++ b/src/api/base-payments.ts
@@ -15,6 +15,7 @@ export abstract class BasePaymentsAPI {
   protected appId?: string
   protected version?: string
   protected accountAddress?: string
+  protected heliconeApiKey?: string
   public isBrowserInstance = true
 
   constructor(options: PaymentOptions) {
@@ -37,6 +38,7 @@ export abstract class BasePaymentsAPI {
       }
       const jwt = decodeJwt(this.nvmApiKey)
       this.accountAddress = jwt.sub
+      this.heliconeApiKey = jwt.observability as string
     } catch (error) {
       throw new PaymentsError('Invalid NVM API Key')
     }

--- a/src/api/base-payments.ts
+++ b/src/api/base-payments.ts
@@ -38,7 +38,7 @@ export abstract class BasePaymentsAPI {
       }
       const jwt = decodeJwt(this.nvmApiKey)
       this.accountAddress = jwt.sub
-      this.heliconeApiKey = jwt.observability as string
+      this.heliconeApiKey = jwt.o11y as string
     } catch (error) {
       throw new PaymentsError('Invalid NVM API Key')
     }

--- a/src/api/observability-api.ts
+++ b/src/api/observability-api.ts
@@ -350,7 +350,6 @@ export class ObservabilityAPI extends BasePaymentsAPI {
    * @param resultExtractor - Function to extract the user-facing result from internal result
    * @param usageCalculator - Function to calculate usage metrics from the internal result
    * @param responseIdPrefix - Prefix for the response ID
-   * @param heliconeApiKey - The Helicone API key for logging
    * @param customAgentId - Optional custom agent ID
    * @param customSessionId - Optional custom session ID
    * @returns Promise that resolves to the extracted user result
@@ -362,7 +361,6 @@ export class ObservabilityAPI extends BasePaymentsAPI {
     resultExtractor: (internalResult: TInternal) => TExtracted,
     usageCalculator: (internalResult: TInternal) => HeliconeResponseConfig['usage'],
     responseIdPrefix: string,
-    heliconeApiKey: string,
     customAgentId?: string,
     customSessionId?: string,
   ): Promise<TExtracted> {
@@ -373,7 +371,7 @@ export class ObservabilityAPI extends BasePaymentsAPI {
       resultExtractor,
       usageCalculator,
       responseIdPrefix,
-      heliconeApiKey,
+      this.heliconeApiKey!,
       customAgentId,
       customSessionId,
     )
@@ -394,11 +392,16 @@ export class ObservabilityAPI extends BasePaymentsAPI {
   withHeliconeLangchain(
     model: string,
     apiKey: string,
-    heliconeApiKey: string,
     customAgentId?: string,
     customSessionId?: string,
   ) {
-    return withHeliconeLangchain(model, apiKey, heliconeApiKey, customAgentId, customSessionId)
+    return withHeliconeLangchain(
+      model,
+      apiKey,
+      this.heliconeApiKey!,
+      customAgentId,
+      customSessionId,
+    )
   }
 
   /**
@@ -407,18 +410,12 @@ export class ObservabilityAPI extends BasePaymentsAPI {
    * Usage: const openai = new OpenAI(observability.withHeliconeOpenAI(apiKey, heliconeApiKey));
    *
    * @param apiKey - The OpenAI API key
-   * @param heliconeApiKey - The Helicone API key for logging
    * @param customAgentId - Optional custom agent ID
    * @param customSessionId - Optional custom session ID
    * @returns Configuration object for OpenAI constructor with Helicone enabled
    */
-  withHeliconeOpenAI(
-    apiKey: string,
-    heliconeApiKey: string,
-    customAgentId?: string,
-    customSessionId?: string,
-  ) {
-    return withHeliconeOpenAI(apiKey, heliconeApiKey, customAgentId, customSessionId)
+  withHeliconeOpenAI(apiKey: string, customAgentId?: string, customSessionId?: string) {
+    return withHeliconeOpenAI(apiKey, this.heliconeApiKey!, customAgentId, customSessionId)
   }
 
   /**

--- a/tests/unit/observability-api.test.ts
+++ b/tests/unit/observability-api.test.ts
@@ -1,0 +1,18 @@
+import { Payments } from '../../src/payments'
+
+describe('Observability-Api (unit)', () => {
+  const nvmApiKeyHash =
+    'eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweDA2OEVkMDBjRjA0NDFlNDgyOUQ5Nzg0ZkNCZTdiOWUyNkQ0QkQ4ZDAiLCJzdWIiOiIweDc3OUEzMDNEYTA3NjkwMzgxNkNBOTRlODhERDViNDJCMjE3M0YyNjciLCJqdGkiOiIweDM0MzAxYmIyMDYzYjNlYjVkNWE0NjFmZDM1YzI2MmVhNzI5Yzg5NDlhMWYzZTFhNzY4YmM2MWZiN2EzMzkyN2IiLCJleHAiOjE3ODcwODMxMzksIm9ic2VydmFiaWxpdHkiOiJzay1oZWxpY29uZS0zMm1hanFpLWZscGVsZGEtdTcyaWZ0eS1mY2VjY3lxIn0.aHNSLRCNOa3TBP2lTvlqOHuGTA0l7JhpuxoSm7VsB91PbXhVixq79wpxzLoe_H7OCSTzIbKLi5HXv_7vLEr7MBw'
+
+  it('should initialize correctly with the helicone api key', () => {
+    const payments = Payments.getInstance({
+      nvmApiKey: nvmApiKeyHash,
+      environment: 'staging_sandbox',
+    })
+
+    const cfg = payments.observability.withHeliconeOpenAI('sk-openai')
+    expect(cfg.defaultHeaders['Helicone-Auth']).toBe(
+      'Bearer sk-helicone-32majqi-flpelda-u72ifty-fceccyq',
+    )
+  })
+})

--- a/tests/unit/observability-api.test.ts
+++ b/tests/unit/observability-api.test.ts
@@ -2,7 +2,7 @@ import { Payments } from '../../src/payments'
 
 describe('Observability-Api (unit)', () => {
   const nvmApiKeyHash =
-    'eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweDA2OEVkMDBjRjA0NDFlNDgyOUQ5Nzg0ZkNCZTdiOWUyNkQ0QkQ4ZDAiLCJzdWIiOiIweDc3OUEzMDNEYTA3NjkwMzgxNkNBOTRlODhERDViNDJCMjE3M0YyNjciLCJqdGkiOiIweDM0MzAxYmIyMDYzYjNlYjVkNWE0NjFmZDM1YzI2MmVhNzI5Yzg5NDlhMWYzZTFhNzY4YmM2MWZiN2EzMzkyN2IiLCJleHAiOjE3ODcwODMxMzksIm9ic2VydmFiaWxpdHkiOiJzay1oZWxpY29uZS0zMm1hanFpLWZscGVsZGEtdTcyaWZ0eS1mY2VjY3lxIn0.aHNSLRCNOa3TBP2lTvlqOHuGTA0l7JhpuxoSm7VsB91PbXhVixq79wpxzLoe_H7OCSTzIbKLi5HXv_7vLEr7MBw'
+    'eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweDA2OEVkMDBjRjA0NDFlNDgyOUQ5Nzg0ZkNCZTdiOWUyNkQ0QkQ4ZDAiLCJzdWIiOiIweDQzQ0FDZUQxNURhRWE4MDE2RTIzNDI5NThFZjgyQTk0NTAxMTJlMTgiLCJqdGkiOiIweDJmNzZlN2ZkYzI3ZWIyYmYzYjQ0ODRlYmY1Mzk4YWQ5MjllMjMxYTYwODlmMDE5Zjk5ZDAzMjk3Mjk4YWYzZTkiLCJleHAiOjE3ODczMjc3MDEsIm8xMXkiOiJzay1oZWxpY29uZS1tamZ6MzJhLXF4aXVpMnEteDV5YmNoeS11NnJjZXhpIn0.KdMMHlHvpENmvT6ozVdfmtNC6KFMnh_XNNQEV_qxPpFgzvUM86vM21E5YKFVWkjK_yMAnNh6XVJGVjqPVuew6xs'
 
   it('should initialize correctly with the helicone api key', () => {
     const payments = Payments.getInstance({
@@ -12,7 +12,7 @@ describe('Observability-Api (unit)', () => {
 
     const cfg = payments.observability.withHeliconeOpenAI('sk-openai')
     expect(cfg.defaultHeaders['Helicone-Auth']).toBe(
-      'Bearer sk-helicone-32majqi-flpelda-u72ifty-fceccyq',
+      'Bearer sk-helicone-mjfz32a-qxiui2q-x5ybchy-u6rcexi',
     )
   })
 })


### PR DESCRIPTION
## Description

- Removes the need for a user wanting to use the observability api to have to provide an helicone api key
- The nvm api key jwt now contains the helicone api key
- The observability api class is now initialized with the helicone api key for internal use

## Is this PR related with an open issue?

Related to Issue #129 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()
