### PR TITLE
feat: add batch request functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/payments",
-  "version": "1.0.0-rc15",
+  "version": "1.0.0-rc16",
   "description": "Typescript SDK to interact with the Nevermined Payments Protocol",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/api/observability-api.ts
+++ b/src/api/observability-api.ts
@@ -62,6 +62,7 @@ export type NeverminedHeliconeHeaders = {
   'Helicone-Property-agentRequestId': string
   'Helicone-Property-pricePerCredit': string
   'Helicone-Property-environmentName': string
+  'Helicone-Property-batch': string
 }
 
 export type DefaultHeliconeHeaders = NeverminedHeliconeHeaders & CustomProperties
@@ -100,6 +101,7 @@ function getDefaultHeliconeHeaders(
     'Helicone-Property-agentRequestId': agentRequest.agentRequestId,
     'Helicone-Property-pricePerCredit': agentRequest.balance.pricePerCredit.toString(),
     'Helicone-Property-environmentName': environmentName,
+    'Helicone-Property-batch': agentRequest.batch.toString(),
   }
 
   // Build custom property headers from all properties

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -180,6 +180,7 @@ export interface StartAgentRequest {
   balance: PlanBalance
   urlMatching: string
   verbMatching: string
+  batch: boolean
 }
 
 export interface ValidationAgentRequest {

--- a/tests/unit/observability-api.test.ts
+++ b/tests/unit/observability-api.test.ts
@@ -17,6 +17,7 @@ describe('Observability-Api (unit)', () => {
     },
     urlMatching: 'test-url-matching',
     verbMatching: 'test-verb-matching',
+    batch: false,
   } as StartAgentRequest
 
   it('should initialize correctly with the helicone api key and helicone url', () => {


### PR DESCRIPTION
## Description

- Adds two new methods `startProcessingBatchRequest`, `redeemCreditsFromBatchRequest` that sets the batch flag to true to be logged by helicone and notify the backend that it's a batch request when redeeming the credits

## Is this PR related with an open issue?

Related to Issue https://github.com/nevermined-io/nvm-monorepo/issues/427

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()
