### PR TITLE
fix: update environment naming in docs and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ import { Payments } from "@nevermined-io/payments";
 
 const payments = Payments.getInstance({
   nvmApiKey,
-  environment: 'testing' as EnvironmentName,
+  environment: 'sandbox' as EnvironmentName,
 })
 ```
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -6,8 +6,8 @@ import { EnvironmentName } from '../environments.js'
 export interface PaymentOptions {
   /**
    * The Nevermined environment to connect to.
-   * If you are developing an agent it's recommended to use the "testing" environment.
-   * When deploying to production use the "arbitrum" environment.
+   * If you are developing an agent it's recommended to use the "sandbox" environment.
+   * When deploying to live use the "live" environment.
    */
   environment: EnvironmentName
 

--- a/src/environments.ts
+++ b/src/environments.ts
@@ -29,7 +29,7 @@ export const Environments: Record<EnvironmentName, EnvironmentInfo> = {
     heliconeUrl: 'https://helicone.nevermined.dev',
   },
   /**
-   * The Production environment URLs.
+   * The Sandbox environment URLs.
    */
   sandbox: {
     frontend: 'https://nevermined.app',
@@ -37,6 +37,9 @@ export const Environments: Record<EnvironmentName, EnvironmentInfo> = {
     proxy: 'https://proxy.sandbox.nevermined.app',
     heliconeUrl: 'https://helicone.nevermined.dev',
   },
+  /**
+   * The Live environment URLs.
+   */
   live: {
     frontend: 'https://nevermined.app',
     backend: 'https://api.live.nevermined.app/',

--- a/src/payments.ts
+++ b/src/payments.ts
@@ -99,9 +99,9 @@ export class Payments extends BasePaymentsAPI {
    * @param options - The options to initialize the payments class.
    * @example
    * ```
-   * const payments = Payments.getInstance({1
+   * const payments = Payments.getInstance({
    *   nvmApiKey: 'your-nvm-api-key',
-   *   environment: 'testing'
+   *   environment: 'sandbox'
    * })
    * ```
    * @returns An instance of {@link Payments}
@@ -125,7 +125,7 @@ export class Payments extends BasePaymentsAPI {
    * ```
    * const payments = Payments.getBrowserInstance({
    *   returnUrl: 'https://mysite.example',
-   *   environment: 'testing',
+   *   environment: 'sandbox',
    *   appId: 'my-app-id',
    *   version: '1.0.0'
    * })

--- a/src/x402/facilitator-api.ts
+++ b/src/x402/facilitator-api.ts
@@ -9,7 +9,7 @@
  * // Initialize the Payments instance
  * const payments = Payments.getInstance({
  *   nvmApiKey: 'your-nvm-api-key',
- *   environment: 'testing'
+ *   environment: 'sandbox'
  * })
  *
  * // Get X402 access token from X402 API

--- a/tests/unit/mcp/oauth_metadata_builders.test.ts
+++ b/tests/unit/mcp/oauth_metadata_builders.test.ts
@@ -288,8 +288,8 @@ describe('OAuth Metadata Builders', () => {
       expect(urls.userinfoUri).toContain('/oauth/userinfo')
     })
 
-    test('should return URLs for production environment', () => {
-      const urls = getOAuthUrls('production')
+    test('should return URLs for live environment', () => {
+      const urls = getOAuthUrls('live')
 
       expect(urls.issuer).toBeDefined()
       expect(urls.authorizationUri).toContain('/oauth/authorize')

--- a/tests/unit/payments.test.ts
+++ b/tests/unit/payments.test.ts
@@ -74,13 +74,13 @@ describe('Payments', () => {
 
     test('getServiceHostFromEndpoints should extract host correctly', () => {
       const endpoints: Endpoint[] = [
-        { POST: 'https://one-backend.testing.nevermined.app/api/v1/agents/(.*)/tasks' },
+        { POST: 'https://api.sandbox.nevermined.app/api/v1/agents/(.*)/tasks' },
         {
-          GET: 'https://one-backend.testing.nevermined.app/api/v1/agents/(.*)/tasks/(.*)',
+          GET: 'https://api.sandbox.nevermined.app/api/v1/agents/(.*)/tasks/(.*)',
         },
       ]
       const serviceHost = getServiceHostFromEndpoints(endpoints)
-      expect(serviceHost).toBe('https://one-backend.testing.nevermined.app')
+      expect(serviceHost).toBe('https://api.sandbox.nevermined.app')
     })
   })
 })


### PR DESCRIPTION
## Summary
- Replace deprecated 'testing'/'production' references with correct 'sandbox'/'live' environment names
- Update code examples in README.md, src/payments.ts, src/x402/facilitator-api.ts
- Fix environment comments in src/environments.ts and src/common/types.ts
- Update test URLs to use sandbox domain

## Test plan
- [ ] Verify documentation renders correctly
- [ ] Run unit tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)