### PR TITLE
fix(ci): skip npm version when CLI already matches tag

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -56,8 +56,11 @@ jobs:
       - name: Update CLI version
         working-directory: cli
         run: |
-          npm version ${{ steps.version.outputs.version }} --no-git-tag-version
-          echo "Updated CLI version to ${{ steps.version.outputs.version }}"
+          CURRENT=$(node -p "require('./package.json').version")
+          if [ "$CURRENT" != "${{ steps.version.outputs.version }}" ]; then
+            npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+          fi
+          echo "CLI version is ${{ steps.version.outputs.version }}"
 
       - name: Generate CLI commands
         working-directory: cli


### PR DESCRIPTION
## Summary
- Fixes `Publish CLI Package` workflow failure when `cli/package.json` already has the target version
- `npm version X --no-git-tag-version` errors with "Version not changed" if the version is already set — this adds a check to skip it

## Changed files
- `.github/workflows/cli-publish.yml` — Compare current version before running `npm version`

## Context
This caused the `Publish CLI Package` workflow to fail on the `v1.0.4` release (run #21864786490), even though the CLI was published correctly by the NPM Release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)