### PR TITLE
fix: use Node 20.x in release workflows

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.17
+          node-version: '20.x'
 
       - name: Create release branch
         id: info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.17
+          node-version: '20.x'
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.17
+          node-version: '20.x'
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
@@ -89,7 +89,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.17
+          node-version: '20.x'
           cache: 'yarn'
           cache-dependency-path: yarn.lock
           registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
## Summary

- Update `prepare-release.yml` and `release.yml` to use Node `20.x` instead of `22.17`
- `posthog-node@5.24.7` (transitive dep via `@traceloop/node-server-sdk`) requires Node `^20.20.0 || >=22.22.0` — Node `22.17` falls outside both ranges
- All other workflows already use `20.x`, this makes release workflows consistent

## Test plan

- [x] Verified `yarn install && yarn build` passes locally with Node `20.20.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)