### PR TITLE
feat: add DelegationAPI for stripe delegation management

### DIFF
--- a/src/api/nvm-api.ts
+++ b/src/api/nvm-api.ts
@@ -29,6 +29,13 @@ export const API_URL_CREATE_USER = '/api/v1/organizations/account'
 export const API_URL_GET_MEMBERS = '/api/v1/organizations/members'
 export const API_URL_CONNECT_STRIPE_ACCOUNT = '/api/v1/stripe/account'
 
+// Delegation endpoints
+export const API_URL_DELEGATION_SETUP_INTENT = '/api/v1/delegation/setup-intent'
+export const API_URL_DELEGATION_CREATE = '/api/v1/delegation/create'
+export const API_URL_DELEGATION_LIST = '/api/v1/delegation'
+export const API_URL_DELEGATION_GET = '/api/v1/delegation'
+export const API_URL_DELEGATION_PAYMENT_METHODS = '/api/v1/delegation/payment-methods'
+
 export interface BackendApiOptions {
   /**
    * The host of the backend server

--- a/src/delegation/delegation-api.ts
+++ b/src/delegation/delegation-api.ts
@@ -22,7 +22,7 @@
  * const { delegationToken, delegationId } = await payments.delegation.createDelegation({
  *   providerPaymentMethodId: methods[0].id,
  *   spendingLimitCents: 10000, // $100
- *   durationDays: 7,
+ *   durationSecs: 604800, // 7 days
  * })
  *
  * // 4. Use the delegationToken as the x402 access token (payment-signature header)
@@ -49,8 +49,8 @@ export interface CreateDelegationParams {
   providerPaymentMethodId: string
   /** Maximum spending limit in cents */
   spendingLimitCents: number
-  /** Duration of the delegation in days */
-  durationDays: number
+  /** Duration of the delegation in seconds */
+  durationSecs: number
   /** Currency code (default: 'usd') */
   currency?: string
   /** Optional: restrict to a specific plan */

--- a/src/delegation/delegation-api.ts
+++ b/src/delegation/delegation-api.ts
@@ -1,0 +1,222 @@
+/**
+ * The DelegationAPI class provides methods to manage fiat spending delegations.
+ * Delegations allow clients to authorize AI agents to make payments on their behalf
+ * using saved payment methods (e.g., Stripe) within defined spending limits.
+ *
+ * @example
+ * ```typescript
+ * import { Payments } from '@nevermined-io/payments'
+ *
+ * const payments = Payments.getInstance({
+ *   nvmApiKey: 'your-nvm-api-key',
+ *   environment: 'sandbox'
+ * })
+ *
+ * // 1. Create a SetupIntent to save a payment method
+ * const { clientSecret } = await payments.delegation.createSetupIntent()
+ *
+ * // 2. After confirming with Stripe.js, list saved payment methods
+ * const methods = await payments.delegation.listPaymentMethods()
+ *
+ * // 3. Create a delegation with spending limits
+ * const { delegationToken, delegationId } = await payments.delegation.createDelegation({
+ *   providerPaymentMethodId: methods[0].id,
+ *   spendingLimitCents: 10000, // $100
+ *   durationDays: 7,
+ * })
+ *
+ * // 4. Use the delegationToken as the x402 access token (payment-signature header)
+ * // The verify/settle endpoints auto-detect the JWT delegation token
+ * ```
+ */
+
+import { BasePaymentsAPI } from '../api/base-payments.js'
+import {
+  API_URL_DELEGATION_SETUP_INTENT,
+  API_URL_DELEGATION_CREATE,
+  API_URL_DELEGATION_LIST,
+  API_URL_DELEGATION_GET,
+  API_URL_DELEGATION_PAYMENT_METHODS,
+} from '../api/nvm-api.js'
+import { PaymentsError } from '../common/payments.error.js'
+import { PaymentOptions } from '../common/types.js'
+
+/**
+ * Parameters for creating a spending delegation
+ */
+export interface CreateDelegationParams {
+  /** Stripe payment method ID (e.g., 'pm_xxx') */
+  providerPaymentMethodId: string
+  /** Maximum spending limit in cents */
+  spendingLimitCents: number
+  /** Duration of the delegation in days */
+  durationDays: number
+  /** Currency code (default: 'usd') */
+  currency?: string
+  /** Optional: restrict to a specific plan */
+  planId?: string
+  /** Optional: restrict to a specific merchant */
+  merchantAccountId?: string
+  /** Optional: maximum number of transactions */
+  maxTransactions?: number
+}
+
+/**
+ * Summary of a saved payment method
+ */
+export interface PaymentMethodSummary {
+  id: string
+  type: string
+  brand: string
+  last4: string
+  expMonth: number
+  expYear: number
+}
+
+/**
+ * Summary of a delegation (matches server DelegationSummaryDto)
+ */
+export interface DelegationSummary {
+  delegationId: string
+  provider: string
+  status: string
+  spendingLimitCents: string
+  amountSpentCents: string
+  remainingBudgetCents: string
+  currency: string
+  expiresAt: string
+  createdAt: string
+}
+
+/**
+ * Detailed delegation information (matches server DelegationDetailsDto)
+ */
+export interface DelegationDetails extends DelegationSummary {
+  providerPaymentMethodId: string
+  planId: string | null
+  merchantAccountId: string | null
+  maxTransactions: number | null
+  transactionCount: number
+  lastUsedAt: string | null
+}
+
+/**
+ * Paginated delegation list (matches server DelegationListDto)
+ */
+export interface DelegationListResult {
+  delegations: DelegationSummary[]
+  totalResults: number
+  page: number
+  offset: number
+}
+
+/**
+ * Delegation transaction record (matches server DelegationTransactionDto)
+ */
+export interface DelegationTransaction {
+  id: string
+  providerTransactionId: string
+  amountCents: string
+  currency: string
+  status: string
+  failureReason: string | null
+  createdAt: string
+}
+
+/**
+ * Paginated transaction list (matches server DelegationTransactionListDto)
+ */
+export interface DelegationTransactionListResult {
+  transactions: DelegationTransaction[]
+  totalResults: number
+  page: number
+  offset: number
+}
+
+/**
+ * The DelegationAPI class provides methods to manage fiat spending delegations.
+ * It enables clients to save payment methods, create delegations with spending limits,
+ * and manage delegation lifecycle.
+ */
+export class DelegationAPI extends BasePaymentsAPI {
+  static getInstance(options: PaymentOptions): DelegationAPI {
+    return new DelegationAPI(options)
+  }
+
+  /** Create a Stripe SetupIntent for saving a payment method. */
+  async createSetupIntent(): Promise<{ clientSecret: string }> {
+    return this.fetchJson('POST', API_URL_DELEGATION_SETUP_INTENT)
+  }
+
+  /** List saved payment methods for the authenticated user. */
+  async listPaymentMethods(): Promise<PaymentMethodSummary[]> {
+    return this.fetchJson('GET', API_URL_DELEGATION_PAYMENT_METHODS)
+  }
+
+  /** Create a spending delegation and return a signed JWT token. */
+  async createDelegation(
+    params: CreateDelegationParams,
+  ): Promise<{ delegationToken: string; delegationId: string }> {
+    return this.fetchJson('POST', API_URL_DELEGATION_CREATE, { body: params })
+  }
+
+  /** List all delegations for the authenticated user. */
+  async listDelegations(page = 1, offset = 10): Promise<DelegationListResult> {
+    return this.fetchJson('GET', API_URL_DELEGATION_LIST, {
+      query: { page: String(page), offset: String(offset) },
+    })
+  }
+
+  /** Get detailed delegation information including remaining budget. */
+  async getDelegation(delegationId: string): Promise<DelegationDetails> {
+    return this.fetchJson('GET', `${API_URL_DELEGATION_GET}/${delegationId}`)
+  }
+
+  /** Revoke an active delegation. This immediately prevents any further charges. */
+  async revokeDelegation(delegationId: string): Promise<{ success: boolean }> {
+    return this.fetchJson('DELETE', `${API_URL_DELEGATION_GET}/${delegationId}`)
+  }
+
+  /** List transactions for a specific delegation. */
+  async getTransactions(
+    delegationId: string,
+    page = 1,
+    offset = 10,
+  ): Promise<DelegationTransactionListResult> {
+    return this.fetchJson('GET', `${API_URL_DELEGATION_GET}/${delegationId}/transactions`, {
+      query: { page: String(page), offset: String(offset) },
+    })
+  }
+
+  // --- Private helpers ---
+
+  private async fetchJson<T>(
+    method: string,
+    path: string,
+    opts?: { body?: any; query?: Record<string, string> },
+  ): Promise<T> {
+    const url = new URL(path, this.environment.backend)
+    if (opts?.query) {
+      for (const [k, v] of Object.entries(opts.query)) url.searchParams.set(k, v)
+    }
+    const fetchOpts = this.getBackendHTTPOptions(method, opts?.body)
+
+    try {
+      const response = await fetch(url, fetchOpts)
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        throw PaymentsError.fromBackend(errorData.message || `Request failed: ${method} ${path}`, {
+          message: errorData.message,
+          code: `HTTP ${response.status}`,
+        })
+      }
+      return await response.json()
+    } catch (error) {
+      if (error instanceof PaymentsError) throw error
+      throw PaymentsError.fromBackend(`Network error: ${method} ${path}`, {
+        message: error instanceof Error ? error.message : String(error),
+        code: 'network_error',
+      })
+    }
+  }
+}

--- a/src/delegation/index.ts
+++ b/src/delegation/index.ts
@@ -1,0 +1,10 @@
+export {
+  DelegationAPI,
+  type CreateDelegationParams,
+  type PaymentMethodSummary,
+  type DelegationSummary,
+  type DelegationDetails,
+  type DelegationListResult,
+  type DelegationTransaction,
+  type DelegationTransactionListResult,
+} from './delegation-api.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,18 @@ export * from './api/observability-api/observability-api.js'
 export type { BackendApiOptions } from './api/nvm-api.js'
 export { ContractsAPI } from './api/contracts-api.js'
 
+// Delegation types
+export { DelegationAPI } from './delegation/delegation-api.js'
+export type {
+  CreateDelegationParams,
+  PaymentMethodSummary,
+  DelegationSummary,
+  DelegationDetails,
+  DelegationListResult,
+  DelegationTransaction,
+  DelegationTransactionListResult,
+} from './delegation/delegation-api.js'
+
 // x402 utilities and types
 export { buildPaymentRequired } from './x402/facilitator-api.js'
 export type {

--- a/src/payments.ts
+++ b/src/payments.ts
@@ -13,6 +13,7 @@ import { PaymentsA2AServer } from './a2a/server.js'
 import { buildPaymentAgentCard } from './a2a/agent-card.js'
 import * as mcpModule from './mcp/index.js'
 import { OrganizationsAPI } from './api/organizations-api/organizations-api.js'
+import { DelegationAPI } from './delegation/delegation-api.js'
 import { FacilitatorAPI } from './x402/facilitator-api.js'
 import { X402TokenAPI } from './x402/token.js'
 
@@ -37,6 +38,7 @@ export class Payments extends BasePaymentsAPI {
   public observability!: ObservabilityAPI
   public organizations!: OrganizationsAPI
   public contracts!: ContractsAPI
+  public delegation!: DelegationAPI
   public facilitator!: FacilitatorAPI
   public x402!: X402TokenAPI
   private _a2aRegistry?: ClientRegistry
@@ -177,6 +179,7 @@ export class Payments extends BasePaymentsAPI {
     this.organizations = OrganizationsAPI.getInstance(options)
     this.query = AIQueryApi.getInstance()
     this.contracts = new ContractsAPI(options)
+    this.delegation = DelegationAPI.getInstance(options)
     this.facilitator = FacilitatorAPI.getInstance(options)
     this.x402 = X402TokenAPI.getInstance(options)
   }


### PR DESCRIPTION
## Summary

- Adds `DelegationAPI` class to the payments SDK for managing fiat spending delegations
- Supports SetupIntent creation, payment method listing, delegation CRUD, and transaction history
- Type definitions matching server DTOs (`DelegationSummary`, `DelegationDetails`, `DelegationTransaction`, etc.)
- Registered as `payments.delegation` in `Payments.initializeApi()`
- Companion to [nevermined-io/nvm-monorepo feat/stripe-delegation](https://github.com/nevermined-io/nvm-monorepo/pull/new/feat/stripe-delegation)

## Test plan

- [ ] `yarn build` compiles successfully
- [ ] `yarn test:unit` — all 105 unit tests pass
- [ ] Integration test: `createSetupIntent()` returns valid client secret
- [ ] Integration test: `createDelegation()` → `getDelegation()` round-trip
- [ ] Integration test: `revokeDelegation()` → verify status change
- [ ] E2E: delegation token used as `payment-signature` header for x402 settle

🤖 Generated with [Claude Code](https://claude.com/claude-code)