### PR TITLE
chore(ci): upgrade all workflows to Node 24

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 

--- a/.github/workflows/cli-sync-and-test.yml
+++ b/.github/workflows/cli-sync-and-test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 

--- a/.github/workflows/openclaw-sync-and-test.yml
+++ b/.github/workflows/openclaw-sync-and-test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
 
       - name: Create release branch
         id: info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 
@@ -73,7 +73,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
@@ -108,7 +108,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'yarn'
           cache-dependency-path: yarn.lock
           registry-url: https://registry.npmjs.org/
@@ -188,7 +188,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'yarn'
           cache-dependency-path: yarn.lock
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 
@@ -123,7 +123,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 
@@ -162,7 +162,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- Upgrade all GitHub Actions workflows from Node 20.x to Node 24.x
- Node 24 ships with npm 11.11.0, which is required for OIDC trusted publishing (npm 11.5.1+ required)

## Test plan

- [ ] Trigger a release tag and verify npm publish succeeds via OIDC
- [ ] Verify CI tests pass with Node 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)