### PR TITLE
feat: make agentDefinitionUrl and endpoints optional in AgentAPIAttributes

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -329,17 +329,24 @@ export interface PlanMetadata extends AgentMetadata {
  */
 export interface AgentAPIAttributes {
   /**
-   * The list endpoints of the upstream service. All these endpoints are protected and only accessible to subscribers of the Payment Plan.
+   * Optional allowlist of upstream endpoints that require a valid Payment Plan
+   * subscription. When provided, the Nevermined platform enforces this list as
+   * **Additional Security** (defense-in-depth) on top of any per-route gating
+   * the Payments library middleware applies in your agent. When omitted, no
+   * route-level allowlist is enforced — your library middleware remains the
+   * sole gate.
    */
-  endpoints: Endpoint[]
+  endpoints?: Endpoint[]
   /**
    * The list of endpoints of the upstream service that publicly available. The access to these endpoints don't require subscription to the Payment Plan. They are useful to expose documentation, etc.
    */
   openEndpoints?: string[]
   /**
-   * The URL to the agent definition. Can be an OpenAPI spec, MCP Manifest, or A2A agent card. This field is mandatory and defines how the agent/service can be discovered and queried.
+   * Optional URL to a discoverable agent definition (OpenAPI spec, MCP
+   * Manifest, or A2A agent card). Stored as metadata for documentation /
+   * discovery — not consumed at runtime by the Nevermined platform.
    */
-  agentDefinitionUrl: string
+  agentDefinitionUrl?: string
 
   /////// AUTHORIZATION ///////
 

--- a/tests/unit/agent-api-attributes-optional.test.ts
+++ b/tests/unit/agent-api-attributes-optional.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Type-level + runtime checks that AgentAPIAttributes accepts payloads with
+ * `endpoints` and `agentDefinitionUrl` omitted. These two fields are now
+ * opt-in Additional Security — see nevermined-io/internal#897.
+ */
+
+import { AgentAPIAttributes } from '../../src/common/types.js'
+
+describe('AgentAPIAttributes — optional fields', () => {
+  it('compiles when endpoints and agentDefinitionUrl are omitted', () => {
+    const minimal: AgentAPIAttributes = {}
+    expect(minimal).toEqual({})
+  })
+
+  it('compiles with only authentication fields', () => {
+    const authOnly: AgentAPIAttributes = {
+      authType: 'bearer',
+      token: 'sk-test-abc',
+    }
+    expect(authOnly.authType).toBe('bearer')
+    expect(authOnly.token).toBe('sk-test-abc')
+  })
+
+  it('still accepts the full shape with both fields populated', () => {
+    const full: AgentAPIAttributes = {
+      endpoints: [{ POST: 'https://example.com/api/run' }],
+      openEndpoints: ['https://example.com/health'],
+      agentDefinitionUrl: 'https://example.com/openapi.json',
+      authType: 'bearer',
+      token: 'sk-test',
+    }
+    expect(full.endpoints).toHaveLength(1)
+    expect(full.agentDefinitionUrl).toBe('https://example.com/openapi.json')
+  })
+
+  it('compiles when only endpoints is provided (Additional Security opt-in)', () => {
+    const allowlistOnly: AgentAPIAttributes = {
+      endpoints: [{ POST: 'https://example.com/api/run' }],
+    }
+    expect(allowlistOnly.agentDefinitionUrl).toBeUndefined()
+  })
+
+  it('compiles when only agentDefinitionUrl is provided', () => {
+    const definitionOnly: AgentAPIAttributes = {
+      agentDefinitionUrl: 'https://example.com/openapi.json',
+    }
+    expect(definitionOnly.endpoints).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Implements **Phase 2** (TypeScript SDK) of [nevermined-io/internal#897](https://github.com/nevermined-io/internal/issues/897) — see also sub-issue [#911](https://github.com/nevermined-io/internal/issues/911).

## Summary

Both fields in \`AgentAPIAttributes\` are now optional:

- \`endpoints?: Endpoint[]\` — opt-in **Additional Security** route allowlist
- \`agentDefinitionUrl?: string\` — optional discovery metadata

JSDoc updated to reframe \`endpoints\` as defense-in-depth on top of library-level gating, not a baseline requirement.

The SDK remains pure pass-through. No new helpers, no auto-derivation. Builders who omit both fields get the simpler default; builders who provide them get the platform-enforced allowlist.

## Why

- The Nevermined platform no longer needs an OpenAPI URL at registration time — it's stored as discoverable metadata only and not consumed at runtime.
- Builders integrating via the Payments library declare paid routes via library annotations / middleware, so requiring the allowlist at registration was redundant for the common case. Keeping it as opt-in **Additional Security** preserves defense-in-depth for those who want it.

## Compatibility

No breakage:
- \`openclaw/src/tools.ts\` continues to provide both fields (still valid).
- All E2E test fixtures (\`tests/e2e/*\`) continue to provide both fields (still valid).
- Existing apps that pass these fields are unaffected.

## Test plan

- [x] \`pnpm build\` — TypeScript compiles
- [x] \`pnpm test:unit\` — 118 tests pass (incl. 5 new in \`agent-api-attributes-optional.test.ts\`)
- [x] \`pnpm lint\` — no new errors (1 pre-existing TSDoc warning unrelated)
- [ ] **After Phase 1 backend lands on staging:** \`pnpm test:e2e\` against staging with a registration payload that omits both fields

## Rollout gate

⚠️ **Depends on:** [nvm-monorepo PR #1348](https://github.com/nevermined-io/nvm-monorepo/pull/1348) being merged to staging first, otherwise SDK calls without these fields will be rejected by the API DTO validation.

Closes #911
Refs #897