### PR TITLE
feat!: rename PlanCreditsConfig.proofRequired to onchainMirror (#1281)

### DIFF
--- a/cli/docs/plans.md
+++ b/cli/docs/plans.md
@@ -318,14 +318,14 @@ nvm plans get-non-expirable-duration-config
 
 ## Advanced Operations
 
-### Set Proof Required
+### Set Onchain Mirror
 
-Mark whether proof is required in a credits configuration:
+Mark whether burns of these credits are mirrored on-chain:
 
 ```bash
-nvm plans set-proof-required \
+nvm plans set-onchain-mirror \
   --credits-config credits-config.json \
-  --proof-required
+  --onchain-mirror
 ```
 
 ### Set Redemption Type

--- a/cli/src/commands/plans/set-onchain-mirror.ts
+++ b/cli/src/commands/plans/set-onchain-mirror.ts
@@ -2,13 +2,13 @@ import { Flags } from '@oclif/core'
 import { BaseCommand } from '../../base-command.js'
 
 /**
- * Marks whether proof is required in a credits configuration.
+ * Marks whether burns of these credits are mirrored on-chain.
  */
-export default class SetProofRequired extends BaseCommand {
-  static override description = "Marks whether proof is required in a credits configuration."
+export default class SetOnchainMirror extends BaseCommand {
+  static override description = "Marks whether burns of these credits are mirrored on-chain."
 
   static override examples = [
-    '$ nvm plans set-proof-required'
+    '$ nvm plans set-onchain-mirror'
   ]
 
   static override flags = {
@@ -17,7 +17,7 @@ export default class SetProofRequired extends BaseCommand {
       description: "creditsConfig as JSON string",
       required: true
     }),
-    'proof-required': Flags.boolean({ required: false }),
+    'onchain-mirror': Flags.boolean({ required: false }),
   }
 
 
@@ -28,7 +28,7 @@ export default class SetProofRequired extends BaseCommand {
     const payments = await this.initPayments()
 
     try {
-      const result = await payments.plans.setProofRequired(await this.parseJsonInput(flags['credits-config']), flags['proof-required'])
+      const result = await payments.plans.setOnchainMirror(await this.parseJsonInput(flags['credits-config']), flags['onchain-mirror'])
 
       this.formatter.output(result)
     } catch (error) {

--- a/cli/src/commands/plans/set-onchain-mirror.ts
+++ b/cli/src/commands/plans/set-onchain-mirror.ts
@@ -2,10 +2,10 @@ import { Flags } from '@oclif/core'
 import { BaseCommand } from '../../base-command.js'
 
 /**
- * Marks whether burns of these credits are mirrored on-chain.
+ * Marks whether burns of these credits are mirrored on-chain. When `false`, the credits ledger is the API's Postgres and burns are recorded off-chain only — this is also the structural default of `PlanCreditsConfig.onchainMirror` produced by the credits-config builders. When `true`, an on-chain audit mirror replays each burn to `NFT1155Credits`.
  */
 export default class SetOnchainMirror extends BaseCommand {
-  static override description = "Marks whether burns of these credits are mirrored on-chain."
+  static override description = "Marks whether burns of these credits are mirrored on-chain. When `false`, the credits ledger is the API's Postgres and burns are recorded off-chain only — this is also the structural default of `PlanCreditsConfig.onchainMirror` produced by the credits-config builders. When `true`, an on-chain audit mirror replays each burn to `NFT1155Credits`."
 
   static override examples = [
     '$ nvm plans set-onchain-mirror'

--- a/cli/src/commands/plans/set-onchain-mirror.ts
+++ b/cli/src/commands/plans/set-onchain-mirror.ts
@@ -2,10 +2,10 @@ import { Flags } from '@oclif/core'
 import { BaseCommand } from '../../base-command.js'
 
 /**
- * Marks whether burns of these credits are mirrored on-chain. When `false`, the credits ledger is the API's Postgres and burns are recorded off-chain only — this is also the structural default of `PlanCreditsConfig.onchainMirror` produced by the credits-config builders. When `true`, an on-chain audit mirror replays each burn to `NFT1155Credits`.
+ * Marks whether burns of these credits are mirrored on-chain.
  */
 export default class SetOnchainMirror extends BaseCommand {
-  static override description = "Marks whether burns of these credits are mirrored on-chain. When `false`, the credits ledger is the API's Postgres and burns are recorded off-chain only — this is also the structural default of `PlanCreditsConfig.onchainMirror` produced by the credits-config builders. When `true`, an on-chain audit mirror replays each burn to `NFT1155Credits`."
+  static override description = "Marks whether burns of these credits are mirrored on-chain."
 
   static override examples = [
     '$ nvm plans set-onchain-mirror'

--- a/openclaw/src/tools.ts
+++ b/openclaw/src/tools.ts
@@ -260,7 +260,7 @@ export function createTools(
           {
             isRedemptionAmountFixed: true,
             redemptionType: 4,
-            proofRequired: false,
+            onchainMirror: false,
             durationSecs: 0n,
             amount: BigInt(creditsAmount),
             minAmount: 1n,
@@ -352,7 +352,7 @@ export function createTools(
           {
             isRedemptionAmountFixed: true,
             redemptionType: 4,
-            proofRequired: false,
+            onchainMirror: false,
             durationSecs: 0n,
             amount: BigInt(creditsAmount),
             minAmount: 1n,

--- a/src/api/plans-api.ts
+++ b/src/api/plans-api.ts
@@ -204,17 +204,25 @@ export class PlansAPI extends BasePaymentsAPI {
   }
 
   /**
-   * Marks whether proof is required in a credits configuration.
+   * Marks whether burns of these credits are mirrored on-chain.
+   *
+   * When `false`, the credits ledger is the API's Postgres and burns are
+   * recorded off-chain only — this is also the structural default of
+   * `PlanCreditsConfig.onchainMirror` produced by the credits-config
+   * builders. When `true`, an on-chain audit mirror replays each burn to
+   * `NFT1155Credits`.
    *
    * @param creditsConfig - Credits configuration to modify.
-   * @param proofRequired - Whether proof is required (default true).
+   * @param onchainMirror - Whether on-chain mirroring is enabled. Defaults
+   *   to `true` so calling `setOnchainMirror(config)` enables the mirror;
+   *   pass `false` explicitly to disable it.
    * @returns The updated PlanCreditsConfig.
    */
-  public setProofRequired(
+  public setOnchainMirror(
     creditsConfig: PlanCreditsConfig,
-    proofRequired = true,
+    onchainMirror = true,
   ): PlanCreditsConfig {
-    return Plans.setProofRequired(creditsConfig, proofRequired)
+    return Plans.setOnchainMirror(creditsConfig, onchainMirror)
   }
   /**
    * This method is used to create a singleton instance of the PlansAPI class.

--- a/src/api/plans-api.ts
+++ b/src/api/plans-api.ts
@@ -206,16 +206,14 @@ export class PlansAPI extends BasePaymentsAPI {
   /**
    * Marks whether burns of these credits are mirrored on-chain.
    *
-   * When `false`, the credits ledger is the API's Postgres and burns are
-   * recorded off-chain only — this is also the structural default of
-   * `PlanCreditsConfig.onchainMirror` produced by the credits-config
-   * builders. When `true`, an on-chain audit mirror replays each burn to
-   * `NFT1155Credits`.
-   *
    * @param creditsConfig - Credits configuration to modify.
    * @param onchainMirror - Whether on-chain mirroring is enabled. Defaults
    *   to `true` so calling `setOnchainMirror(config)` enables the mirror;
-   *   pass `false` explicitly to disable it.
+   *   pass `false` explicitly to disable it. The `PlanCreditsConfig`
+   *   field itself defaults to `false` (set by all credits-config
+   *   builders) — when `false` the credits ledger lives in the API's
+   *   Postgres and burns are recorded off-chain only; when `true`, an
+   *   on-chain audit mirror replays each burn to `NFT1155Credits`.
    * @returns The updated PlanCreditsConfig.
    */
   public setOnchainMirror(

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -115,9 +115,12 @@ export interface PlanCreditsConfig {
    */
   redemptionType: PlanRedemptionType
   /**
-   * Whether the credits burn proof signed by the user is required
+   * Whether burns of these credits are mirrored on-chain. When `false`
+   * (default) the credits ledger lives in the API's Postgres and burns
+   * are recorded off-chain only. When `true` an `OnchainMirrorWorker`
+   * replays each off-chain burn to `NFT1155Credits` for audit.
    */
-  proofRequired: boolean
+  onchainMirror: boolean
   /**
    * The duration of the credits in seconds
    * @remarks 0 means non-expirable

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -103,7 +103,7 @@ export const getExpirableDurationConfig = (durationOfPlan: bigint): PlanCreditsC
   return {
     isRedemptionAmountFixed: false,
     redemptionType: PlanRedemptionType.ONLY_SUBSCRIBER,
-    proofRequired: false,
+    onchainMirror: false,
     durationSecs: durationOfPlan,
     amount: 1n,
     minAmount: 1n,
@@ -122,7 +122,7 @@ export const getFixedCreditsConfig = (
   return {
     isRedemptionAmountFixed: true,
     redemptionType: PlanRedemptionType.ONLY_SUBSCRIBER,
-    proofRequired: false,
+    onchainMirror: false,
     durationSecs: 0n,
     amount: creditsGranted,
     minAmount: creditsPerRequest,
@@ -138,7 +138,7 @@ export const getDynamicCreditsConfig = (
   return {
     isRedemptionAmountFixed: false,
     redemptionType: PlanRedemptionType.ONLY_SUBSCRIBER,
-    proofRequired: false,
+    onchainMirror: false,
     durationSecs: 0n,
     amount: creditsGranted,
     minAmount: minCreditsPerRequest,
@@ -156,13 +156,13 @@ export const setRedemptionType = (
   }
 }
 
-export const setProofRequired = (
+export const setOnchainMirror = (
   creditsConfig: PlanCreditsConfig,
-  proofRequired = true,
+  onchainMirror = true,
 ): PlanCreditsConfig => {
   return {
     ...creditsConfig,
-    proofRequired,
+    onchainMirror,
   }
 }
 
@@ -207,7 +207,7 @@ export const getPayAsYouGoCreditsConfig = (): PlanCreditsConfig => {
   return {
     isRedemptionAmountFixed: false,
     redemptionType: PlanRedemptionType.ONLY_SUBSCRIBER,
-    proofRequired: false,
+    onchainMirror: false,
     durationSecs: 0n,
     amount: 1n,
     minAmount: 1n,


### PR DESCRIPTION
## Summary

Sub-issue [nvm-monorepo#1281](https://github.com/nevermined-io/nvm-monorepo/issues/1281) of the off-chain credits epic ([#1274](https://github.com/nevermined-io/nvm-monorepo/issues/1274)). Aligns the TS SDK with the protocol#178 storage-preserving rename and the off-chain credits work landed in nvm-monorepo.

This is the next-major release of `@nevermined-io/payments`.

## What changes

**Field rename** — `PlanCreditsConfig.proofRequired` (boolean) → `PlanCreditsConfig.onchainMirror` (boolean). Same shape, same default (`false`), different name.

**Helper rename** — `Payments.plans.setProofRequired(...)` → `setOnchainMirror(...)`. Drops the deprecation shim from the rollout window. The standalone helper export in `src/plans.ts` is also renamed.

**CLI command rename** — `nvm plans set-proof-required` → `nvm plans set-onchain-mirror`. Flag `--proof-required` becomes `--onchain-mirror`.

**openclaw plugin** — two literals updated to use the new field name.

**No `SettlementResult` type added** — keeping the settle response shape close to the x402 spec, no Nevermined-specific wrapper.

**`getZeroDevBurnPolicies` removal** — already shipped in the API SDK chain ([nvm-monorepo#1280](https://github.com/nevermined-io/nvm-monorepo/issues/1280)). This SDK never imported it; nothing to do here.

## Semantics

`onchainMirror=false` (the default, unchanged from the old `proofRequired=false`) means: credits live only in the API's Postgres; burns are recorded off-chain. `onchainMirror=true` means the API's `OnchainMirrorWorker` replays each off-chain burn to `NFT1155Credits` for audit. This is documented in the JSDoc on the renamed field.

## Compatibility

- API side: end-to-end accepts `onchainMirror` since nvm-monorepo#1277.
- Wire format: matches the API's request/response shape; no on-the-fly translation needed.
- Pre-major SDK consumers must update their field references; no automated migration is shipped.

## Migration

```ts
// before
import { setProofRequired } from '@nevermined-io/payments/plans'
const cfg = setProofRequired(creditsConfig, true)

// after
import { setOnchainMirror } from '@nevermined-io/payments/plans'
const cfg = setOnchainMirror(creditsConfig, true)
```

```ts
// before
const cfg: PlanCreditsConfig = { ...rest, proofRequired: false }

// after
const cfg: PlanCreditsConfig = { ...rest, onchainMirror: false }
```

```bash
# before
nvm plans set-proof-required --credits-config x.json --proof-required

# after
nvm plans set-onchain-mirror --credits-config x.json --onchain-mirror
```

## Test plan

- [x] `pnpm build` clean.
- [x] `pnpm test:unit` — 118/118 passing (1 pre-existing skip).
- [ ] Integration tests against staging API (which already speaks `onchainMirror`).
- [ ] In-tree consumers (`cli/`, `openclaw/`) build clean — verified via `pnpm build`.

## Out of scope

- The auth-identity refactor (replacing `burnSessionKeyHash` with `subscriberAuthToken`) — tracked in nvm-monorepo#1275, will be a future SDK major.
- `SettlementResult` type — explicitly dropped from #1281 scope; settle response stays x402-spec-shaped.
- Downstream consumer migrations in `tutorials`, `hackathons` — those repos will get their own follow-up PRs after this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)