### PR TITLE
fix(openclaw): harden ClawHub metadata + remediate security findings (#327)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,12 +221,24 @@ jobs:
 
       - name: Update OpenClaw Plugin version
         working-directory: openclaw
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
         run: |
           CURRENT=$(node -p "require('./package.json').version")
-          if [ "$CURRENT" != "${{ steps.version.outputs.version }}" ]; then
-            npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+          if [ "$CURRENT" != "$RELEASE_VERSION" ]; then
+            npm version "$RELEASE_VERSION" --no-git-tag-version
           fi
-          echo "OpenClaw Plugin version is ${{ steps.version.outputs.version }}"
+          # Keep openclaw.plugin.json in lockstep so the published tarball
+          # never ships package.json and openclaw.plugin.json with different
+          # version strings.
+          node -e "
+            const fs = require('node:fs');
+            const path = 'openclaw.plugin.json';
+            const data = JSON.parse(fs.readFileSync(path, 'utf8'));
+            data.version = process.env.RELEASE_VERSION;
+            fs.writeFileSync(path, JSON.stringify(data, null, 2) + '\n');
+          "
+          echo "OpenClaw Plugin version is $RELEASE_VERSION (package.json + openclaw.plugin.json)"
 
       - name: Build OpenClaw Plugin
         working-directory: openclaw
@@ -251,11 +263,13 @@ jobs:
           path: openclaw/*.tgz
 
       - name: Commit OpenClaw Plugin version update
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add openclaw/package.json
-          git diff --cached --quiet || git commit -m "chore(openclaw): bump version to ${{ steps.version.outputs.version }}"
+          git add openclaw/package.json openclaw/openclaw.plugin.json
+          git diff --cached --quiet || git commit -m "chore(openclaw): bump version to $RELEASE_VERSION"
           git push origin HEAD:main || echo "Could not push to main (protected branch)"
 
   publish-clawhub:
@@ -303,6 +317,13 @@ jobs:
           if [ "$CURRENT" != "$RELEASE_VERSION" ]; then
             npm version "$RELEASE_VERSION" --no-git-tag-version
           fi
+          node -e "
+            const fs = require('node:fs');
+            const path = 'openclaw.plugin.json';
+            const data = JSON.parse(fs.readFileSync(path, 'utf8'));
+            data.version = process.env.RELEASE_VERSION;
+            fs.writeFileSync(path, JSON.stringify(data, null, 2) + '\n');
+          "
 
       - name: Install ClawHub CLI
         run: npm install -g clawhub@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,56 +277,32 @@ jobs:
     needs: publish-openclaw
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.ref }}
-
-      - uses: pnpm/action-setup@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: '24.x'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
 
-      - name: Extract version from tag
-        id: version
-        env:
-          GITHUB_REF: ${{ github.ref }}
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Publishing ClawHub skill at version: $VERSION"
+      - name: Download OpenClaw Plugin tarball from publish-openclaw
+        uses: actions/download-artifact@v4
+        with:
+          name: openclaw-tarball
+          path: tarball
 
-      - name: Build OpenClaw Plugin
+      - name: Resolve tarball path
+        id: tarball
+        # The CLI interprets bare paths as `owner/repo` GitHub references — the
+        # leading `./` is required to force "this is a local file".
         run: |
-          pnpm install --frozen-lockfile --ignore-engines
-          pnpm build
-          pnpm --filter ./openclaw install --frozen-lockfile --ignore-engines || (cd openclaw && pnpm install --frozen-lockfile --ignore-engines)
-          rm -rf openclaw/node_modules/@nevermined-io/payments
-          ln -s "$PWD" openclaw/node_modules/@nevermined-io/payments
-          (cd openclaw && pnpm build)
-
-      - name: Sync OpenClaw Plugin version with release tag
-        working-directory: openclaw
-        env:
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          CURRENT=$(node -p "require('./package.json').version")
-          if [ "$CURRENT" != "$RELEASE_VERSION" ]; then
-            npm version "$RELEASE_VERSION" --no-git-tag-version
+          FILE=$(ls tarball/*.tgz | head -n1)
+          if [ -z "$FILE" ]; then
+            echo "::error::No .tgz found in the openclaw-tarball artifact."
+            exit 1
           fi
-          node -e "
-            const fs = require('node:fs');
-            const path = 'openclaw.plugin.json';
-            const data = JSON.parse(fs.readFileSync(path, 'utf8'));
-            data.version = process.env.RELEASE_VERSION;
-            fs.writeFileSync(path, JSON.stringify(data, null, 2) + '\n');
-          "
+          echo "path=./$FILE" >> "$GITHUB_OUTPUT"
+          echo "Tarball: ./$FILE"
 
       - name: Install ClawHub CLI
-        run: npm install -g clawhub@latest
+        # Pinned to ^0.12 — bump deliberately when ClawHub ships a major.
+        run: npm install -g clawhub@^0.12
 
       - name: Authenticate with ClawHub
         env:
@@ -340,16 +316,53 @@ jobs:
           clawhub whoami
 
       - name: Dry-run ClawHub publish
-        run: clawhub package publish ./openclaw --family code-plugin --dry-run --json
+        # When publishing from a tarball, the CLI cannot infer git source
+        # attribution, so pass it explicitly from the GitHub Actions context.
+        env:
+          TARBALL: ${{ steps.tarball.outputs.path }}
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_COMMIT: ${{ github.sha }}
+          SOURCE_REF: ${{ github.ref }}
+        run: |
+          clawhub package publish "$TARBALL" \
+            --family code-plugin \
+            --source-repo "$SOURCE_REPO" \
+            --source-commit "$SOURCE_COMMIT" \
+            --source-ref "$SOURCE_REF" \
+            --source-path openclaw \
+            --dry-run --json
 
       - name: Publish OpenClaw Plugin to ClawHub
-        # If the version already exists on ClawHub the CLI will exit non-zero;
-        # we treat that as success so re-runs of the same release tag are idempotent.
+        # Re-runs of the same release tag should be idempotent: if the CLI fails
+        # solely because this exact version is already published, swallow it.
+        # Any other failure (auth, schema, network, validation) still fails the
+        # job loudly so we don't ship a release that quietly skipped ClawHub.
+        env:
+          TARBALL: ${{ steps.tarball.outputs.path }}
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_COMMIT: ${{ github.sha }}
+          SOURCE_REF: ${{ github.ref }}
         run: |
-          if ! clawhub package publish ./openclaw --family code-plugin --json; then
-            echo "::warning::ClawHub publish failed (the version may already be published). Inspect the log above."
-            exit 1
+          set +e
+          OUT=$(clawhub package publish "$TARBALL" \
+            --family code-plugin \
+            --source-repo "$SOURCE_REPO" \
+            --source-commit "$SOURCE_COMMIT" \
+            --source-ref "$SOURCE_REF" \
+            --source-path openclaw \
+            --json 2>&1)
+          STATUS=$?
+          set -e
+          echo "$OUT"
+          if [ "$STATUS" -eq 0 ]; then
+            exit 0
           fi
+          if echo "$OUT" | grep -qiE "already (published|exists)|version (already|exists)|duplicate version|^http.*409|status\s*[:=]?\s*409|conflict"; then
+            echo "::notice::ClawHub already has this version — treating as idempotent success."
+            exit 0
+          fi
+          echo "::error::ClawHub publish failed for a reason other than 'already published'."
+          exit "$STATUS"
 
   github-release:
     name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,7 +238,7 @@ jobs:
 
       - name: Publish OpenClaw Plugin package
         working-directory: openclaw
-        run: npm publish --access public
+        run: npm publish --access public --provenance
 
       - name: Pack OpenClaw Plugin tarball
         working-directory: openclaw

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,6 +258,78 @@ jobs:
           git diff --cached --quiet || git commit -m "chore(openclaw): bump version to ${{ steps.version.outputs.version }}"
           git push origin HEAD:main || echo "Could not push to main (protected branch)"
 
+  publish-clawhub:
+    name: Publish OpenClaw Plugin to ClawHub
+    needs: publish-openclaw
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Extract version from tag
+        id: version
+        env:
+          GITHUB_REF: ${{ github.ref }}
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing ClawHub skill at version: $VERSION"
+
+      - name: Build OpenClaw Plugin
+        run: |
+          pnpm install --frozen-lockfile --ignore-engines
+          pnpm build
+          pnpm --filter ./openclaw install --frozen-lockfile --ignore-engines || (cd openclaw && pnpm install --frozen-lockfile --ignore-engines)
+          rm -rf openclaw/node_modules/@nevermined-io/payments
+          ln -s "$PWD" openclaw/node_modules/@nevermined-io/payments
+          (cd openclaw && pnpm build)
+
+      - name: Sync OpenClaw Plugin version with release tag
+        working-directory: openclaw
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+          if [ "$CURRENT" != "$RELEASE_VERSION" ]; then
+            npm version "$RELEASE_VERSION" --no-git-tag-version
+          fi
+
+      - name: Install ClawHub CLI
+        run: npm install -g clawhub@latest
+
+      - name: Authenticate with ClawHub
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
+          if [ -z "$CLAWHUB_TOKEN" ]; then
+            echo "::error::CLAWHUB_TOKEN secret is not configured. Configure it in the repo or org settings to enable ClawHub publishing."
+            exit 1
+          fi
+          clawhub login --token "$CLAWHUB_TOKEN"
+          clawhub whoami
+
+      - name: Dry-run ClawHub publish
+        run: clawhub package publish ./openclaw --family code-plugin --dry-run --json
+
+      - name: Publish OpenClaw Plugin to ClawHub
+        # If the version already exists on ClawHub the CLI will exit non-zero;
+        # we treat that as success so re-runs of the same release tag are idempotent.
+        run: |
+          if ! clawhub package publish ./openclaw --family code-plugin --json; then
+            echo "::warning::ClawHub publish failed (the version may already be published). Inspect the log above."
+            exit 1
+          fi
+
   github-release:
     name: Create GitHub Release
     needs: [publish-cli, publish-openclaw]

--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ The library is designed for use in browser environments or as part of AI Agents:
 
 ```bash
 # pnpm
-pnpm add @nevermined-io/payments
+pnpm add @nevermined-io/payments@^1.1
 
 # npm
-npm install @nevermined-io/payments
+npm install @nevermined-io/payments@^1.1
 ```
+
+> Pin the major version (or rely on a committed lockfile) so SDK upgrades are explicit. Always commit `package-lock.json` / `pnpm-lock.yaml`.
 ## A2A Integration (Agents‑to‑Agents)
 
 Nevermined Payments integrates with the A2A protocol to authorize and charge per request between agents:

--- a/RUN.md
+++ b/RUN.md
@@ -225,8 +225,15 @@ app.post('/api/task', async (req, res) => {
   }
 })
 
-app.listen(3000)
+// Bind to localhost; expose via a reverse proxy with HTTPS for public traffic
+const server = app.listen(3000, '127.0.0.1')
+
+process.on('SIGINT', () => {
+  server.close(() => process.exit(0))
+})
 ```
+
+> 🔐 **Production deployments**: terminate TLS in a reverse proxy (Caddy, nginx, Traefik) and forward only over a private network to the agent. The `payment-signature` header is a bearer credential — never accept it over plain HTTP.
 
 ### X402 Payment Required Response
 

--- a/markdown/a2a-integration.md
+++ b/markdown/a2a-integration.md
@@ -22,13 +22,15 @@ The A2A integration provides:
 The agent card is published at `/.well-known/agent.json` and includes payment metadata. Before sending a paid request, **clients should fetch and validate the target agent's card** to confirm the expected `agentId`, the `capabilities`, and the supported X402 schemes — this protects against routing payment-signature tokens to a typosquatted or unauthorised endpoint:
 
 ```typescript
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1'])
+
 const cardUrl = new URL('/.well-known/agent.json', agentUrl)
 const card = await fetch(cardUrl, { method: 'GET' }).then((r) => r.json())
 
 if (card.agentId !== expectedAgentId) {
   throw new Error(`Agent card mismatch: expected ${expectedAgentId}, got ${card.agentId}`)
 }
-if (!cardUrl.protocol.startsWith('https') && !isLoopback(cardUrl.hostname)) {
+if (cardUrl.protocol !== 'https:' && !LOOPBACK_HOSTS.has(cardUrl.hostname)) {
   console.warn(`Agent card fetched over ${cardUrl.protocol} — production traffic must use HTTPS.`)
 }
 ```

--- a/markdown/a2a-integration.md
+++ b/markdown/a2a-integration.md
@@ -19,7 +19,21 @@ The A2A integration provides:
 
 ## Build Payment Agent Card
 
-The agent card is published at `/.well-known/agent.json` and includes payment metadata:
+The agent card is published at `/.well-known/agent.json` and includes payment metadata. Before sending a paid request, **clients should fetch and validate the target agent's card** to confirm the expected `agentId`, the `capabilities`, and the supported X402 schemes — this protects against routing payment-signature tokens to a typosquatted or unauthorised endpoint:
+
+```typescript
+const cardUrl = new URL('/.well-known/agent.json', agentUrl)
+const card = await fetch(cardUrl, { method: 'GET' }).then((r) => r.json())
+
+if (card.agentId !== expectedAgentId) {
+  throw new Error(`Agent card mismatch: expected ${expectedAgentId}, got ${card.agentId}`)
+}
+if (!cardUrl.protocol.startsWith('https') && !isLoopback(cardUrl.hostname)) {
+  console.warn(`Agent card fetched over ${cardUrl.protocol} — production traffic must use HTTPS.`)
+}
+```
+
+
 
 ```typescript
 import { Payments, EnvironmentName } from '@nevermined-io/payments'
@@ -290,6 +304,8 @@ process.on('SIGINT', async () => {
   process.exit(0)
 })
 ```
+
+> 🔐 **Run behind a reverse proxy with HTTPS in production.** A2A peers exchange paid `payment-signature` tokens over HTTP headers — never expose the raw server on a public hostname without TLS. Bind the dev server to `127.0.0.1` (e.g. by running it inside a container with no published port, or behind a localhost-bound proxy).
 
 ## Credit Reporting
 

--- a/markdown/installation.md
+++ b/markdown/installation.md
@@ -28,15 +28,17 @@ Before installing the Nevermined Payments Library, ensure you have:
 
 ## Installation
 
-Install the library using npm or pnpm:
+Install the library using npm or pnpm. Pin the major version (or use a lockfile-tracked exact version) so SDK upgrades are explicit and reviewable:
 
 ```bash
 # Using npm
-npm install @nevermined-io/payments
+npm install @nevermined-io/payments@^1.1
 
 # Using pnpm
-pnpm add @nevermined-io/payments
+pnpm add @nevermined-io/payments@^1.1
 ```
+
+> 🔐 **Security:** always commit your `package-lock.json` / `pnpm-lock.yaml` and review SDK version bumps before deploying. Running unpinned installs in production lets transitive dependencies change between deploys.
 
 ### Peer Dependencies
 

--- a/markdown/mcp-integration.md
+++ b/markdown/mcp-integration.md
@@ -196,9 +196,10 @@ payments.mcp.registerTool(
   { credits: 1n }
 )
 
-// Start server
+// Start server (bind to localhost by default; expose via a reverse proxy with HTTPS for public traffic)
 const { info, stop } = await payments.mcp.start({
   port: 5001,
+  host: process.env.MCP_HOST ?? '127.0.0.1',
   agentId: process.env.NVM_AGENT_ID!,
   serverName: 'weather-server',
   version: '1.0.0',
@@ -214,6 +215,8 @@ process.on('SIGINT', async () => {
   process.exit(0)
 })
 ```
+
+> 🔐 **Bind to localhost in development.** The MCP server holds an OAuth issuer and accepts paid requests — exposing it directly on `0.0.0.0` is rarely what you want. Bind to `127.0.0.1` and front it with a reverse proxy (Caddy, nginx, Traefik) terminating TLS for any public traffic.
 
 ## MCP Logical URIs
 
@@ -338,9 +341,10 @@ payments.mcp.registerResource(
   { credits: 1n }
 )
 
-// Start server
+// Start server (bind to localhost by default; front with HTTPS reverse proxy for public traffic)
 const { info, stop } = await payments.mcp.start({
   port: 5001,
+  host: process.env.MCP_HOST ?? '127.0.0.1',
   agentId: process.env.NVM_AGENT_ID!,
   serverName: 'weather-agent',
   version: '1.0.0',
@@ -470,7 +474,12 @@ app.get('/custom', (req, res) => {
   res.json({ status: 'ok' })
 })
 
-app.listen(5001)
+// Bind to localhost; expose via a reverse proxy with HTTPS for public traffic
+const server = app.listen(5001, '127.0.0.1')
+
+process.on('SIGINT', () => {
+  server.close(() => process.exit(0))
+})
 ```
 
 ## Best Practices

--- a/markdown/querying-an-agent.md
+++ b/markdown/querying-an-agent.md
@@ -8,6 +8,8 @@ icon: "message"
 
 After purchasing a payment plan, subscribers can generate X402 access tokens and use them to query AI agents. This guide explains how to get tokens and make authenticated requests.
 
+> 🔐 **Treat access tokens like API keys.** The `accessToken` returned by `getX402AccessToken()` is a bearer credential that authorises spending against your plan. Send it only over HTTPS, never log its full value, and scrub the `payment-signature` header from any pino/winston/OpenTelemetry exporter. Use a redaction helper such as ``redactToken(t) => `${t.slice(0,6)}…${t.slice(-4)}` `` if you need diagnostic output.
+
 ## Overview
 
 The query flow consists of:
@@ -153,7 +155,8 @@ const { accessToken } = await subscriberPayments.x402.getX402AccessToken(
   agentId
 )
 
-console.log(`Token generated, length: ${accessToken.length} characters`)
+// ⚠️ Never log the full token — it is a bearer credential.
+console.log('Access token generated')
 ```
 
 ## Token Structure (X402 v2)

--- a/markdown/validation-of-requests.md
+++ b/markdown/validation-of-requests.md
@@ -8,6 +8,8 @@ icon: "shield-check"
 
 This guide explains how AI agents validate incoming requests and settle payments using the Nevermined Facilitator. Agent builders use these methods to verify subscriber access and burn credits.
 
+> 🔐 **Never log incoming tokens.** When you extract the `payment-signature` header, treat it as a bearer secret: do not echo it in error messages, debug output, or telemetry. Configure your log/trace exporters to redact `payment-signature`, `authorization`, and `cookie` headers by default.
+
 ## Overview
 
 The validation flow consists of:

--- a/markdown/x402.md
+++ b/markdown/x402.md
@@ -8,6 +8,8 @@ icon: "file-contract"
 
 The X402 protocol is a payment-aware HTTP extension that enables AI agents to require and verify payments for API access. This guide provides a complete overview of X402 implementation in the Nevermined Payments Library.
 
+> 🔐 **Bearer-token hygiene.** The `payment-signature` header is a bearer credential — anyone holding it can spend the associated plan's credits until it expires. Send it only over HTTPS, never log the full value, and configure your log/trace exporters (pino, winston, OpenTelemetry) to redact `payment-signature`, `authorization`, and `cookie` headers by default.
+
 ## Overview of X402
 
 X402 is an HTTP-based protocol for payment-protected resources:

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -2,11 +2,29 @@
 
 OpenClaw plugin for [Nevermined](https://nevermined.io) — exposes AI agent payment operations as gateway tools callable from any OpenClaw channel (Telegram, Discord, WhatsApp, etc.).
 
+## Official source & provenance
+
+This plugin is published from the [`nevermined-io/payments`](https://github.com/nevermined-io/payments) monorepo (subdirectory `openclaw/`) by Nevermined AG.
+
+| | |
+|---|---|
+| **npm package** | [`@nevermined-io/openclaw-plugin`](https://www.npmjs.com/package/@nevermined-io/openclaw-plugin) — published with [npm provenance](https://docs.npmjs.com/generating-provenance-statements) attestations from this repo's `release.yml` workflow. |
+| **GitHub repository** | https://github.com/nevermined-io/payments (subdirectory [`openclaw/`](https://github.com/nevermined-io/payments/tree/main/openclaw)) |
+| **License** | Apache-2.0 |
+| **Security policy** | https://github.com/nevermined-io/payments/security/policy |
+| **Issue tracker** | https://github.com/nevermined-io/payments/issues |
+
+> ⚠️ **Unofficial mirrors.** Only install from the npm registry under the `@nevermined-io` scope or from a ClawHub listing whose publisher matches `nevermined-io`. Listings under any other publisher (for example `clawhub.ai/aaitor/nevermined-payments/...`) are **not** maintained by Nevermined and may lag behind security fixes. Verify the listed source repository before installing.
+>
+> 🔐 **Never log payment tokens.** x402 access tokens (the `payment-signature` header) are bearer credentials. Treat them like API keys: redact them in any debug output, log pipeline, or telemetry exporter (pino, winston, OpenTelemetry, etc.).
+
 ## Installation
 
 ```bash
-openclaw plugin install @nevermined-io/openclaw-plugin
+openclaw plugin install @nevermined-io/openclaw-plugin@^1.1
 ```
+
+The plugin requires `@nevermined-io/payments@^1.1` as a peer dependency. Pin both packages in production deployments (lockfiles, container images) so SDK upgrades are explicit and reviewable.
 
 ## Authentication
 
@@ -77,8 +95,9 @@ Add your API key directly to `openclaw.json`:
 |------|-------------|------------|
 | `nevermined_checkBalance` | Check credit balance for a plan | `planId` |
 | `nevermined_getAccessToken` | Get an x402 access token | `planId`, `agentId` |
-| `nevermined_orderPlan` | Purchase a payment plan | `planId` |
-| `nevermined_queryAgent` | Query an agent end-to-end | `agentUrl`, `prompt`, `planId`, `agentId` |
+| `nevermined_orderPlan` | Purchase a crypto payment plan (two-step: returns a quote until `confirm: true` is passed) | `planId`, `confirm` |
+| `nevermined_orderFiatPlan` | Order a fiat payment plan (two-step: returns a quote until `confirm: true` is passed) | `planId`, `confirm` |
+| `nevermined_queryAgent` | Query an agent end-to-end (HTTPS recommended) | `agentUrl`, `prompt`, `planId`, `agentId` |
 
 ### Builder Tools
 

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -14,7 +14,7 @@ This plugin is published from the [`nevermined-io/payments`](https://github.com/
 | **Security policy** | https://github.com/nevermined-io/payments/security/policy |
 | **Issue tracker** | https://github.com/nevermined-io/payments/issues |
 
-> ⚠️ **Unofficial mirrors.** Only install from the npm registry under the `@nevermined-io` scope or from a ClawHub listing whose publisher matches `nevermined-io`. Listings under any other publisher (for example `clawhub.ai/aaitor/nevermined-payments/...`) are **not** maintained by Nevermined and may lag behind security fixes. Verify the listed source repository before installing.
+> ✅ **Official ClawHub listing.** Until ClawHub ships org publishers, the official skill lives at [`clawhub.ai/aaitor/nevermined-payments`](https://clawhub.ai/aaitor/nevermined-payments/openclaw) — `@aaitor` is a Nevermined admin and that account's token is the one used by this repo's release workflow. Treat any other ClawHub publisher as a third-party mirror until further notice. The canonical npm package is [`@nevermined-io/openclaw-plugin`](https://www.npmjs.com/package/@nevermined-io/openclaw-plugin).
 >
 > 🔐 **Never log payment tokens.** x402 access tokens (the `payment-signature` header) are bearer credentials. Treat them like API keys: redact them in any debug output, log pipeline, or telemetry exporter (pino, winston, OpenTelemetry, etc.).
 

--- a/openclaw/docs/commands.md
+++ b/openclaw/docs/commands.md
@@ -102,14 +102,19 @@ Purchase a payment plan using cryptocurrency. This initiates an on-chain transac
 
 Use this for plans priced in native tokens (ETH, MATIC) or ERC-20 tokens (USDC). For plans priced in fiat currency, use `nevermined_orderFiatPlan` instead.
 
+> ⚠️ **Two-step confirmation flow.** This tool spends real money. The first call returns a *quote* — `planId`, `name`, `price`, `credits`, `paymentType`, `environment`, plus the literal `"Re-call with confirm: true to proceed."`. The agent must show that quote to the user and only call again with `confirm: true` once the user has explicitly approved.
+
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `planId` | string | No | Config `planId` | The plan ID to purchase |
+| `confirm` | boolean | No | `false` | Set to `true` only after the user has approved the quote returned by the first call. |
 
 **Example prompt:**
 > Buy the Weather Forecast plan so I can start querying the agent.
 
-**Returns:** Order confirmation with transaction hash.
+**Returns:**
+- Without `confirm: true`: `{ planId, name, price, credits, paymentType, environment, requiresConfirmation: true, message: "Re-call with confirm: true to proceed." }`
+- With `confirm: true`: order confirmation with transaction hash.
 
 ---
 
@@ -119,14 +124,19 @@ Purchase a payment plan using fiat currency (USD). Instead of executing an on-ch
 
 Use this for plans that have been created with `pricingType: fiat`. For crypto-priced plans, use `nevermined_orderPlan` instead.
 
+> ⚠️ **Two-step confirmation flow.** Same as `nevermined_orderPlan`: the first call returns a quote, the second call (with `confirm: true`) issues the Stripe checkout URL.
+
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `planId` | string | No | Config `planId` | The plan ID to purchase |
+| `confirm` | boolean | No | `false` | Set to `true` only after the user has approved the quote returned by the first call. |
 
 **Example prompt:**
 > I want to subscribe to the Premium Agent plan using my credit card.
 
 **Returns:**
+- Without `confirm: true`: `{ planId, name, price, credits, paymentType: "fiat", environment, requiresConfirmation: true, message: "Re-call with confirm: true to proceed." }`
+- With `confirm: true`:
 ```json
 {
   "result": {

--- a/openclaw/docs/getting-started.md
+++ b/openclaw/docs/getting-started.md
@@ -19,8 +19,10 @@ The Nevermined OpenClaw plugin exposes AI agent payment operations as gateway to
 Install the plugin from your OpenClaw gateway:
 
 ```bash
-openclaw plugin install @nevermined-io/openclaw-plugin
+openclaw plugin install @nevermined-io/openclaw-plugin@^1.1
 ```
+
+The plugin requires `@nevermined-io/payments@^1.1` as a peer dependency. Pin both packages and commit your lockfile so SDK upgrades are explicit.
 
 ## Authentication
 

--- a/openclaw/docs/guide.md
+++ b/openclaw/docs/guide.md
@@ -43,15 +43,22 @@ The plugin adds 9 payment tools and 2 slash commands to your OpenClaw gateway:
 - Node.js >= 18
 - A [Nevermined account](https://nevermined.app) with an API key
 
+> 🔐 **Security expectations.** This plugin issues `payment-signature` bearer tokens that authorise spending against your plan. In production:
+>
+> - **Use HTTPS for every `agentUrl`** passed to `nevermined_queryAgent`. The tool warns when the URL is not `https://` (loopback hosts excepted for local dev).
+> - **Validate agent cards** at `<agentUrl>/.well-known/agent.json` before issuing a paid request — confirm `agentId` and supported X402 schemes match what you expect.
+> - **Never log payment tokens** — redact the `payment-signature` header in pino, winston, OpenTelemetry, and any sentry/datadog/log-shipping layer.
+> - **Confirm before ordering** — `nevermined_orderPlan` and `nevermined_orderFiatPlan` are gated by a `confirm: true` parameter so the agent must show the user the price/credits/environment first.
+
 ## Step 1: Install the Plugin
 
 From your OpenClaw gateway server:
 
 ```bash
-openclaw plugin install @nevermined-io/openclaw-plugin
+openclaw plugin install @nevermined-io/openclaw-plugin@^1.1
 ```
 
-Or install manually by placing the package in `~/.openclaw/extensions/nevermined/`.
+Or install manually by placing the package in `~/.openclaw/extensions/nevermined/`. Pin the major version and commit your lockfile so SDK upgrades are explicit.
 
 After installation, restart the gateway:
 

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -1,7 +1,25 @@
 {
   "id": "openclaw-plugin",
   "name": "@nevermined-io/openclaw-plugin",
-  "description": "Nevermined plugin for OpenClaw — AI agent payments and access control",
+  "version": "1.1.1",
+  "license": "Apache-2.0",
+  "description": "Official Nevermined plugin for OpenClaw — AI-agent payments, x402 access tokens, and gateway tools.",
+  "author": {
+    "name": "Nevermined AG",
+    "url": "https://nevermined.io"
+  },
+  "homepage": "https://nevermined.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nevermined-io/payments.git",
+    "directory": "openclaw"
+  },
+  "bugs": {
+    "url": "https://github.com/nevermined-io/payments/issues"
+  },
+  "security": {
+    "url": "https://github.com/nevermined-io/payments/security/policy"
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -40,10 +40,23 @@
     "zod": "^3.23.0"
   },
   "license": "Apache-2.0",
+  "author": {
+    "name": "Nevermined AG",
+    "url": "https://nevermined.io"
+  },
+  "homepage": "https://github.com/nevermined-io/payments/tree/main/openclaw#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/nevermined-io/payments.git",
     "directory": "openclaw"
+  },
+  "bugs": {
+    "url": "https://github.com/nevermined-io/payments/issues"
+  },
+  "funding": "https://nevermined.io",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   },
   "openclaw": {
     "extensions": [

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -61,7 +61,13 @@
   "openclaw": {
     "extensions": [
       "./dist/index.js"
-    ]
+    ],
+    "compat": {
+      "pluginApi": ">=2026.3.24-beta.2"
+    },
+    "build": {
+      "openclawVersion": "2026.3.24-beta.2"
+    }
   },
   "keywords": [
     "nevermined",

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -63,7 +63,7 @@
       "./dist/index.js"
     ],
     "compat": {
-      "pluginApi": ">=2026.3.24-beta.2"
+      "pluginApi": "*"
     },
     "build": {
       "openclawVersion": "2026.3.24-beta.2"

--- a/openclaw/skills/nevermined/SKILL.md
+++ b/openclaw/skills/nevermined/SKILL.md
@@ -1,5 +1,46 @@
 ---
+name: Nevermined Payments
+description: Pay-per-use payments and access control for AI agents — x402 access tokens, MCP/A2A bridges, and credit plans for OpenClaw.
 metadata:
+  clawdis:
+    author: Nevermined AG
+    homepage: https://nevermined.io
+    primaryEnv: NVM_API_KEY
+    links:
+      homepage: https://nevermined.io
+      repository: https://github.com/nevermined-io/payments
+      documentation: https://docs.nevermined.io/docs/api-reference/openclaw-plugin
+      changelog: https://github.com/nevermined-io/payments/releases
+    requires:
+      env:
+        - NVM_API_KEY
+      config:
+        - plugins.openclaw-plugin
+    envVars:
+      - name: NVM_API_KEY
+        required: true
+        description: "Nevermined API key. Use /nvm_login for browser-based authentication, or set this directly. Tokens are prefixed with sandbox: or live: depending on environment."
+      - name: NVM_ENVIRONMENT
+        required: false
+        description: "Nevermined environment to connect to: sandbox (default) or live."
+      - name: NVM_PLAN_ID
+        required: false
+        description: "Default payment plan ID for subscriber tools (checkBalance, getAccessToken, queryAgent)."
+      - name: NVM_AGENT_ID
+        required: false
+        description: "Default agent ID. Required when querying agents in multi-agent plans."
+      - name: BUILDER_ADDRESS
+        required: false
+        description: "0x-prefixed wallet address that receives plan revenue. Used by builder/registration tools when no priceReceivers are supplied."
+    dependencies:
+      - name: "@nevermined-io/payments"
+        type: npm
+        version: ">=1.1.0"
+        repository: https://github.com/nevermined-io/payments
+      - name: "@nevermined-io/openclaw-plugin"
+        type: npm
+        version: ">=1.1.0"
+        repository: https://github.com/nevermined-io/payments
   openclaw:
     requires:
       config: ["plugins.openclaw-plugin"]
@@ -8,6 +49,10 @@ metadata:
 # Nevermined Tools
 
 This plugin provides gateway tools for interacting with Nevermined AI agent payments. Supports both crypto (on-chain) and fiat (credit card) payment flows.
+
+> **Official source.** This skill is published from [`nevermined-io/payments`](https://github.com/nevermined-io/payments) (subdirectory `openclaw/`) by Nevermined AG. The npm package is [`@nevermined-io/openclaw-plugin`](https://www.npmjs.com/package/@nevermined-io/openclaw-plugin) (Apache-2.0). Any ClawHub listing under a different publisher is unofficial — see the README's [Official source & provenance](https://github.com/nevermined-io/payments/tree/main/openclaw#official-source--provenance) section.
+>
+> **Never log payment tokens.** x402 access tokens (the `payment-signature` header) are bearer credentials. Redact them in any debug or telemetry output.
 
 ## Authentication
 
@@ -33,20 +78,24 @@ Get an x402 access token for authenticating agent requests. Supports crypto and 
 - `spendingLimitCents` (optional) — max spend in cents for fiat (default: 1000)
 - `delegationDurationSecs` (optional) — delegation duration in seconds for fiat (default: 3600)
 
+The returned token is a bearer credential. Treat it like an API key — never log it, never embed it in URLs, and pass it only over HTTPS.
+
 ### `nevermined_orderPlan`
-Purchase a crypto payment plan.
+Purchase a crypto payment plan. **Two-step flow:** the first call returns a quote; pass `confirm: true` on the second call to actually order the plan.
 - `planId` (optional if set in config)
+- `confirm` (optional, default `false`) — set to `true` to execute the on-chain purchase. Without `confirm: true` the tool returns the plan summary (price, credits, paymentType, environment) plus the literal string `"Re-call with confirm: true to proceed."`.
 
 ### `nevermined_orderFiatPlan`
-Order a fiat payment plan — returns a Stripe checkout URL.
+Order a fiat payment plan — returns a Stripe checkout URL. **Two-step flow:** the first call returns a quote; pass `confirm: true` on the second call to receive the checkout URL.
 - `planId` (optional if set in config)
+- `confirm` (optional, default `false`) — set to `true` to receive the Stripe checkout URL. Without `confirm: true` the tool returns the plan summary plus the literal string `"Re-call with confirm: true to proceed."`.
 
 ### `nevermined_listPaymentMethods`
 List enrolled credit cards available for fiat payments. No parameters.
 
 ### `nevermined_queryAgent`
-End-to-end agent query — acquires a token, calls the agent, returns the response. Supports crypto and fiat.
-- `agentUrl` (required) — the agent endpoint URL
+End-to-end agent query — acquires a token, calls the agent, returns the response. Supports crypto and fiat. **Use HTTPS URLs.** The tool warns when `agentUrl` is not `https://`.
+- `agentUrl` (required) — the agent endpoint URL. Must use `https://` outside local development.
 - `prompt` (required) — the prompt to send
 - `planId` (optional if set in config)
 - `agentId` (optional if set in config)
@@ -64,7 +113,7 @@ Register a new AI agent with a payment plan.
 - `agentUrl` (required) — agent endpoint
 - `planName` (required) — plan name
 - `priceAmounts` (required) — comma-separated prices in wei (crypto) or cents (fiat)
-- `priceReceivers` (optional) — comma-separated receiver addresses. Defaults to authenticated user's wallet.
+- `priceReceivers` (optional) — comma-separated receiver addresses. Defaults to authenticated user's wallet (or `BUILDER_ADDRESS` env var if set).
 - `creditsAmount` (required) — number of credits
 - `tokenAddress` (optional) — ERC20 token address (e.g. USDC). Omit for native token.
 - `pricingType` (optional) — `"crypto"` (default), `"erc20"`, or `"fiat"`
@@ -73,7 +122,7 @@ Register a new AI agent with a payment plan.
 Create a standalone payment plan. Supports fiat (Stripe), ERC20 tokens (USDC), and native crypto pricing.
 - `name` (required) — plan name
 - `priceAmount` (required) — price in cents for fiat (e.g. "100" = $1.00), in token smallest unit for crypto (e.g. "1000000" = 1 USDC)
-- `receiver` (optional) — receiver wallet address (0x...). Defaults to authenticated user's wallet.
+- `receiver` (optional) — receiver wallet address (0x...). Defaults to authenticated user's wallet (or `BUILDER_ADDRESS` env var if set).
 - `creditsAmount` (required) — number of credits
 - `pricingType` (optional) — `"fiat"` for Stripe/USD, `"erc20"` for ERC20 tokens like USDC, `"crypto"` for native token (default: crypto)
 - `accessLimit` (optional) — `"credits"` or `"time"`

--- a/openclaw/skills/nevermined/SKILL.md
+++ b/openclaw/skills/nevermined/SKILL.md
@@ -50,7 +50,7 @@ metadata:
 
 This plugin provides gateway tools for interacting with Nevermined AI agent payments. Supports both crypto (on-chain) and fiat (credit card) payment flows.
 
-> **Official source.** This skill is published from [`nevermined-io/payments`](https://github.com/nevermined-io/payments) (subdirectory `openclaw/`) by Nevermined AG. The npm package is [`@nevermined-io/openclaw-plugin`](https://www.npmjs.com/package/@nevermined-io/openclaw-plugin) (Apache-2.0). Any ClawHub listing under a different publisher is unofficial — see the README's [Official source & provenance](https://github.com/nevermined-io/payments/tree/main/openclaw#official-source--provenance) section.
+> **Official source.** This skill is published from [`nevermined-io/payments`](https://github.com/nevermined-io/payments) (subdirectory `openclaw/`) by Nevermined AG, mirrored to ClawHub at [`clawhub.ai/aaitor/nevermined-payments`](https://clawhub.ai/aaitor/nevermined-payments/openclaw) (publishing handle is a Nevermined admin until ClawHub ships org publishers). The npm package is [`@nevermined-io/openclaw-plugin`](https://www.npmjs.com/package/@nevermined-io/openclaw-plugin) (Apache-2.0).
 >
 > **Never log payment tokens.** x402 access tokens (the `payment-signature` header) are bearer credentials. Redact them in any debug or telemetry output.
 

--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -1,5 +1,5 @@
 import { validateConfig, createPaymentsFromConfig, requireApiKey, getEffectivePlans } from './config.js'
-import { createTools } from './tools.js'
+import { createTools, redactToken } from './tools.js'
 import { startLoginFlow, looksLikeApiKey, getLoginUrl, getApiKeyUrl } from './auth.js'
 import { registerPaidEndpoint } from './paid-endpoint.js'
 import { Payments, buildPaymentRequired } from '@nevermined-io/payments'
@@ -12,6 +12,7 @@ export type { AgentHandler }
 export { validateConfig, createPaymentsFromConfig, requireApiKey }
 export { startLoginFlow, openBrowser } from './auth.js'
 export { registerPaidEndpoint, mockWeatherHandler } from './paid-endpoint.js'
+export { redactToken }
 
 /**
  * HTTP route handler signature used by OpenClaw's registerHttpRoute.

--- a/openclaw/src/tools.ts
+++ b/openclaw/src/tools.ts
@@ -90,16 +90,21 @@ export function createTools(
     {
       name: 'nevermined_orderPlan',
       label: 'Nevermined Order Plan',
-      description: 'Order (purchase) a Nevermined crypto payment plan',
+      description: 'Order (purchase) a Nevermined crypto payment plan. Two-step: returns a quote until called again with confirm:true.',
       parameters: {
         type: 'object' as const,
         properties: {
           planId: { type: 'string', description: 'The payment plan ID to order' },
+          confirm: { type: 'boolean', description: 'Set to true to execute the on-chain purchase. Without confirm:true the tool returns the plan summary only.' },
         },
       },
       async execute(_id: string, params: Record<string, unknown>) {
         const planId = str(params, 'planId') ?? resolveDefaultPlanId(config, 'crypto')
         if (!planId) throw new Error('planId is required — provide it as a parameter or in the plugin config')
+
+        if (!isConfirmed(params)) {
+          return result(await buildOrderQuote(getPayments, planId, 'crypto', config))
+        }
 
         const res = await getPayments().plans.orderPlan(planId)
         return result(res)
@@ -109,16 +114,21 @@ export function createTools(
     {
       name: 'nevermined_orderFiatPlan',
       label: 'Nevermined Order Fiat Plan',
-      description: 'Order a fiat payment plan — returns a Stripe checkout URL for completing the purchase',
+      description: 'Order a fiat payment plan — returns a Stripe checkout URL. Two-step: returns a quote until called again with confirm:true.',
       parameters: {
         type: 'object' as const,
         properties: {
           planId: { type: 'string', description: 'The payment plan ID to order' },
+          confirm: { type: 'boolean', description: 'Set to true to receive the Stripe checkout URL. Without confirm:true the tool returns the plan summary only.' },
         },
       },
       async execute(_id: string, params: Record<string, unknown>) {
         const planId = str(params, 'planId') ?? resolveDefaultPlanId(config, 'fiat')
         if (!planId) throw new Error('planId is required — provide it as a parameter or in the plugin config')
+
+        if (!isConfirmed(params)) {
+          return result(await buildOrderQuote(getPayments, planId, 'fiat', config))
+        }
 
         const res = await getPayments().plans.orderFiatPlan(planId)
         return result(res)
@@ -167,6 +177,8 @@ export function createTools(
         if (!planId) throw new Error('planId is required — provide it as a parameter or in the plugin config')
         const agentId = str(params, 'agentId') ?? config.agentId
         const method = str(params, 'method') ?? 'POST'
+
+        warnIfInsecureUrl(agentUrl)
 
         const tokenOptions = await buildTokenOptions(getPayments, params, config)
         const { accessToken } = await getPayments().x402.getX402AccessToken(planId, agentId, tokenOptions)
@@ -467,4 +479,74 @@ function parsePriceToBigInt(priceStr: string, pricingType: string): bigint {
     return BigInt(Math.round(dollars * 10 ** decimals))
   }
   return BigInt(trimmed)
+}
+
+/** Whether the caller passed an explicit confirm:true. Anything else (false, "false", undefined) is treated as a quote request. */
+function isConfirmed(params: Record<string, unknown>): boolean {
+  const raw = params.confirm
+  if (typeof raw === 'boolean') return raw
+  if (typeof raw === 'string') return raw.toLowerCase() === 'true'
+  return false
+}
+
+/**
+ * Fetch a plan summary so the agent can show price, credits, and environment to the user
+ * before they pass `confirm: true`. Used to gate the order tools per ClawHub finding #1.
+ */
+export async function buildOrderQuote(
+  getPayments: () => Payments,
+  planId: string,
+  paymentType: 'crypto' | 'fiat',
+  config: NeverminedPluginConfig,
+): Promise<Record<string, unknown>> {
+  let summary: Record<string, unknown> = { planId }
+  try {
+    const plan = (await getPayments().plans.getPlan(planId)) as Record<string, unknown> | undefined
+    if (plan && typeof plan === 'object') {
+      summary = {
+        planId,
+        name: plan.name ?? plan.planName,
+        price: plan.price,
+        credits: plan.credits ?? plan.creditsAmount,
+      }
+    }
+  } catch {
+    // Plan lookup failures shouldn't block the quote — the LLM can still confirm explicitly.
+  }
+  return {
+    ...summary,
+    paymentType,
+    environment: config.environment ?? 'sandbox',
+    requiresConfirmation: true,
+    message: 'Re-call with confirm: true to proceed.',
+  }
+}
+
+/**
+ * Redact a bearer token / payment-signature for safe logging.
+ * Returns "<empty>" for empty input, the token itself if it's already short,
+ * or a head/tail-only form like `eyJhbG…aA1c` (8 chars total).
+ */
+export function redactToken(token: unknown): string {
+  if (typeof token !== 'string' || token.length === 0) return '<empty>'
+  if (token.length <= 12) return `${token.slice(0, 2)}…${token.slice(-2)}`
+  return `${token.slice(0, 6)}…${token.slice(-4)}`
+}
+
+/**
+ * Warn (do not throw) when an agent URL is not HTTPS. Local development
+ * (`localhost`, `127.0.0.1`, `::1`) is allowed silently. ClawHub finding #6.
+ */
+function warnIfInsecureUrl(url: string): void {
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol === 'https:') return
+    const host = parsed.hostname
+    if (host === 'localhost' || host === '127.0.0.1' || host === '::1') return
+    console.warn(
+      `[nevermined] agentUrl uses ${parsed.protocol}//${host} — payment-signature tokens must only be sent over HTTPS in production.`,
+    )
+  } catch {
+    // Invalid URLs will be surfaced by the fetch call itself.
+  }
 }

--- a/openclaw/src/tools.ts
+++ b/openclaw/src/tools.ts
@@ -490,8 +490,34 @@ function isConfirmed(params: Record<string, unknown>): boolean {
 }
 
 /**
+ * Shape of the response returned by `payments.plans.getPlan(planId)`. Only the
+ * fields we actually read for the quote are typed here — see
+ * `apps/api/src/plans/dto/get-plan-dto.ts` and `metadata.dto.ts` in nvm-monorepo
+ * for the full definition.
+ */
+interface GetPlanResponse {
+  id?: string
+  metadata?: {
+    main?: { name?: string; price?: string }
+    plan?: {
+      accessLimit?: 'credits' | 'time'
+      currency?: string
+      fiatPaymentProvider?: 'stripe' | 'braintree'
+    }
+  }
+  registry?: {
+    price?: { isCrypto?: boolean; amounts?: bigint[] }
+    credits?: { amount?: bigint }
+  }
+}
+
+/**
  * Fetch a plan summary so the agent can show price, credits, and environment to the user
  * before they pass `confirm: true`. Used to gate the order tools per ClawHub finding #1.
+ *
+ * Field paths follow the canonical `getPlan` response shape (`metadata.main.*`,
+ * `metadata.plan.*`, `registry.credits.amount`, `registry.price.*`); BigInts are
+ * stringified so the JSON envelope serialises safely.
  */
 export async function buildOrderQuote(
   getPayments: () => Payments,
@@ -501,13 +527,21 @@ export async function buildOrderQuote(
 ): Promise<Record<string, unknown>> {
   let summary: Record<string, unknown> = { planId }
   try {
-    const plan = (await getPayments().plans.getPlan(planId)) as Record<string, unknown> | undefined
+    const plan = (await getPayments().plans.getPlan(planId)) as GetPlanResponse | undefined
     if (plan && typeof plan === 'object') {
+      const main = plan.metadata?.main
+      const planMeta = plan.metadata?.plan
+      const creditsAmount = plan.registry?.credits?.amount
+      // Always echo the user-provided planId so a follow-up `confirm: true` call
+      // re-uses the same identifier the agent already showed the user.
       summary = {
         planId,
-        name: plan.name ?? plan.planName,
-        price: plan.price,
-        credits: plan.credits ?? plan.creditsAmount,
+        name: main?.name,
+        price: main?.price,
+        credits: creditsAmount !== undefined ? creditsAmount.toString() : undefined,
+        accessLimit: planMeta?.accessLimit,
+        currency: planMeta?.currency,
+        fiatPaymentProvider: planMeta?.fiatPaymentProvider,
       }
     }
   } catch {

--- a/openclaw/src/tools.ts
+++ b/openclaw/src/tools.ts
@@ -523,9 +523,12 @@ export async function buildOrderQuote(
 }
 
 /**
- * Redact a bearer token / payment-signature for safe logging.
- * Returns "<empty>" for empty input, the token itself if it's already short,
- * or a head/tail-only form like `eyJhbG…aA1c` (8 chars total).
+ * Redact a bearer token / payment-signature for safe logging. Output forms:
+ *   - Empty / non-string input  → `"<empty>"`
+ *   - Length ≤ 12               → `"ab…yz"`           (head 2 + ellipsis + tail 2 = 5 chars)
+ *   - Length > 12               → `"eyJhbG…aA1c"`     (head 6 + ellipsis + tail 4 = 11 chars)
+ *
+ * Intended for debug output and log redactors — never reconstructs the token.
  */
 export function redactToken(token: unknown): string {
   if (typeof token !== 'string' || token.length === 0) return '<empty>'

--- a/openclaw/src/tools.ts
+++ b/openclaw/src/tools.ts
@@ -187,7 +187,7 @@ export function createTools(
           method,
           headers: {
             'Content-Type': 'application/json',
-            'PAYMENT-SIGNATURE': accessToken,
+            'payment-signature': accessToken,
           },
           body: method !== 'GET' ? JSON.stringify({ prompt }) : undefined,
         })

--- a/openclaw/tests/plugin.test.ts
+++ b/openclaw/tests/plugin.test.ts
@@ -552,7 +552,7 @@ describe('OpenClaw Nevermined Plugin', () => {
       globalThis.fetch = originalFetch
     })
 
-    test('sends prompt with PAYMENT-SIGNATURE header', async () => {
+    test('sends prompt with payment-signature header', async () => {
       const mockFetch = globalThis.fetch as jest.Mock<typeof fetch>
       mockFetch.mockResolvedValue({
         ok: true,
@@ -576,7 +576,7 @@ describe('OpenClaw Nevermined Plugin', () => {
       expect(fetchCall[0]).toBe('https://agent.example.com/tasks')
       const fetchInit = fetchCall[1] as RequestInit
       expect(fetchInit.method).toBe('POST')
-      expect((fetchInit.headers as Record<string, string>)['PAYMENT-SIGNATURE']).toBe('tok_test_123')
+      expect((fetchInit.headers as Record<string, string>)['payment-signature']).toBe('tok_test_123')
       expect(JSON.parse(fetchInit.body as string)).toEqual({ prompt: 'What is AI?' })
 
       expect(result).toEqual({ answer: 'hello' })

--- a/openclaw/tests/plugin.test.ts
+++ b/openclaw/tests/plugin.test.ts
@@ -23,6 +23,12 @@ function createMockPayments() {
       }),
       orderPlan: jest.fn<() => Promise<unknown>>().mockResolvedValue({ txHash: '0xdeadbeef', success: true }),
       getPlans: jest.fn<() => Promise<unknown>>().mockResolvedValue([{ planId: 'plan-1' }, { planId: 'plan-2' }]),
+      getPlan: jest.fn<() => Promise<unknown>>().mockResolvedValue({
+        planId: 'plan-default',
+        name: 'Test Plan',
+        price: '1 USDC',
+        credits: 100,
+      }),
       registerPlan: jest.fn<() => Promise<unknown>>().mockResolvedValue({ planId: 'plan-new' }),
       orderFiatPlan: jest.fn<() => Promise<unknown>>().mockResolvedValue({ result: { checkoutUrl: 'https://checkout.stripe.com/test_session' } }),
     },
@@ -417,21 +423,49 @@ describe('OpenClaw Nevermined Plugin', () => {
       expect(result).toEqual({ accessToken: 'tok_test_123' })
     })
 
-    test('nevermined_orderPlan — returns order result', async () => {
+    test('nevermined_orderPlan — without confirm, returns a quote and does not order', async () => {
       const { tools, mockPayments } = registerWithMock()
 
       const tool = tools.get('nevermined_orderPlan')!
-      const result = parseResult(await tool.execute('call-1', {}))
+      const result = parseResult(await tool.execute('call-1', {})) as Record<string, unknown>
+
+      expect(mockPayments.plans.orderPlan).not.toHaveBeenCalled()
+      expect(mockPayments.plans.getPlan).toHaveBeenCalledWith('plan-default')
+      expect(result.requiresConfirmation).toBe(true)
+      expect(result.message).toBe('Re-call with confirm: true to proceed.')
+      expect(result.paymentType).toBe('crypto')
+      expect(result.planId).toBe('plan-default')
+      expect(result.credits).toBe(100)
+    })
+
+    test('nevermined_orderPlan — with confirm:true, executes the order', async () => {
+      const { tools, mockPayments } = registerWithMock()
+
+      const tool = tools.get('nevermined_orderPlan')!
+      const result = parseResult(await tool.execute('call-1', { confirm: true }))
 
       expect(mockPayments.plans.orderPlan).toHaveBeenCalledWith('plan-default')
       expect(result).toEqual({ txHash: '0xdeadbeef', success: true })
     })
 
-    test('nevermined_orderFiatPlan — returns Stripe checkout URL', async () => {
+    test('nevermined_orderFiatPlan — without confirm, returns a quote and does not call Stripe', async () => {
       const { tools, mockPayments } = registerWithMock()
 
       const tool = tools.get('nevermined_orderFiatPlan')!
-      const result = parseResult(await tool.execute('call-1', { planId: 'plan-fiat' }))
+      const result = parseResult(await tool.execute('call-1', { planId: 'plan-fiat' })) as Record<string, unknown>
+
+      expect(mockPayments.plans.orderFiatPlan).not.toHaveBeenCalled()
+      expect(result.requiresConfirmation).toBe(true)
+      expect(result.message).toBe('Re-call with confirm: true to proceed.')
+      expect(result.paymentType).toBe('fiat')
+      expect(result.planId).toBe('plan-fiat')
+    })
+
+    test('nevermined_orderFiatPlan — with confirm:true, returns Stripe checkout URL', async () => {
+      const { tools, mockPayments } = registerWithMock()
+
+      const tool = tools.get('nevermined_orderFiatPlan')!
+      const result = parseResult(await tool.execute('call-1', { planId: 'plan-fiat', confirm: true }))
 
       expect(mockPayments.plans.orderFiatPlan).toHaveBeenCalledWith('plan-fiat')
       expect(result).toEqual({ result: { checkoutUrl: 'https://checkout.stripe.com/test_session' } })

--- a/openclaw/tests/plugin.test.ts
+++ b/openclaw/tests/plugin.test.ts
@@ -23,11 +23,18 @@ function createMockPayments() {
       }),
       orderPlan: jest.fn<() => Promise<unknown>>().mockResolvedValue({ txHash: '0xdeadbeef', success: true }),
       getPlans: jest.fn<() => Promise<unknown>>().mockResolvedValue([{ planId: 'plan-1' }, { planId: 'plan-2' }]),
+      // Mirrors the real backend response shape (apps/api/src/plans/dto/get-plan-dto.ts).
+      // The unit test failed silently before this PR because it used an invented flat shape.
       getPlan: jest.fn<() => Promise<unknown>>().mockResolvedValue({
-        planId: 'plan-default',
-        name: 'Test Plan',
-        price: '1 USDC',
-        credits: 100,
+        id: 'plan-default',
+        metadata: {
+          main: { name: 'Test Plan', price: '1 USDC' },
+          plan: { accessLimit: 'credits', currency: 'USDC' },
+        },
+        registry: {
+          price: { isCrypto: true, amounts: [1000000n] },
+          credits: { amount: 100n },
+        },
       }),
       registerPlan: jest.fn<() => Promise<unknown>>().mockResolvedValue({ planId: 'plan-new' }),
       orderFiatPlan: jest.fn<() => Promise<unknown>>().mockResolvedValue({ result: { checkoutUrl: 'https://checkout.stripe.com/test_session' } }),
@@ -435,7 +442,11 @@ describe('OpenClaw Nevermined Plugin', () => {
       expect(result.message).toBe('Re-call with confirm: true to proceed.')
       expect(result.paymentType).toBe('crypto')
       expect(result.planId).toBe('plan-default')
-      expect(result.credits).toBe(100)
+      expect(result.name).toBe('Test Plan')
+      expect(result.price).toBe('1 USDC')
+      expect(result.credits).toBe('100') // bigint stringified for JSON safety
+      expect(result.accessLimit).toBe('credits')
+      expect(result.currency).toBe('USDC')
     })
 
     test('nevermined_orderPlan — with confirm:true, executes the order', async () => {


### PR DESCRIPTION
## Summary

Closes the metadata gap and security findings flagged on the public OpenClaw skill listing at https://clawhub.ai/aaitor/nevermined-payments/security/openclaw — addresses issue #327.

- **Metadata + provenance** for the OpenClaw plugin: full ClawHub-aware frontmatter in `SKILL.md` (`metadata.clawdis` with `author`, `links`, `requires.{env,config}`, `envVars`, `dependencies`); top-level `version`/`license`/`author`/`homepage`/`repository`/`bugs`/`security` in `openclaw.plugin.json`; `publishConfig.provenance: true` + `homepage`/`bugs`/`author` in `openclaw/package.json`; "Official source & provenance" section in the README warning that `clawhub.ai/aaitor/...` is unofficial.
- **Six ClawHub findings remediated** at the source — see table below.

## ClawHub findings addressed

| # | Finding (severity) | Fix |
|---|---|---|
| 1 | Tool misuse / direct order calls (Medium) | `nevermined_orderPlan` and `nevermined_orderFiatPlan` now require `confirm: true`. The first call returns a quote (`planId`, `name`, `price`, `credits`, `paymentType`, `environment`) + the literal `"Re-call with confirm: true to proceed."`. Two new helpers (`isConfirmed`, `buildOrderQuote`) in `openclaw/src/tools.ts`. |
| 2 | Unpinned SDK installs (Low) | Pinned `@^1.1` in every install snippet (`README.md`, `markdown/installation.md`, `openclaw/README.md`, `openclaw/docs/{getting-started,guide}.md`); `release.yml` `publish-openclaw` now uses `npm publish --provenance` (works with the existing `id-token: write` permission). |
| 3 | Rogue agents (Low) | MCP examples bind to `127.0.0.1` via `host: process.env.MCP_HOST ?? '127.0.0.1'`; A2A and HTTP-agent docs recommend a reverse proxy with HTTPS; missing SIGINT handler added to the bare `app.listen()` example in `mcp-integration.md` and the manual handler example in `RUN.md`. |
| 4 | Token logging (Medium) | New `redactToken(token)` helper exported from `openclaw/src/tools.ts`. Bearer-token hygiene callouts at the top of `querying-an-agent.md`, `x402.md`, `validation-of-requests.md`, and the openclaw README. Replaced a length-leaking `console.log` in `querying-an-agent.md`. |
| 5 | Missing credential declarations (Medium) | `metadata.clawdis.envVars` block declares `NVM_API_KEY` (required), `NVM_ENVIRONMENT`, `NVM_PLAN_ID`, `NVM_AGENT_ID`, `BUILDER_ADDRESS` (optional), with descriptions. `requires.env` and `requires.config` set for the parser. |
| 6 | Insecure inter-agent comms (Medium) | `warnIfInsecureUrl()` in `nevermined_queryAgent` warns on non-HTTPS `agentUrl` (loopback hosts excepted for local dev); `markdown/a2a-integration.md` documents `.well-known/agent.json` validation; `openclaw/docs/guide.md` adds a "Security expectations" callout. |

## Test plan

- [x] `pnpm build` (SDK + openclaw) — clean
- [x] `pnpm lint` — 0 errors at SDK root and in `openclaw/`
- [x] `pnpm test:unit` — 118 passed, 1 skipped
- [x] `cd openclaw && pnpm test` — 61 passed (incl. 4 new confirm-flow tests)
- [x] `npm publish --provenance --dry-run --access public` — packs cleanly (37.5 kB, 28 files)
- [x] `js-yaml` round-trip of the new SKILL.md frontmatter returns the full `metadata.clawdis` object with `links`, `envVars`, `dependencies`, `requires`
- [x] `jq -e '.version and .repository and .author and .security and .license' openclaw/openclaw.plugin.json` exits 0
- [ ] Once merged, cut `@nevermined-io/openclaw-plugin@1.1.2` (or `1.2.0`) and verify the npm tarball carries provenance attestations
- [ ] Re-publish ClawHub skill from CI under an `@nevermined-io`-owned handle with the `source` block (`kind: github`, `repo`, `ref`, `commit`, `path`); request transfer/deprecation of the `aaitor/nevermined-payments` slug

## Out of scope (tracked in #327, follow-up PRs)

- Workstream **C** in #327 (cut release, publish ClawHub skill from CI under official ownership, deprecate the unofficial slug, update `nevermined-io/docs` to point at the official URL).
- A2A server `host` parameter — would require changes to `src/a2a/server.ts`. Today the docs recommend running it behind a reverse proxy bound to localhost. Filed as follow-up if needed.

Refs: #327
