### PR TITLE
docs: fix broken Discord invite link in CLI docs

### DIFF
--- a/cli/CLI_GUIDE.md
+++ b/cli/CLI_GUIDE.md
@@ -577,4 +577,4 @@ chore: update dependencies
 
 - Documentation: https://nevermined.ai/docs
 - Issues: https://github.com/nevermined-io/payments/issues
-- Discord: https://discord.gg/nevermined
+- Discord: https://discord.gg/GZju2qScKq

--- a/cli/docs/README.md
+++ b/cli/docs/README.md
@@ -288,7 +288,7 @@ nvm plans get-plan --help
 
 ### Support
 
-- Discord Community: https://discord.gg/nevermined
+- Discord Community: https://discord.gg/GZju2qScKq
 - Email Support: support@nevermined.io
 - Developer Forum: https://forum.nevermined.io
 

--- a/cli/docs/getting-started.md
+++ b/cli/docs/getting-started.md
@@ -289,4 +289,4 @@ nvm plans get-plan --help
 For support:
 - Documentation: https://nevermined.ai/docs
 - Issues: https://github.com/nevermined-io/payments/issues
-- Discord: https://discord.gg/nevermined
+- Discord: https://discord.gg/GZju2qScKq


### PR DESCRIPTION
## Summary

The CLI docs in this repo point to `https://discord.gg/nevermined`, which is not a valid invite — Discord's API returns `Unknown Invite` (error code 10006) because that vanity URL is not registered on the Nevermined server.

This replaces it with `https://discord.gg/GZju2qScKq`, the canonical invite already used everywhere else (docs, website, nvm-monorepo, .github/profile).

Files updated:
- `cli/CLI_GUIDE.md`
- `cli/docs/README.md`
- `cli/docs/getting-started.md`

The Mintlify-mirrored copies under `docs_mintlify/api-reference/cli/` will refresh on the next docs sync — no manual edit needed there.

## Validation

```
$ curl -s 'https://discord.com/api/v10/invites/nevermined?with_counts=true' | jq '{code, message}'
{ "code": 10006, "message": "Unknown Invite" }

$ curl -s 'https://discord.com/api/v10/invites/GZju2qScKq?with_counts=true' | jq '{guild_name: .guild.name, members: .approximate_member_count}'
{ "guild_name": "Nevermined", "members": 1340 }
```

## Test plan

- [ ] CI passes (docs-only change, no code paths touched)
- [ ] Click the updated link from each of the three rendered files and confirm it lands on the Nevermined Discord