### PR TITLE
docs(openclaw): point ClawHub references to @nevermined org

### DIFF
--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -14,7 +14,7 @@ This plugin is published from the [`nevermined-io/payments`](https://github.com/
 | **Security policy** | https://github.com/nevermined-io/payments/security/policy |
 | **Issue tracker** | https://github.com/nevermined-io/payments/issues |
 
-> ✅ **Official ClawHub listing.** Until ClawHub ships org publishers, the official skill lives at [`clawhub.ai/aaitor/nevermined-payments`](https://clawhub.ai/aaitor/nevermined-payments/openclaw) — `@aaitor` is a Nevermined admin and that account's token is the one used by this repo's release workflow. Treat any other ClawHub publisher as a third-party mirror until further notice. The canonical npm package is [`@nevermined-io/openclaw-plugin`](https://www.npmjs.com/package/@nevermined-io/openclaw-plugin).
+> ✅ **Official ClawHub listing.** The official skill lives at [`clawhub.ai/nevermined/nevermined-payments`](https://clawhub.ai/nevermined/nevermined-payments) under the `@nevermined` org publisher. Treat any other ClawHub publisher as a third-party mirror until further notice. The canonical npm package is [`@nevermined-io/openclaw-plugin`](https://www.npmjs.com/package/@nevermined-io/openclaw-plugin).
 >
 > 🔐 **Never log payment tokens.** x402 access tokens (the `payment-signature` header) are bearer credentials. Treat them like API keys: redact them in any debug output, log pipeline, or telemetry exporter (pino, winston, OpenTelemetry, etc.).
 

--- a/openclaw/skills/nevermined/SKILL.md
+++ b/openclaw/skills/nevermined/SKILL.md
@@ -50,7 +50,7 @@ metadata:
 
 This plugin provides gateway tools for interacting with Nevermined AI agent payments. Supports both crypto (on-chain) and fiat (credit card) payment flows.
 
-> **Official source.** This skill is published from [`nevermined-io/payments`](https://github.com/nevermined-io/payments) (subdirectory `openclaw/`) by Nevermined AG, mirrored to ClawHub at [`clawhub.ai/aaitor/nevermined-payments`](https://clawhub.ai/aaitor/nevermined-payments/openclaw) (publishing handle is a Nevermined admin until ClawHub ships org publishers). The npm package is [`@nevermined-io/openclaw-plugin`](https://www.npmjs.com/package/@nevermined-io/openclaw-plugin) (Apache-2.0).
+> **Official source.** This skill is published from [`nevermined-io/payments`](https://github.com/nevermined-io/payments) (subdirectory `openclaw/`) by Nevermined AG, mirrored to ClawHub at [`clawhub.ai/nevermined/nevermined-payments`](https://clawhub.ai/nevermined/nevermined-payments) under the `@nevermined` org publisher. The npm package is [`@nevermined-io/openclaw-plugin`](https://www.npmjs.com/package/@nevermined-io/openclaw-plugin) (Apache-2.0).
 >
 > **Never log payment tokens.** x402 access tokens (the `payment-signature` header) are bearer credentials. Redact them in any debug or telemetry output.
 


### PR DESCRIPTION
## Summary

The OpenClaw skill was republished under the new `@nevermined` org publisher on ClawHub today (slug remains `nevermined-payments`, latest version `0.3.0`). Update the two places in `openclaw/` that pointed at the old `@aaitor` URL and remove the now-stale "until ClawHub ships org publishers" caveat.

Files updated:
- `openclaw/README.md`
- `openclaw/skills/nevermined/SKILL.md`

URL change: `clawhub.ai/aaitor/nevermined-payments` → `clawhub.ai/nevermined/nevermined-payments`

## Validation

```
$ curl -sS -o /dev/null -w "%{http_code} -> %{redirect_url}\n" \
    https://clawhub.ai/aaitor/nevermined-payments
307 -> https://clawhub.ai/nevermined/nevermined-payments

$ curl -sS -o /dev/null -w "%{http_code}\n" \
    https://clawhub.ai/nevermined/nevermined-payments
200

$ curl -sL https://clawhub.ai/api/v1/packages/nevermined-payments | \
    jq '.package | {ownerHandle, latestVersion}'
{ "ownerHandle": "nevermined", "latestVersion": "0.3.0" }
```

ClawHub also serves a 307 redirect from the old `@aaitor` URL, so any external links remain live.

## Test plan

- [ ] CI passes (docs-only change in `openclaw/*.md`)
- [ ] Render the updated README on GitHub and confirm both Markdown links resolve to the new ClawHub page