### PR TITLE
fix(ci): drop yarn-only --ignore-engines from pnpm install in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,14 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Install SDK dependencies
-        run: pnpm install --frozen-lockfile --ignore-engines
+        run: pnpm install --frozen-lockfile
 
       - name: Build SDK
         run: pnpm build
 
       - name: Install CLI dependencies
         working-directory: cli
-        run: pnpm install --frozen-lockfile --ignore-engines
+        run: pnpm install --frozen-lockfile
 
       - name: Link local SDK into CLI
         run: rm -rf cli/node_modules/@nevermined-io/payments && ln -s "$PWD" cli/node_modules/@nevermined-io/payments
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install OpenClaw Plugin dependencies
         working-directory: openclaw
-        run: pnpm install --frozen-lockfile --ignore-engines
+        run: pnpm install --frozen-lockfile
 
       - name: Link local SDK into OpenClaw Plugin
         run: rm -rf openclaw/node_modules/@nevermined-io/payments && ln -s "$PWD" openclaw/node_modules/@nevermined-io/payments
@@ -81,7 +81,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-engines
+        run: pnpm install --frozen-lockfile
 
       - name: Build SDK
         run: pnpm build
@@ -127,14 +127,14 @@ jobs:
           echo "Publishing version: $VERSION"
 
       - name: Install SDK dependencies
-        run: pnpm install --frozen-lockfile --ignore-engines
+        run: pnpm install --frozen-lockfile
 
       - name: Build SDK
         run: pnpm build
 
       - name: Install CLI dependencies
         working-directory: cli
-        run: pnpm install --frozen-lockfile --ignore-engines
+        run: pnpm install --frozen-lockfile
 
       - name: Link local SDK into CLI
         run: rm -rf cli/node_modules/@nevermined-io/payments && ln -s "$PWD" cli/node_modules/@nevermined-io/payments
@@ -207,14 +207,14 @@ jobs:
           echo "Publishing version: $VERSION"
 
       - name: Install SDK dependencies
-        run: pnpm install --frozen-lockfile --ignore-engines
+        run: pnpm install --frozen-lockfile
 
       - name: Build SDK
         run: pnpm build
 
       - name: Install OpenClaw Plugin dependencies
         working-directory: openclaw
-        run: pnpm install --frozen-lockfile --ignore-engines
+        run: pnpm install --frozen-lockfile
 
       - name: Link local SDK into OpenClaw Plugin
         run: rm -rf openclaw/node_modules/@nevermined-io/payments && ln -s "$PWD" openclaw/node_modules/@nevermined-io/payments


### PR DESCRIPTION
## Summary

The `Release` workflow has been failing on every tag push since the yarn → pnpm migration (#287). It still calls `pnpm install --frozen-lockfile --ignore-engines`, but `--ignore-engines` is a yarn-only flag — pnpm rejects it:

```
ERROR  Unknown option: 'ignore-engines'
Did you mean 'ignore-scripts'?
```

The `Build & Test` job in the v1.3.4 release run ([25388981620](https://github.com/nevermined-io/payments/actions/runs/25388981620)) failed at the very first install step, blocking the SDK / CLI / OpenClaw / docs publish jobs downstream. v1.3.4 was tagged but never published to npm by CI.

## Fix

Remove `--ignore-engines` from all 8 `pnpm install` steps in `.github/workflows/release.yml`. Every other workflow in the repo (`testing.yml`, `cli-sync-and-test.yml`, `openclaw-sync-and-test.yml`, `build-cli.yml`, `update-docs.yml`) already uses plain `pnpm install --frozen-lockfile`, so this just brings `release.yml` into line.

No engine constraint actually needs ignoring — the migration commit set the runner to Node 24.x, which satisfies all `engines` ranges in the repo. We were silently flag-stripping nothing.

## Test plan

- [ ] CI on this PR is green (the regular `Payments Tests` / `CLI Sync` / `OpenClaw Sync` workflows already do not use `--ignore-engines`, so the new diff only affects the release pipeline).
- [ ] After merge, retry v1.3.4 publish or cut v1.3.5 — the `Build & Test` job in `release.yml` should now reach the `Build SDK` step, and the publish jobs (`Publish SDK to npm`, `Publish CLI to npm`, `Publish OpenClaw Plugin to npm`, `Publish Documentation`, `Create GitHub Release`, `Publish OpenClaw Plugin to ClawHub`) should run end to end.
- [ ] Verify `@nevermined-io/payments@1.3.4` appears on npm afterward (currently `npm view` will still show 1.3.3 as the latest published).