### PR TITLE
fix(cli): JSON-parse --agent-api in agents commands (#336)

### DIFF
--- a/cli/src/commands/agents/register-agent-and-plan.ts
+++ b/cli/src/commands/agents/register-agent-and-plan.ts
@@ -17,7 +17,10 @@ export default class RegisterAgentAndPlan extends BaseCommand {
       description: "agentMetadata as JSON string",
       required: true
     }),
-    'agent-api': Flags.string({ required: true }),
+    'agent-api': Flags.string({
+      description: "agentApi as JSON string",
+      required: true
+    }),
     'plan-metadata': Flags.string({
       description: "planMetadata as JSON string",
       required: true
@@ -41,7 +44,7 @@ export default class RegisterAgentAndPlan extends BaseCommand {
     const payments = await this.initPayments()
 
     try {
-      const result = await payments.agents.registerAgentAndPlan(await this.parseJsonInput(flags['agent-metadata']), flags['agent-api'], await this.parseJsonInput(flags['plan-metadata']), await this.parseJsonInput(flags['price-config']), await this.parseJsonInput(flags['credits-config']), flags['access-limit'])
+      const result = await payments.agents.registerAgentAndPlan(await this.parseJsonInput(flags['agent-metadata']), await this.parseJsonInput(flags['agent-api']), await this.parseJsonInput(flags['plan-metadata']), await this.parseJsonInput(flags['price-config']), await this.parseJsonInput(flags['credits-config']), flags['access-limit'])
 
       this.formatter.output(result)
     } catch (error) {

--- a/cli/src/commands/agents/register-agent.ts
+++ b/cli/src/commands/agents/register-agent.ts
@@ -17,7 +17,10 @@ export default class RegisterAgent extends BaseCommand {
       description: "agentMetadata as JSON string",
       required: true
     }),
-    'agent-api': Flags.string({ required: true }),
+    'agent-api': Flags.string({
+      description: "agentApi as JSON string",
+      required: true
+    }),
     'payment-plans': Flags.string({ required: true }),
   }
 
@@ -29,7 +32,7 @@ export default class RegisterAgent extends BaseCommand {
     const payments = await this.initPayments()
 
     try {
-      const result = await payments.agents.registerAgent(await this.parseJsonInput(flags['agent-metadata']), flags['agent-api'], flags['payment-plans'])
+      const result = await payments.agents.registerAgent(await this.parseJsonInput(flags['agent-metadata']), await this.parseJsonInput(flags['agent-api']), flags['payment-plans'])
 
       this.formatter.output(result)
     } catch (error) {

--- a/cli/src/commands/agents/update-agent-metadata.ts
+++ b/cli/src/commands/agents/update-agent-metadata.ts
@@ -17,7 +17,10 @@ export default class UpdateAgentMetadata extends BaseCommand {
       description: "agentMetadata as JSON string",
       required: true
     }),
-    'agent-api': Flags.string({ required: true }),
+    'agent-api': Flags.string({
+      description: "agentApi as JSON string",
+      required: true
+    }),
   }
 
   static override args = {
@@ -34,7 +37,7 @@ export default class UpdateAgentMetadata extends BaseCommand {
     const payments = await this.initPayments()
 
     try {
-      const result = await payments.agents.updateAgentMetadata(args.agent, await this.parseJsonInput(flags['agent-metadata']), flags['agent-api'])
+      const result = await payments.agents.updateAgentMetadata(args.agent, await this.parseJsonInput(flags['agent-metadata']), await this.parseJsonInput(flags['agent-api']))
 
       this.formatter.output(result)
     } catch (error) {

--- a/cli/src/generator/command-generator.ts
+++ b/cli/src/generator/command-generator.ts
@@ -370,8 +370,8 @@ ${runMethod}
       return true
     }
 
-    // Types ending with Config, Metadata, Options are likely interfaces
-    if (/(Config|Metadata|Options|Settings|Params)$/.test(baseType)) {
+    // Types ending with Config, Metadata, Options, Attributes, etc. are likely interfaces
+    if (/(Config|Metadata|Options|Settings|Params|Attributes)$/.test(baseType)) {
       return true
     }
 

--- a/cli/test/integration/generated-commands.test.ts
+++ b/cli/test/integration/generated-commands.test.ts
@@ -78,7 +78,22 @@ describe('Generated Commands Integration Tests', () => {
       expect(stdout).toContain('agent-metadata')
       expect(stdout).toContain('agent-api')
       expect(stdout).toContain('payment-plans')
-      expect(stdout).toContain('JSON string')
+      expect(stdout).toContain('agentMetadata as JSON string')
+      expect(stdout).toContain('agentApi as JSON string')
+    })
+
+    test('agents register-agent-and-plan documents agent-api as JSON', () => {
+      const { stdout, exitCode } = runCLI(['agents', 'register-agent-and-plan', '--help'])
+
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('agentApi as JSON string')
+    })
+
+    test('agents update-agent-metadata documents agent-api as JSON', () => {
+      const { stdout, exitCode } = runCLI(['agents', 'update-agent-metadata', '--help'])
+
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('agentApi as JSON string')
     })
 
     test('agents register-agent requires all flags', () => {


### PR DESCRIPTION
## Summary

Closes #336.

The CLI generator's `isComplexType()` regex (`cli/src/generator/command-generator.ts`) only matched the suffixes `Config|Metadata|Options|Settings|Params`. `AgentAPIAttributes` ends in `Attributes`, so the generated `--agent-api` flag was emitted as a plain string and the value was forwarded to the SDK verbatim. The backend rejected every call with:

```
Error: Unable to register agent ... agentApiAttributes must be an object,nested property agentApiAttributes must be either object or array
```

This made `agents register-agent`, `agents register-agent-and-plan`, and `agents update-agent-metadata` non-functional from the CLI — there was no value the user could pass for `--agent-api` that the backend would accept.

## Changes

- **Generator fix:** `cli/src/generator/command-generator.ts` — extend the complex-type suffix regex to include `Attributes`.
- **Regenerated commands** (via `pnpm generate`): `register-agent.ts`, `register-agent-and-plan.ts`, `update-agent-metadata.ts` — `--agent-api` now has the standard `"agentApi as JSON string"` description and is routed through `await this.parseJsonInput(...)` like the other JSON flags.
- **Tests:** strengthen the existing `register-agent --help` assertion to look for the per-flag description, and add equivalent regression tests for `register-agent-and-plan` and `update-agent-metadata`.

## Verification

```bash
cd cli && pnpm test:unit          # 10/10 passing
cd cli && pnpm test:integration   # 28/28 passing (was 26 + 2 new)
```

End-to-end against `production_sandbox` (`https://api.sandbox.nevermined.app`) with the patched CLI:

```bash
nvm agents register-agent-and-plan \
  --agent-metadata '{"name":"x","description":"x","tags":["t"]}' \
  --agent-api '{"endpoints":[{"POST":"https://example.com/api/test"}],"agentDefinitionUrl":"https://example.com/openapi.json"}' \
  --plan-metadata '{...}' --price-config '{...}' --credits-config '{...}' \
  -f json
# {
#   "agentId": "10666800742370571046680760094597...",
#   "planId":  "36886266855447749473057019049493...",
#   "txHash":  "0x17b2c40c834977585b659b164afac6d5..."
# }
```

Same call previously failed with the `agentApiAttributes` server error.

## Test plan

- [x] `cli/src/commands/agents/register-agent*.ts` and `update-agent-metadata.ts` route `--agent-api` through `parseJsonInput()`
- [x] `cli/src/generator/command-generator.ts` recognises `*Attributes` types as complex (so future `Attributes`-suffixed SDK types are handled correctly out of the box)
- [x] Unit + integration tests pass locally
- [x] End-to-end against sandbox returns 201 with a valid `agentId` / `planId` / `txHash`
- [ ] CI green (build, lint, cli-sync-and-test)