### PR TITLE
feat(cli): add x402token build-payment-required helper (#337)

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -77,12 +77,13 @@ jobs:
       - name: Debug manifest + dist (TEMP — remove before merge)
         working-directory: cli
         run: |
-          echo "=== Direct invocation (no NODE_ENV) ==="
-          node bin/run.js x402token build-payment-required 12345 --resource-url 'https://example.com/test' -f json || echo "FAILED EXIT=$?"
-          echo "=== Direct invocation (NODE_ENV=test) ==="
-          NODE_ENV=test node bin/run.js x402token build-payment-required 12345 --resource-url 'https://example.com/test' -f json 2>&1 | tail -25 || echo "FAILED EXIT=$?"
-          echo "=== Run jest test only for build-payment-required (verbose) ==="
-          DEBUG='oclif:*' npx jest test/integration/generated-commands.test.ts -t "build-payment-required emits valid" --no-color 2>&1 | tail -40 || echo "JEST FAILED"
+          echo "=== Run cli-basic.test.ts FIRST then verify manifest ==="
+          npx jest test/integration/cli-basic.test.ts --no-color 2>&1 | tail -15 || echo "CLI BASIC FAILED"
+          echo "=== Manifest after cli-basic ==="
+          ls -la oclif.manifest.json 2>&1 || echo "MANIFEST GONE"
+          ls -la dist/commands/x402token/ 2>&1 || echo "DIST GONE"
+          echo "=== Direct invocation after cli-basic ==="
+          node bin/run.js x402token build-payment-required 12345 --resource-url 'https://example.com/test' -f json 2>&1 | head -25 || echo "DIRECT FAILED EXIT=$?"
 
       - name: Run CLI sync check
         working-directory: cli

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -68,7 +68,11 @@ jobs:
 
       - name: Build CLI
         working-directory: cli
-        run: pnpm build
+        # Use build:manifest (not just build) so oclif.manifest.json is
+        # written. Without the manifest, oclif walks src/ when resolving
+        # commands with positional args and chokes on the .ts files'
+        # `.js` ESM import paths. Mirrors cli-sync-and-test.yml.
+        run: pnpm build:manifest
 
       - name: Run CLI sync check
         working-directory: cli

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -74,6 +74,18 @@ jobs:
         # `.js` ESM import paths. Mirrors cli-sync-and-test.yml.
         run: pnpm build:manifest
 
+      - name: Debug manifest + dist (TEMP — remove before merge)
+        working-directory: cli
+        run: |
+          echo "=== oclif.manifest.json: total commands ==="
+          node -e "const m=require('./oclif.manifest.json'); console.log('Total:', Object.keys(m.commands).length); console.log('Has build-payment-required:', 'x402token:build-payment-required' in m.commands);"
+          echo "=== build-payment-required manifest entry ==="
+          node -e "const m=require('./oclif.manifest.json'); console.log(JSON.stringify(m.commands['x402token:build-payment-required'], null, 2));"
+          echo "=== dist/commands/x402token files ==="
+          ls -la dist/commands/x402token/ || true
+          echo "=== Direct invocation (with manifest) ==="
+          node bin/run.js x402token build-payment-required 12345 --resource-url 'https://example.com/test' -f json || echo "FAILED with EXIT=$?"
+
       - name: Run CLI sync check
         working-directory: cli
         run: pnpm sync-check

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -77,14 +77,12 @@ jobs:
       - name: Debug manifest + dist (TEMP — remove before merge)
         working-directory: cli
         run: |
-          echo "=== oclif.manifest.json: total commands ==="
-          node -e "const m=require('./oclif.manifest.json'); console.log('Total:', Object.keys(m.commands).length); console.log('Has build-payment-required:', 'x402token:build-payment-required' in m.commands);"
-          echo "=== build-payment-required manifest entry ==="
-          node -e "const m=require('./oclif.manifest.json'); console.log(JSON.stringify(m.commands['x402token:build-payment-required'], null, 2));"
-          echo "=== dist/commands/x402token files ==="
-          ls -la dist/commands/x402token/ || true
-          echo "=== Direct invocation (with manifest) ==="
-          node bin/run.js x402token build-payment-required 12345 --resource-url 'https://example.com/test' -f json || echo "FAILED with EXIT=$?"
+          echo "=== Direct invocation (no NODE_ENV) ==="
+          node bin/run.js x402token build-payment-required 12345 --resource-url 'https://example.com/test' -f json || echo "FAILED EXIT=$?"
+          echo "=== Direct invocation (NODE_ENV=test) ==="
+          NODE_ENV=test node bin/run.js x402token build-payment-required 12345 --resource-url 'https://example.com/test' -f json 2>&1 | tail -25 || echo "FAILED EXIT=$?"
+          echo "=== Run jest test only for build-payment-required (verbose) ==="
+          DEBUG='oclif:*' npx jest test/integration/generated-commands.test.ts -t "build-payment-required emits valid" --no-color 2>&1 | tail -40 || echo "JEST FAILED"
 
       - name: Run CLI sync check
         working-directory: cli

--- a/cli/src/commands/x402token/build-payment-required.ts
+++ b/cli/src/commands/x402token/build-payment-required.ts
@@ -1,0 +1,102 @@
+import { Args, Flags } from '@oclif/core'
+import { BaseCommand } from '../../base-command.js'
+import { buildPaymentRequired, EnvironmentName } from '@nevermined-io/payments'
+
+const SCHEME_OPTIONS = ['nvm:erc4337', 'nvm:card-delegation'] as const
+type SchemeOption = (typeof SCHEME_OPTIONS)[number]
+
+/**
+ * Build an X402PaymentRequired payload for verify-permissions / settle-permissions.
+ */
+export default class BuildPaymentRequired extends BaseCommand {
+  static override description =
+    'Build an X402PaymentRequired payload for the given plan. The output can be passed verbatim into the `paymentRequired` field of `nvm facilitator verify-permissions` and `nvm facilitator settle-permissions`.'
+
+  static override examples = [
+    '$ nvm x402token build-payment-required <planId> --resource-url https://example.com/api/test',
+    '$ nvm x402token build-payment-required <planId> --resource-url https://example.com/api/test --agent-id <agentId> --http-verb POST',
+    '$ nvm x402token build-payment-required <planId> --scheme nvm:card-delegation --network stripe',
+    '$ nvm x402token build-payment-required <planId> --resource-url https://example.com/api/test -f json',
+  ]
+
+  static override flags = {
+    ...BaseCommand.baseFlags,
+    'resource-url': Flags.string({
+      description: 'Protected resource URL (maps to the `endpoint` option in the SDK)',
+      required: false,
+    }),
+    'agent-id': Flags.string({ required: false }),
+    'http-verb': Flags.string({
+      description: 'HTTP verb of the protected resource (e.g. POST)',
+      required: false,
+    }),
+    scheme: Flags.string({
+      description: 'x402 payment scheme',
+      options: [...SCHEME_OPTIONS],
+      default: 'nvm:erc4337',
+      required: false,
+    }),
+    network: Flags.string({
+      description:
+        'Override the network. Defaults to the scheme/environment default (e.g. eip155:84532 for nvm:erc4337 on sandbox).',
+      required: false,
+    }),
+    description: Flags.string({
+      description: 'Human-readable description of the protected resource',
+      required: false,
+    }),
+    'mime-type': Flags.string({
+      description: 'MIME type of the protected resource',
+      required: false,
+    }),
+    environment: Flags.string({
+      description:
+        'Environment used to resolve the default network. Falls back to the active profile when omitted.',
+      required: false,
+    }),
+  }
+
+  static override args = {
+    plan: Args.string({
+      description: 'plan identifier',
+      required: true,
+    }),
+  }
+
+  public async run(): Promise<void> {
+    const { flags, args } = await this.parse(this.constructor as any)
+
+    try {
+      const environment = await this.resolveEnvironment(flags)
+
+      const paymentRequired = buildPaymentRequired(args.plan, {
+        endpoint: flags['resource-url'],
+        agentId: flags['agent-id'],
+        httpVerb: flags['http-verb'],
+        scheme: flags.scheme as SchemeOption,
+        network: flags.network,
+        description: flags.description,
+        mimeType: flags['mime-type'],
+        environment,
+      })
+
+      this.formatter.output(paymentRequired)
+    } catch (error) {
+      this.handleError(error)
+    }
+  }
+
+  private async resolveEnvironment(flags: any): Promise<EnvironmentName | undefined> {
+    if (flags.environment) {
+      return flags.environment as EnvironmentName
+    }
+
+    const envVar = process.env.NVM_ENVIRONMENT
+    if (envVar) {
+      return envVar as EnvironmentName
+    }
+
+    const config = await this.configManager.get(undefined, flags.profile)
+    return config?.environment as EnvironmentName | undefined
+  }
+}

--- a/cli/src/commands/x402token/build-payment-required.ts
+++ b/cli/src/commands/x402token/build-payment-required.ts
@@ -15,15 +15,16 @@ export default class BuildPaymentRequired extends BaseCommand {
   static override examples = [
     '$ nvm x402token build-payment-required <planId> --resource-url https://example.com/api/test',
     '$ nvm x402token build-payment-required <planId> --resource-url https://example.com/api/test --agent-id <agentId> --http-verb POST',
-    '$ nvm x402token build-payment-required <planId> --scheme nvm:card-delegation --network stripe',
-    '$ nvm x402token build-payment-required <planId> --resource-url https://example.com/api/test -f json',
+    '$ nvm x402token build-payment-required <planId> --resource-url https://example.com/api/test --scheme nvm:card-delegation',
+    '$ nvm x402token build-payment-required <planId> --resource-url https://example.com/api/test --environment live -f json',
   ]
 
   static override flags = {
     ...BaseCommand.baseFlags,
     'resource-url': Flags.string({
-      description: 'Protected resource URL (maps to the `endpoint` option in the SDK)',
-      required: false,
+      description:
+        'Protected resource URL (maps to the `endpoint` option in the SDK). Required because the backend rejects payloads with an empty `resource.url`.',
+      required: true,
     }),
     'agent-id': Flags.string({ required: false }),
     'http-verb': Flags.string({
@@ -52,6 +53,7 @@ export default class BuildPaymentRequired extends BaseCommand {
     environment: Flags.string({
       description:
         'Environment used to resolve the default network. Falls back to the active profile when omitted.',
+      options: ['sandbox', 'live', 'staging_sandbox', 'staging_live', 'custom'],
       required: false,
     }),
   }

--- a/cli/src/generator/command-generator.ts
+++ b/cli/src/generator/command-generator.ts
@@ -7,6 +7,7 @@ import { writeFile, mkdir, readFile } from 'fs/promises'
 import { join, dirname } from 'path'
 import { existsSync } from 'fs'
 import { MethodInfo, APIClassInfo } from './api-scanner.js'
+import { MANUALLY_MAINTAINED_COMMANDS } from './manually-maintained.js'
 
 export interface CommandMetadata {
   className: string
@@ -18,15 +19,6 @@ export interface CommandMetadata {
     afterInit?: string
   }
 }
-
-/**
- * Commands that are manually maintained and should not be overwritten by the generator.
- * Key format: "topic/command-name" (matches the file path under commands/).
- */
-const MANUALLY_MAINTAINED_COMMANDS = new Set([
-  'x402token/get-x402-access-token',
-  'x402token/build-payment-required',
-])
 
 export class CommandGenerator {
   private outputDir: string

--- a/cli/src/generator/command-generator.ts
+++ b/cli/src/generator/command-generator.ts
@@ -25,6 +25,7 @@ export interface CommandMetadata {
  */
 const MANUALLY_MAINTAINED_COMMANDS = new Set([
   'x402token/get-x402-access-token',
+  'x402token/build-payment-required',
 ])
 
 export class CommandGenerator {

--- a/cli/src/generator/manually-maintained.ts
+++ b/cli/src/generator/manually-maintained.ts
@@ -1,0 +1,10 @@
+/**
+ * Commands that are manually maintained and should not be overwritten by the
+ * generator or flagged as "extra" by the sync check.
+ *
+ * Key format: "topic/command-name" (matches the file path under commands/).
+ */
+export const MANUALLY_MAINTAINED_COMMANDS = new Set([
+  'x402token/get-x402-access-token',
+  'x402token/build-payment-required',
+])

--- a/cli/src/generator/sync-check.ts
+++ b/cli/src/generator/sync-check.ts
@@ -11,6 +11,7 @@ import { dirname } from 'path'
 import { readdir } from 'fs/promises'
 import { existsSync } from 'fs'
 import { APIScanner } from './api-scanner.js'
+import { MANUALLY_MAINTAINED_COMMANDS } from './manually-maintained.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -100,13 +101,18 @@ async function main() {
       }
     }
 
-    // Check for extra commands (removed from SDK)
+    // Check for extra commands (removed from SDK), skipping manually-maintained ones
     for (const commandName of existingCommands) {
-      if (!expectedCommands.has(commandName)) {
-        const message = `Extra command (not in SDK): ${topic} ${commandName}`
-        console.log(`   ⚠️  ${message}`)
-        issues.push({ type: 'extra', message })
+      if (expectedCommands.has(commandName)) {
+        continue
       }
+      if (MANUALLY_MAINTAINED_COMMANDS.has(`${topic}/${commandName}`)) {
+        console.log(`   ✓ ${commandName} (manually maintained)`)
+        continue
+      }
+      const message = `Extra command (not in SDK): ${topic} ${commandName}`
+      console.log(`   ⚠️  ${message}`)
+      issues.push({ type: 'extra', message })
     }
   }
 

--- a/cli/test/integration/cli-basic.test.ts
+++ b/cli/test/integration/cli-basic.test.ts
@@ -10,10 +10,15 @@ import { join } from 'path'
 const CLI_PATH = join(__dirname, '../../bin/run.js')
 
 function runCLI(args: string[]): { stdout: string; stderr: string; exitCode: number } {
+  // Strip NODE_ENV=test from the child env: oclif treats that as development
+  // mode and scans src/ instead of dist/, which breaks command resolution.
+  const childEnv = { ...process.env }
+  delete childEnv.NODE_ENV
   try {
     const stdout = execSync(`node ${CLI_PATH} ${args.join(' ')}`, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      env: childEnv,
     })
     return { stdout, stderr: '', exitCode: 0 }
   } catch (error: any) {

--- a/cli/test/integration/generated-commands.test.ts
+++ b/cli/test/integration/generated-commands.test.ts
@@ -9,10 +9,16 @@ import { join } from 'path'
 const CLI_PATH = join(__dirname, '../../bin/run.js')
 
 function runCLI(args: string[]): { stdout: string; stderr: string; exitCode: number } {
+  // Strip NODE_ENV=test from the child env: oclif treats that as development
+  // mode and scans src/ instead of dist/, which breaks command resolution for
+  // commands with positional args (oclif misinterprets the arg as a subcommand).
+  const childEnv = { ...process.env }
+  delete childEnv.NODE_ENV
   try {
     const stdout = execSync(`node ${CLI_PATH} ${args.join(' ')}`, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      env: childEnv,
     })
     return { stdout, stderr: '', exitCode: 0 }
   } catch (error: any) {
@@ -173,6 +179,8 @@ describe('Generated Commands Integration Tests', () => {
         'x402token',
         'build-payment-required',
         '12345',
+        '--resource-url',
+        'https://example.com/api/test',
         '--environment',
         'live',
         '-f',
@@ -181,6 +189,7 @@ describe('Generated Commands Integration Tests', () => {
 
       expect(exitCode).toBe(0)
       const payload = JSON.parse(stdout)
+      expect(payload.resource.url).toBe('https://example.com/api/test')
       expect(payload.accepts[0].network).toBe('eip155:8453')
     })
 
@@ -189,6 +198,8 @@ describe('Generated Commands Integration Tests', () => {
         'x402token',
         'build-payment-required',
         '12345',
+        '--resource-url',
+        'https://example.com/api/test',
         '--scheme',
         'nvm:card-delegation',
         '-f',
@@ -197,6 +208,7 @@ describe('Generated Commands Integration Tests', () => {
 
       expect(exitCode).toBe(0)
       const payload = JSON.parse(stdout)
+      expect(payload.resource.url).toBe('https://example.com/api/test')
       expect(payload.accepts[0].scheme).toBe('nvm:card-delegation')
       expect(payload.accepts[0].network).toBe('stripe')
     })
@@ -206,6 +218,28 @@ describe('Generated Commands Integration Tests', () => {
 
       expect(exitCode).not.toBe(0)
       expect(stderr.length).toBeGreaterThan(0)
+    })
+
+    test('x402token build-payment-required requires --resource-url', () => {
+      const { stderr, exitCode } = runCLI(['x402token', 'build-payment-required', '12345'])
+
+      expect(exitCode).not.toBe(0)
+      expect(stderr).toContain('resource-url')
+    })
+
+    test('x402token build-payment-required rejects unknown --environment', () => {
+      const { stderr, exitCode } = runCLI([
+        'x402token',
+        'build-payment-required',
+        '12345',
+        '--resource-url',
+        'https://example.com/api/test',
+        '--environment',
+        'mainnet',
+      ])
+
+      expect(exitCode).not.toBe(0)
+      expect(stderr).toContain('environment')
     })
   })
 

--- a/cli/test/integration/generated-commands.test.ts
+++ b/cli/test/integration/generated-commands.test.ts
@@ -97,6 +97,101 @@ describe('Generated Commands Integration Tests', () => {
       expect(stdout).toContain('USAGE')
       expect(stdout).toContain('x402')
     })
+
+    test('x402token build-payment-required shows help', () => {
+      const { stdout, exitCode } = runCLI(['x402token', 'build-payment-required', '--help'])
+
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('USAGE')
+      expect(stdout).toContain('build-payment-required')
+      expect(stdout).toContain('plan identifier')
+      expect(stdout).toContain('--resource-url')
+      expect(stdout).toContain('--scheme')
+    })
+
+    test('x402token build-payment-required emits valid X402PaymentRequired JSON', () => {
+      const { stdout, exitCode } = runCLI([
+        'x402token',
+        'build-payment-required',
+        '12345',
+        '--resource-url',
+        'https://example.com/api/test',
+        '--agent-id',
+        '999',
+        '--http-verb',
+        'POST',
+        '--description',
+        'TestResource',
+        '--mime-type',
+        'application/json',
+        '--environment',
+        'sandbox',
+        '-f',
+        'json',
+      ])
+
+      expect(exitCode).toBe(0)
+      const payload = JSON.parse(stdout)
+      expect(payload.x402Version).toBe(2)
+      expect(payload.resource).toEqual({
+        url: 'https://example.com/api/test',
+        description: 'TestResource',
+        mimeType: 'application/json',
+      })
+      expect(payload.extensions).toEqual({})
+      expect(Array.isArray(payload.accepts)).toBe(true)
+      expect(payload.accepts).toHaveLength(1)
+      expect(payload.accepts[0]).toEqual({
+        scheme: 'nvm:erc4337',
+        network: 'eip155:84532',
+        planId: '12345',
+        extra: {
+          version: '1',
+          agentId: '999',
+          httpVerb: 'POST',
+        },
+      })
+    })
+
+    test('x402token build-payment-required resolves live network from --environment', () => {
+      const { stdout, exitCode } = runCLI([
+        'x402token',
+        'build-payment-required',
+        '12345',
+        '--environment',
+        'live',
+        '-f',
+        'json',
+      ])
+
+      expect(exitCode).toBe(0)
+      const payload = JSON.parse(stdout)
+      expect(payload.accepts[0].network).toBe('eip155:8453')
+    })
+
+    test('x402token build-payment-required uses card-delegation defaults', () => {
+      const { stdout, exitCode } = runCLI([
+        'x402token',
+        'build-payment-required',
+        '12345',
+        '--scheme',
+        'nvm:card-delegation',
+        '-f',
+        'json',
+      ])
+
+      expect(exitCode).toBe(0)
+      const payload = JSON.parse(stdout)
+      expect(payload.accepts[0].scheme).toBe('nvm:card-delegation')
+      expect(payload.accepts[0].network).toBe('stripe')
+    })
+
+    test('x402token build-payment-required requires plan argument', () => {
+      const { stderr, exitCode } = runCLI(['x402token', 'build-payment-required'])
+
+      expect(exitCode).not.toBe(0)
+      expect(stderr.length).toBeGreaterThan(0)
+    })
   })
 
   describe('Facilitator Commands', () => {


### PR DESCRIPTION
## Summary

Closes #337.

`nvm facilitator verify-permissions` and `nvm facilitator settle-permissions` require a fully-formed `X402PaymentRequired` object inside `--params`, but the CLI offered no helper to build it. Users had to read `payments/src/x402/facilitator-api.ts` to discover the exact shape (notably `resource: { url: ... }` rather than a flat `resource: string`) and hand-build the JSON, iterating against confusing server-side validation errors:

```
Error: paymentRequired should not be null or undefined.
Error: resource should not be null or undefined.
```

This PR adds a thin CLI wrapper around the SDK's already-exported `buildPaymentRequired()` helper.

## New command

```bash
$ nvm x402token build-payment-required --help
ARGUMENTS
  PLAN  plan identifier

FLAGS
  --resource-url=<value>  Protected resource URL (maps to the `endpoint` option in the SDK)
  --agent-id=<value>
  --http-verb=<value>     HTTP verb of the protected resource (e.g. POST)
  --scheme=<option>       [default: nvm:erc4337] x402 payment scheme
                          <options: nvm:erc4337|nvm:card-delegation>
  --network=<value>       Override the network. Defaults to the scheme/environment
                          default (e.g. eip155:84532 for nvm:erc4337 on sandbox).
  --description=<value>   Human-readable description of the protected resource
  --mime-type=<value>     MIME type of the protected resource
  --environment=<value>   Environment used to resolve the default network. Falls
                          back to the active profile when omitted.
```

The output JSON can be piped straight into `verify-permissions` / `settle-permissions`, closing the gap that #337 reports.

The command is registered in `MANUALLY_MAINTAINED_COMMANDS` (consistent with `get-x402-access-token`) so the generator won't overwrite it.

## Verification

```bash
cd cli && pnpm test:unit          # 10/10 passing
cd cli && pnpm test:integration   # 31/31 passing (5 new build-payment-required tests)
```

End-to-end against `production_sandbox` (`https://api.sandbox.nevermined.app`):

```bash
PLAN_ID=...
TOK=$(nvm x402token get-x402-access-token "$PLAN_ID" -f json | jq -r .accessToken)
PR=$(nvm x402token build-payment-required "$PLAN_ID" --resource-url 'https://example.com/api/test' -f json)
PARAMS=$(jq -nc --argjson pr "$PR" --arg tok "$TOK" '{paymentRequired:$pr, x402AccessToken:$tok, maxAmount:"1"}')
nvm facilitator verify-permissions --params "$PARAMS"   # → isValid: true
nvm facilitator settle-permissions --params "$PARAMS"   # → success: true, creditsRedeemed: 1
```

## Test plan

- [x] `pnpm build` clean (root + cli, with local SDK symlinked)
- [x] `pnpm test:unit` (10/10)
- [x] `pnpm test:integration` (31/31, +5 new)
- [x] Help output renders correctly with all flags + examples
- [x] Default network resolves correctly per scheme + environment (`eip155:84532` for sandbox erc4337, `eip155:8453` for live erc4337, `stripe` for card-delegation)
- [x] All builder options propagate through to the resulting JSON (resource fields, extra fields, accepts entry)
- [x] Generated payload accepted verbatim by `verify-permissions` and `settle-permissions` against `production_sandbox`
- [ ] CI green (build, lint, cli-sync-and-test)