### PR TITLE
fix(orgs): align OrganizationType enum with the backend (add Other, drop Free)

### DIFF
--- a/src/api/organizations-api/types.ts
+++ b/src/api/organizations-api/types.ts
@@ -5,15 +5,21 @@ export enum OrganizationMemberRole {
 }
 
 /**
- * Tier of an organization. Mirrors the backend `OrganizationType` enum
- * (`@nevermined-io/commons`). Free orgs were retired (Epic #1339) but the
- * value is kept here for backwards compatibility with historical rows.
+ * Tier of an organization. Mirrors the backend `OrganizationType` enum at
+ * `libs/commons/src/lib/types/types.ts` in nvm-monorepo.
+ *
+ * - `Premium` / `Enterprise` — the paid tiers from Epic #1339.
+ * - `Lapsed` — an org whose paid subscription has expired; replaces the
+ *   retired `Free` bucket (the backend never emits `Free` for new rows).
+ * - `Other` — legacy pre-tiered-pricing bucket still returned for orgs that
+ *   pre-date the tier system; inherits Premium-equivalent caps and features
+ *   server-side.
  */
 export enum OrganizationType {
-  Free = 'Free',
   Premium = 'Premium',
   Enterprise = 'Enterprise',
   Lapsed = 'Lapsed',
+  Other = 'Other',
 }
 
 export type CreateUserResponse = {


### PR DESCRIPTION
## Summary

Follow-up to the review on #342 — the last outstanding finding from @r-marques (https://github.com/nevermined-io/payments/pull/342#issuecomment-4509867826).

The SDK's `OrganizationType` enum shipped as `Free | Premium | Enterprise | Lapsed`, but the backend at `libs/commons/src/lib/types/types.ts` in nvm-monorepo is `Premium | Enterprise | Lapsed | Other`. Two mismatches:

- **`Free` is dead** — Epic #1339 retired it and replaced it with `Lapsed` for orgs whose paid subscription has expired. The backend never emits `Free` for new rows.
- **`Other` is missing** — legacy pre-tiered-pricing bucket the backend still returns for orgs that pre-date the tier system (inherits Premium-equivalent caps and features server-side, per the comment at `types.ts:270` upstream). Live rows with `orgType: "Other"` previously failed to type-narrow against the SDK enum.

Drop `Free`, add `Other`. No other call sites in this repo referenced `Free` (verified across `src/`, `cli/`, `openclaw/`, and `tests/`); the only public surface that changes is the published `OrganizationType` enum, and `Lapsed`/`Premium`/`Enterprise` are unchanged.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm test:unit` — 149 pass, 1 skipped
- [x] `pnpm lint` — 0 errors (1 pre-existing TSDoc warning)
- [ ] CI: Payments Tests + CLI Sync + OpenClaw Sync
- [ ] Reviewer confirms approval can land