### PR TITLE
feat(cli): nvm cards setup/enroll/delegate (nvm-monorepo#1671)

### DIFF
--- a/cli/src/base-command.ts
+++ b/cli/src/base-command.ts
@@ -26,6 +26,16 @@ export abstract class BaseCommand extends Command {
   protected configManager!: ConfigManager
   protected formatter!: OutputFormatter
   protected payments?: Payments
+  /**
+   * Environment + API key resolved by `initPayments()`. Stored here so
+   * subclasses that need to talk to the backend directly (e.g. commands
+   * that POST to endpoints the SDK does not yet wrap) don't have to
+   * re-implement the env-var-first → config-file fallback and
+   * accidentally diverge from the precedence the Payments instance was
+   * actually constructed with.
+   */
+  protected resolvedEnvironment?: EnvironmentName
+  protected resolvedNvmApiKey?: string
 
   async init(): Promise<void> {
     await super.init()
@@ -75,6 +85,10 @@ export abstract class BaseCommand extends Command {
       nvmApiKey,
       environment: environment as EnvironmentName,
     })
+    // Expose for subclasses that need to talk to backend endpoints the
+    // SDK does not yet wrap — see `nvm cards setup/enroll/delegate`.
+    this.resolvedEnvironment = environment as EnvironmentName
+    this.resolvedNvmApiKey = nvmApiKey
 
     return this.payments
   }

--- a/cli/src/commands/cards/delegate.ts
+++ b/cli/src/commands/cards/delegate.ts
@@ -1,0 +1,96 @@
+import { Flags } from '@oclif/core'
+import { Environments, EnvironmentName } from '@nevermined-io/payments'
+import { BaseCommand } from '../../base-command.js'
+import { resolveOrgIdInteractive } from '../../utils/orgs.js'
+import {
+  mintSelfWidgetSession,
+  runWidgetRedirectFlow,
+} from '../../utils/widget-redirect-flow.js'
+
+/**
+ * Single-purpose delegation creation. Opens the chromeless
+ * `/embed/cards/delegate?paymentMethodId=<id>` page where the user
+ * fills in spending limit / duration / max-transactions and submits;
+ * the resulting `delegationId` is redirected back to a localhost
+ * callback.
+ *
+ * The combined `nvm cards setup` flow is preferred for first-time
+ * card setup; use this when the card already exists and only the
+ * delegation needs to be (re-)created.
+ */
+export default class CardsDelegate extends BaseCommand {
+  static override description =
+    'Open the browser to create a spending delegation for an already-enrolled card.'
+
+  static override examples = [
+    '<%= config.bin %> cards delegate --card pm_1234',
+    '<%= config.bin %> cards delegate --card pm_1234 --org org-abc-123',
+  ]
+
+  static override flags = {
+    ...BaseCommand.baseFlags,
+    card: Flags.string({
+      description: 'paymentMethodId of the already-enrolled card to delegate from.',
+      required: true,
+    }),
+    org: Flags.string({
+      description:
+        'Organization id to scope the flow to. Required when the authenticated user belongs to multiple organizations and the terminal is non-interactive.',
+      required: false,
+    }),
+    'no-browser': Flags.boolean({
+      description: 'Print the delegation URL instead of opening the browser.',
+      default: false,
+    }),
+  }
+
+  public async run(): Promise<void> {
+    try {
+      const { flags } = await this.parse(CardsDelegate)
+      const payments = await this.initPayments()
+
+      const { orgId } = await resolveOrgIdInteractive({
+        payments,
+        flagOrgId: flags.org,
+        log: (msg: string) => this.log(msg),
+      })
+
+      const profileName = flags.profile || (await this.configManager.getActiveProfile()) || 'default'
+      const profileCfg = await this.configManager.get(undefined, profileName)
+      const environment = (profileCfg?.environment as EnvironmentName) || 'sandbox'
+      const env = Environments[environment]
+      if (!env) {
+        this.error(`Unknown environment: ${String(environment)}`, { exit: 1 })
+      }
+      const nvmApiKey = profileCfg?.nvmApiKey || process.env.NVM_API_KEY
+      if (!nvmApiKey) {
+        this.error('No NVM API key in the active profile. Run `nvm login` first.', { exit: 1 })
+      }
+      const session = await mintSelfWidgetSession({
+        backendUrl: env.backend,
+        nvmApiKey,
+        orgId,
+      })
+
+      const result = await runWidgetRedirectFlow({
+        backendUrl: env.backend,
+        frontendUrl: env.frontend,
+        sessionToken: session.sessionToken,
+        embedPath: '/embed/cards/delegate',
+        extraSearchParams: { paymentMethodId: flags.card as string },
+        noBrowser: flags['no-browser'],
+        log: (msg: string) => this.log(msg),
+        successPageTitle: 'Delegation created',
+      })
+
+      const delegationId = result.query.delegationId
+      if (!delegationId) {
+        this.error('Delegation callback was missing delegationId.', { exit: 1 })
+      }
+      this.formatter.success(`Delegation created. delegationId: ${delegationId}`)
+      this.formatter.output({ delegationId, paymentMethodId: flags.card, orgId })
+    } catch (error) {
+      this.handleError(error)
+    }
+  }
+}

--- a/cli/src/commands/cards/delegate.ts
+++ b/cli/src/commands/cards/delegate.ts
@@ -1,5 +1,5 @@
 import { Flags } from '@oclif/core'
-import { Environments, EnvironmentName } from '@nevermined-io/payments'
+import { Environments } from '@nevermined-io/payments'
 import { BaseCommand } from '../../base-command.js'
 import { resolveOrgIdInteractive } from '../../utils/orgs.js'
 import {
@@ -25,6 +25,7 @@ export default class CardsDelegate extends BaseCommand {
   static override examples = [
     '<%= config.bin %> cards delegate --card pm_1234',
     '<%= config.bin %> cards delegate --card pm_1234 --org org-abc-123',
+    '<%= config.bin %> cards delegate --card pm_1234 --no-browser',
   ]
 
   static override flags = {
@@ -55,32 +56,35 @@ export default class CardsDelegate extends BaseCommand {
         log: (msg: string) => this.log(msg),
       })
 
-      const profileName = flags.profile || (await this.configManager.getActiveProfile()) || 'default'
-      const profileCfg = await this.configManager.get(undefined, profileName)
-      const environment = (profileCfg?.environment as EnvironmentName) || 'sandbox'
+      const environment = this.resolvedEnvironment!
+      const nvmApiKey = this.resolvedNvmApiKey!
       const env = Environments[environment]
       if (!env) {
         this.error(`Unknown environment: ${String(environment)}`, { exit: 1 })
       }
-      const nvmApiKey = profileCfg?.nvmApiKey || process.env.NVM_API_KEY
-      if (!nvmApiKey) {
-        this.error('No NVM API key in the active profile. Run `nvm login` first.', { exit: 1 })
-      }
-      const session = await mintSelfWidgetSession({
-        backendUrl: env.backend,
-        nvmApiKey,
-        orgId,
-      })
 
       const result = await runWidgetRedirectFlow({
-        backendUrl: env.backend,
         frontendUrl: env.frontend,
-        sessionToken: session.sessionToken,
         embedPath: '/embed/cards/delegate',
+        mintSession: async ({ returnUrl }) => {
+          const session = await mintSelfWidgetSession({
+            backendUrl: env.backend,
+            nvmApiKey,
+            orgId,
+            returnUrl,
+          })
+          if (session.isReturnUrlAllowed === false) {
+            throw new Error(
+              `Backend rejected returnUrl ${returnUrl} — check the widget key's allowedOrigins or fall back to a localhost callback.`,
+            )
+          }
+          return { sessionToken: session.sessionToken }
+        },
         extraSearchParams: { paymentMethodId: flags.card as string },
         noBrowser: flags['no-browser'],
         log: (msg: string) => this.log(msg),
         successPageTitle: 'Delegation created',
+        timeoutMessage: 'Delegation creation timed out after 5 minutes. Please try again.',
       })
 
       const delegationId = result.query.delegationId

--- a/cli/src/commands/cards/enroll.ts
+++ b/cli/src/commands/cards/enroll.ts
@@ -1,5 +1,5 @@
 import { Flags } from '@oclif/core'
-import { Environments, EnvironmentName } from '@nevermined-io/payments'
+import { Environments } from '@nevermined-io/payments'
 import { BaseCommand } from '../../base-command.js'
 import { resolveOrgIdInteractive } from '../../utils/orgs.js'
 import {
@@ -25,6 +25,7 @@ export default class CardsEnroll extends BaseCommand {
     '<%= config.bin %> cards enroll',
     '<%= config.bin %> cards enroll --org org-abc-123',
     '<%= config.bin %> cards enroll --provider braintree',
+    '<%= config.bin %> cards enroll --no-browser',
   ]
 
   static override flags = {
@@ -56,32 +57,35 @@ export default class CardsEnroll extends BaseCommand {
         log: (msg: string) => this.log(msg),
       })
 
-      const profileName = flags.profile || (await this.configManager.getActiveProfile()) || 'default'
-      const profileCfg = await this.configManager.get(undefined, profileName)
-      const environment = (profileCfg?.environment as EnvironmentName) || 'sandbox'
+      const environment = this.resolvedEnvironment!
+      const nvmApiKey = this.resolvedNvmApiKey!
       const env = Environments[environment]
       if (!env) {
         this.error(`Unknown environment: ${String(environment)}`, { exit: 1 })
       }
-      const nvmApiKey = profileCfg?.nvmApiKey || process.env.NVM_API_KEY
-      if (!nvmApiKey) {
-        this.error('No NVM API key in the active profile. Run `nvm login` first.', { exit: 1 })
-      }
-      const session = await mintSelfWidgetSession({
-        backendUrl: env.backend,
-        nvmApiKey,
-        orgId,
-      })
 
       const result = await runWidgetRedirectFlow({
-        backendUrl: env.backend,
         frontendUrl: env.frontend,
-        sessionToken: session.sessionToken,
         embedPath: '/embed/cards/enroll',
+        mintSession: async ({ returnUrl }) => {
+          const session = await mintSelfWidgetSession({
+            backendUrl: env.backend,
+            nvmApiKey,
+            orgId,
+            returnUrl,
+          })
+          if (session.isReturnUrlAllowed === false) {
+            throw new Error(
+              `Backend rejected returnUrl ${returnUrl} — check the widget key's allowedOrigins or fall back to a localhost callback.`,
+            )
+          }
+          return { sessionToken: session.sessionToken }
+        },
         extraSearchParams: { provider: flags.provider as string },
         noBrowser: flags['no-browser'],
         log: (msg: string) => this.log(msg),
         successPageTitle: 'Card enrolled',
+        timeoutMessage: 'Card enrolment timed out after 5 minutes. Please try again.',
       })
 
       const paymentMethodId = result.query.paymentMethodId

--- a/cli/src/commands/cards/enroll.ts
+++ b/cli/src/commands/cards/enroll.ts
@@ -1,0 +1,97 @@
+import { Flags } from '@oclif/core'
+import { Environments, EnvironmentName } from '@nevermined-io/payments'
+import { BaseCommand } from '../../base-command.js'
+import { resolveOrgIdInteractive } from '../../utils/orgs.js'
+import {
+  mintSelfWidgetSession,
+  runWidgetRedirectFlow,
+} from '../../utils/widget-redirect-flow.js'
+
+/**
+ * Single-purpose card enrolment. Opens the chromeless
+ * `/embed/cards/enroll` page in the browser, completes the
+ * tokenization step against the chosen provider, and redirects the
+ * resulting `paymentMethodId` back to a localhost callback.
+ *
+ * For the common case of "add a card AND a delegation in one flow",
+ * use `nvm cards setup` instead — the combined command emits both IDs
+ * in a single callback.
+ */
+export default class CardsEnroll extends BaseCommand {
+  static override description =
+    'Open the browser to enroll a credit/debit card and redirect the resulting paymentMethodId back to this terminal.'
+
+  static override examples = [
+    '<%= config.bin %> cards enroll',
+    '<%= config.bin %> cards enroll --org org-abc-123',
+    '<%= config.bin %> cards enroll --provider braintree',
+  ]
+
+  static override flags = {
+    ...BaseCommand.baseFlags,
+    org: Flags.string({
+      description:
+        'Organization id to scope the flow to. Required when the authenticated user belongs to multiple organizations and the terminal is non-interactive.',
+      required: false,
+    }),
+    'no-browser': Flags.boolean({
+      description: 'Print the enrolment URL instead of opening the browser.',
+      default: false,
+    }),
+    provider: Flags.string({
+      description: 'Tokenization provider used for the card enrolment step.',
+      options: ['stripe', 'braintree', 'visa'],
+      default: 'stripe',
+    }),
+  }
+
+  public async run(): Promise<void> {
+    try {
+      const { flags } = await this.parse(CardsEnroll)
+      const payments = await this.initPayments()
+
+      const { orgId } = await resolveOrgIdInteractive({
+        payments,
+        flagOrgId: flags.org,
+        log: (msg: string) => this.log(msg),
+      })
+
+      const profileName = flags.profile || (await this.configManager.getActiveProfile()) || 'default'
+      const profileCfg = await this.configManager.get(undefined, profileName)
+      const environment = (profileCfg?.environment as EnvironmentName) || 'sandbox'
+      const env = Environments[environment]
+      if (!env) {
+        this.error(`Unknown environment: ${String(environment)}`, { exit: 1 })
+      }
+      const nvmApiKey = profileCfg?.nvmApiKey || process.env.NVM_API_KEY
+      if (!nvmApiKey) {
+        this.error('No NVM API key in the active profile. Run `nvm login` first.', { exit: 1 })
+      }
+      const session = await mintSelfWidgetSession({
+        backendUrl: env.backend,
+        nvmApiKey,
+        orgId,
+      })
+
+      const result = await runWidgetRedirectFlow({
+        backendUrl: env.backend,
+        frontendUrl: env.frontend,
+        sessionToken: session.sessionToken,
+        embedPath: '/embed/cards/enroll',
+        extraSearchParams: { provider: flags.provider as string },
+        noBrowser: flags['no-browser'],
+        log: (msg: string) => this.log(msg),
+        successPageTitle: 'Card enrolled',
+      })
+
+      const paymentMethodId = result.query.paymentMethodId
+      if (!paymentMethodId) {
+        this.error('Enrolment callback was missing paymentMethodId.', { exit: 1 })
+      }
+      this.formatter.success(`Card enrolled. paymentMethodId: ${paymentMethodId}`)
+      this.formatter.output({ paymentMethodId, orgId })
+    } catch (error) {
+      this.handleError(error)
+    }
+  }
+}

--- a/cli/src/commands/cards/setup.ts
+++ b/cli/src/commands/cards/setup.ts
@@ -1,0 +1,135 @@
+import { Flags } from '@oclif/core'
+import { Environments, EnvironmentName } from '@nevermined-io/payments'
+import { BaseCommand } from '../../base-command.js'
+import { resolveOrgIdInteractive } from '../../utils/orgs.js'
+import {
+  mintSelfWidgetSession,
+  runWidgetRedirectFlow,
+} from '../../utils/widget-redirect-flow.js'
+
+/**
+ * Combined "set up a card for agent spend" flow. Opens the user's
+ * browser at the chromeless `/embed/cards/setup` page, where they
+ * enrol a card and create a spending delegation in one session, and
+ * receives `paymentMethodId` + `delegationId` back at a localhost
+ * callback the CLI starts for the duration of the flow.
+ *
+ * Mirrors the `nvm login` UX: ephemeral HTTP server on a random port,
+ * URL printed (or browser opened), 5-minute timeout, single-use
+ * `state` echo for CSRF binding. The user must already be authenticated
+ * (`nvm login`) and must be a member of at least one organisation —
+ * the widgets feature is organisation-scoped (see issue #1671).
+ */
+export default class CardsSetup extends BaseCommand {
+  static override description =
+    'Open the browser to enroll a card and create a spending delegation, then redirect both IDs back to this terminal.'
+
+  static override examples = [
+    '<%= config.bin %> cards setup',
+    '<%= config.bin %> cards setup --org org-abc-123',
+    '<%= config.bin %> cards setup --no-browser',
+  ]
+
+  static override flags = {
+    ...BaseCommand.baseFlags,
+    org: Flags.string({
+      description:
+        'Organization id to scope the flow to. Required when the authenticated user belongs to multiple organizations and the terminal is non-interactive.',
+      required: false,
+    }),
+    'no-browser': Flags.boolean({
+      description: 'Print the setup URL instead of opening the browser.',
+      default: false,
+    }),
+    provider: Flags.string({
+      description: 'Tokenization provider used for the card enrolment step.',
+      options: ['stripe', 'braintree', 'visa'],
+      default: 'stripe',
+    }),
+  }
+
+  public async run(): Promise<void> {
+    try {
+      const { flags } = await this.parse(CardsSetup)
+      const payments = await this.initPayments()
+
+      // Resolve which org the session should be scoped to. Throws (and
+      // we fall through to handleError) on the no-membership / multi-org
+      // non-interactive paths.
+      const { orgId, orgName } = await resolveOrgIdInteractive({
+        payments,
+        flagOrgId: flags.org,
+        log: (msg: string) => this.log(msg),
+      })
+      if (orgName) {
+        this.formatter.info(`Using organization: ${orgName} (${orgId})`)
+      } else {
+        this.formatter.info(`Using organization: ${orgId}`)
+      }
+
+      // Read the environment + key from local config (the Payments
+      // instance keeps them as protected fields). `initPayments()` in the
+      // base command has already validated them — these reads are safe.
+      const profileName = flags.profile || (await this.configManager.getActiveProfile()) || 'default'
+      const profileCfg = await this.configManager.get(undefined, profileName)
+      const environment = (profileCfg?.environment as EnvironmentName) || 'sandbox'
+      const env = Environments[environment]
+      if (!env) {
+        this.error(`Unknown environment: ${String(environment)}`, { exit: 1 })
+      }
+      const nvmApiKey = profileCfg?.nvmApiKey || process.env.NVM_API_KEY
+      if (!nvmApiKey) {
+        this.error('No NVM API key in the active profile. Run `nvm login` first.', { exit: 1 })
+      }
+
+      // Self-mint the widget session against the logged-in API key.
+      // Backend gates this on `OrganizationsService.isOrganizationMember`
+      // — a 403 here means either the flag-supplied orgId doesn't match
+      // a membership or the user has none at all (already caught above
+      // for the interactive path, but the membership check is the
+      // ground truth).
+      const session = await mintSelfWidgetSession({
+        backendUrl: env.backend,
+        nvmApiKey,
+        orgId,
+      })
+
+      // Note: we pass `returnUrl` to `runWidgetRedirectFlow` later (the
+      // helper builds it from the actual port it binds to). The session
+      // we just minted didn't include a returnUrl in the body, so the
+      // server returns `isReturnUrlAllowed: null`; the embed page's
+      // own `/widgets/session/validate` call (with the
+      // `X-Nvm-Widget-Return-Url` header) is the real allow-list check.
+
+      const result = await runWidgetRedirectFlow({
+        backendUrl: env.backend,
+        frontendUrl: env.frontend,
+        sessionToken: session.sessionToken,
+        embedPath: '/embed/cards/setup',
+        extraSearchParams: { provider: flags.provider as string },
+        noBrowser: flags['no-browser'],
+        log: (msg: string) => this.log(msg),
+        successPageTitle: 'Card setup complete',
+      })
+
+      const paymentMethodId = result.query.paymentMethodId
+      const delegationId = result.query.delegationId
+      if (!paymentMethodId || !delegationId) {
+        this.error(
+          `Setup callback was missing required parameters (paymentMethodId=${paymentMethodId ?? 'missing'}, delegationId=${delegationId ?? 'missing'}).`,
+          { exit: 1 },
+        )
+      }
+
+      this.formatter.success(
+        `Card setup complete!\n` +
+          `  paymentMethodId: ${paymentMethodId}\n` +
+          `  delegationId:    ${delegationId}\n` +
+          `  organization:    ${orgId}`,
+      )
+      this.formatter.output({ paymentMethodId, delegationId, orgId })
+    } catch (error) {
+      this.handleError(error)
+    }
+  }
+}

--- a/cli/src/commands/cards/setup.ts
+++ b/cli/src/commands/cards/setup.ts
@@ -1,5 +1,5 @@
 import { Flags } from '@oclif/core'
-import { Environments, EnvironmentName } from '@nevermined-io/payments'
+import { Environments } from '@nevermined-io/payments'
 import { BaseCommand } from '../../base-command.js'
 import { resolveOrgIdInteractive } from '../../utils/orgs.js'
 import {
@@ -67,49 +67,45 @@ export default class CardsSetup extends BaseCommand {
         this.formatter.info(`Using organization: ${orgId}`)
       }
 
-      // Read the environment + key from local config (the Payments
-      // instance keeps them as protected fields). `initPayments()` in the
-      // base command has already validated them — these reads are safe.
-      const profileName = flags.profile || (await this.configManager.getActiveProfile()) || 'default'
-      const profileCfg = await this.configManager.get(undefined, profileName)
-      const environment = (profileCfg?.environment as EnvironmentName) || 'sandbox'
+      // initPayments() has already resolved env+key with the canonical
+      // env-var-first precedence (NVM_API_KEY / NVM_ENVIRONMENT → config
+      // file → defaults). Re-using its decision here keeps the SDK
+      // instance and the direct `mintSelfWidgetSession` call targeting
+      // the same backend + user.
+      const environment = this.resolvedEnvironment!
+      const nvmApiKey = this.resolvedNvmApiKey!
       const env = Environments[environment]
       if (!env) {
         this.error(`Unknown environment: ${String(environment)}`, { exit: 1 })
       }
-      const nvmApiKey = profileCfg?.nvmApiKey || process.env.NVM_API_KEY
-      if (!nvmApiKey) {
-        this.error('No NVM API key in the active profile. Run `nvm login` first.', { exit: 1 })
-      }
-
-      // Self-mint the widget session against the logged-in API key.
-      // Backend gates this on `OrganizationsService.isOrganizationMember`
-      // — a 403 here means either the flag-supplied orgId doesn't match
-      // a membership or the user has none at all (already caught above
-      // for the interactive path, but the membership check is the
-      // ground truth).
-      const session = await mintSelfWidgetSession({
-        backendUrl: env.backend,
-        nvmApiKey,
-        orgId,
-      })
-
-      // Note: we pass `returnUrl` to `runWidgetRedirectFlow` later (the
-      // helper builds it from the actual port it binds to). The session
-      // we just minted didn't include a returnUrl in the body, so the
-      // server returns `isReturnUrlAllowed: null`; the embed page's
-      // own `/widgets/session/validate` call (with the
-      // `X-Nvm-Widget-Return-Url` header) is the real allow-list check.
 
       const result = await runWidgetRedirectFlow({
-        backendUrl: env.backend,
         frontendUrl: env.frontend,
-        sessionToken: session.sessionToken,
         embedPath: '/embed/cards/setup',
+        // Mint AFTER the local server binds — `runWidgetRedirectFlow`
+        // gives us the actual returnUrl so the backend can validate it
+        // at session-creation time (per the documented `isReturnUrlAllowed`
+        // contract). A 403 here means either the flag-supplied orgId
+        // doesn't match a membership or the user has none at all.
+        mintSession: async ({ returnUrl }) => {
+          const session = await mintSelfWidgetSession({
+            backendUrl: env.backend,
+            nvmApiKey,
+            orgId,
+            returnUrl,
+          })
+          if (session.isReturnUrlAllowed === false) {
+            throw new Error(
+              `Backend rejected returnUrl ${returnUrl} — check the widget key's allowedOrigins or fall back to a localhost callback.`,
+            )
+          }
+          return { sessionToken: session.sessionToken }
+        },
         extraSearchParams: { provider: flags.provider as string },
         noBrowser: flags['no-browser'],
         log: (msg: string) => this.log(msg),
         successPageTitle: 'Card setup complete',
+        timeoutMessage: 'Card setup timed out after 5 minutes. Please try again.',
       })
 
       const paymentMethodId = result.query.paymentMethodId

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -1,6 +1,6 @@
 import { Flags } from '@oclif/core'
 import { createServer, IncomingMessage, ServerResponse } from 'http'
-import { execFile } from 'child_process'
+import { openBrowser } from '../utils/browser.js'
 import { BaseCommand } from '../base-command.js'
 import { Environments, EnvironmentName } from '@nevermined-io/payments'
 
@@ -141,24 +141,3 @@ export default class Login extends BaseCommand {
   }
 }
 
-function openBrowser(url: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const platform = process.platform
-    let cmd: string
-    let args: string[]
-    if (platform === 'darwin') {
-      cmd = 'open'
-      args = [url]
-    } else if (platform === 'win32') {
-      cmd = 'cmd'
-      args = ['/c', 'start', '""', url]
-    } else {
-      cmd = 'xdg-open'
-      args = [url]
-    }
-    execFile(cmd, args, (err) => {
-      if (err) reject(err)
-      else resolve()
-    })
-  })
-}

--- a/cli/src/utils/browser.ts
+++ b/cli/src/utils/browser.ts
@@ -1,0 +1,37 @@
+import { execFile } from 'child_process'
+
+/**
+ * Open the user's default browser at `url`. Cross-platform wrapper used
+ * by `nvm login` and `nvm cards setup/enroll/delegate`.
+ *
+ * On Windows we deliberately avoid `cmd /c start <url>`: cmd parses `&`
+ * inside the URL as a command separator, which truncates any URL that
+ * carries multiple query parameters (every redirect flow we use). Using
+ * `rundll32 url.dll,FileProtocolHandler` hands the URL to the OS's
+ * registered protocol handler verbatim — no shell parsing, no
+ * truncation, no command-injection vector if the URL ever carries
+ * caller-controlled state.
+ */
+export function openBrowser(url: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const platform = process.platform
+    let cmd: string
+    let args: string[]
+    if (platform === 'darwin') {
+      cmd = 'open'
+      args = [url]
+    } else if (platform === 'win32') {
+      // No cmd.exe in the chain — rundll32 hands the URL straight to
+      // the OS protocol handler, so `&` survives intact.
+      cmd = 'rundll32'
+      args = ['url.dll,FileProtocolHandler', url]
+    } else {
+      cmd = 'xdg-open'
+      args = [url]
+    }
+    execFile(cmd, args, (err) => {
+      if (err) reject(err)
+      else resolve()
+    })
+  })
+}

--- a/cli/src/utils/orgs.ts
+++ b/cli/src/utils/orgs.ts
@@ -1,0 +1,93 @@
+import { createInterface } from 'readline'
+import type { Payments } from '@nevermined-io/payments'
+
+export interface ResolvedOrgIdResult {
+  orgId: string
+  /** Human-readable org name (for logging). May be empty if the API returned none. */
+  orgName: string
+}
+
+interface ResolveOrgIdOptions {
+  payments: Payments
+  /** Value of `--org <id>` if the user passed one. */
+  flagOrgId?: string
+  /** Print routine — typically the oclif command's `this.log` bound. */
+  log: (msg: string) => void
+  /** Whether the calling terminal is interactive. Defaults to `process.stdin.isTTY`. */
+  isTTY?: boolean
+}
+
+/**
+ * Resolve which organisation a top-level CLI widget flow should be
+ * scoped to.
+ *
+ * Rules (mirror the acceptance criteria in issue #1671):
+ *  - `--org <id>` wins outright (we don't double-check membership — the
+ *    backend's `POST /widgets/session/self` will reject if the user
+ *    isn't a member).
+ *  - Otherwise call `payments.organizations.getMyMemberships()`:
+ *      - 0 → exit with the "card setup is only available to org members"
+ *        message.
+ *      - 1 → use it silently.
+ *      - 2+ → if the terminal is interactive, prompt the user to pick;
+ *        otherwise exit non-zero with "Pass --org <id>".
+ *
+ * Errors thrown by this helper are formatted to be safe to print
+ * directly with `BaseCommand.handleError`.
+ */
+export async function resolveOrgIdInteractive(
+  opts: ResolveOrgIdOptions,
+): Promise<ResolvedOrgIdResult> {
+  if (opts.flagOrgId) {
+    return { orgId: opts.flagOrgId, orgName: '' }
+  }
+
+  const memberships = await opts.payments.organizations.getMyMemberships()
+  if (!memberships || memberships.length === 0) {
+    throw new Error(
+      'Card setup is only available to members of an organization. Create or join one in the dashboard, then re-run this command.',
+    )
+  }
+
+  if (memberships.length === 1) {
+    const m = memberships[0]
+    return { orgId: m.orgId, orgName: m.orgName ?? '' }
+  }
+
+  const isTTY = opts.isTTY ?? process.stdin.isTTY
+  if (!isTTY) {
+    throw new Error(
+      `Multiple organizations found (${memberships.length}). Pass --org <id> to specify which organization to use.`,
+    )
+  }
+
+  opts.log('You are a member of multiple organizations:')
+  memberships.forEach((m, idx) => {
+    const role = m.role ? ` — ${m.role}` : ''
+    opts.log(`  ${idx + 1}. ${m.orgName ?? m.orgId}${role}  (${m.orgId})`)
+  })
+
+  const pick = await promptIndex(memberships.length, '> Select an organization [1]: ')
+  const chosen = memberships[pick - 1]
+  return { orgId: chosen.orgId, orgName: chosen.orgName ?? '' }
+}
+
+async function promptIndex(max: number, prompt: string): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout })
+    rl.question(prompt, (answer) => {
+      rl.close()
+      const trimmed = answer.trim()
+      // Default to 1 when the user just hits Enter — matches the "[1]" in
+      // the prompt and gives interactive users a single-keystroke happy
+      // path when the first org is the one they want.
+      if (trimmed === '') return resolve(1)
+      const n = Number(trimmed)
+      if (!Number.isInteger(n) || n < 1 || n > max) {
+        reject(new Error(`Please enter a number between 1 and ${max}.`))
+        return
+      }
+      resolve(n)
+    })
+  })
+}

--- a/cli/src/utils/widget-redirect-flow.ts
+++ b/cli/src/utils/widget-redirect-flow.ts
@@ -72,10 +72,14 @@ export interface WidgetRedirectFlowResult {
  *
  * Flow:
  *   1. Bind a one-shot HTTP server on `127.0.0.1:0` (the OS picks a free port).
- *   2. Compute `returnUrl = http://localhost:<port>/callback` and hand it
+ *   2. Compute `returnUrl = http://127.0.0.1:<port>/callback` and hand it
  *      to `opts.mintSession`. The caller mints a widget session bound to
  *      that exact returnUrl (which the backend can validate against the
- *      session-specific allow-list at creation time).
+ *      session-specific allow-list at creation time). We use the literal
+ *      `127.0.0.1` rather than `localhost` because the server binds to
+ *      `127.0.0.1` and Node 17+ resolves `localhost` to `::1` first on
+ *      modern hosts — the browser would stall on the IPv6 attempt before
+ *      falling back to IPv4.
  *   3. Open the browser at `{frontend}/embed/<path>?sessionToken=…&returnUrl=…&state=<rand>`.
  *   4. Resolve when the embed page redirects to `/callback?…&state=<echo>`.
  *      `state` is compared in constant time.
@@ -111,6 +115,12 @@ export async function runWidgetRedirectFlow(
 
       const receivedState = url.searchParams.get('state')
       if (!receivedState || !safeEqualHexState(receivedState, state)) {
+        // INTENTIONALLY do NOT close the server here. The state nonce
+        // is 128 bits of randomness, so brute-forcing one bad callback
+        // per request is infeasible. Closing on first 400 would let an
+        // attacker (or a misconfigured redirect) DoS the legitimate
+        // browser callback that's about to arrive. The 5-minute timer
+        // is the upper bound on how long we'll wait either way.
         res.writeHead(400, { 'Content-Type': 'text/html' }).end(
           errorHtml(
             'Callback rejected',
@@ -151,7 +161,11 @@ export async function runWidgetRedirectFlow(
         finalize(new Error('Failed to obtain local callback port'))
         return
       }
-      const returnUrl = `http://localhost:${addr.port}/callback`
+      // Symmetric with the server bind above (`127.0.0.1` only). Using
+      // the `localhost` alias here would cause an IPv6 stall on modern
+      // Linux/macOS where Node's `dns.lookup` prefers `::1`. The backend
+      // returnUrl allow-list accepts both forms.
+      const returnUrl = `http://127.0.0.1:${addr.port}/callback`
 
       // Mint the session now that returnUrl is known. The backend's
       // allow-list check at session creation can validate the URL the
@@ -273,6 +287,21 @@ export interface SelfMintSessionResponse {
   isReturnUrlAllowed?: boolean | null
 }
 
+/**
+ * Hosts a request to `mintSelfWidgetSession` may be sent over plaintext
+ * without warning. Loopback addresses are always safe; every other host
+ * must use `https:` because we're about to send the user's NVM API key
+ * in the `Authorization` header. The `custom` environment variable
+ * (`NVM_BACKEND_URL`) is the only realistic way a user could accidentally
+ * point this at a plaintext non-localhost URL.
+ */
+const LOOPBACK_HOSTNAMES: ReadonlySet<string> = new Set([
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  '[::1]',
+])
+
 export async function mintSelfWidgetSession(args: {
   backendUrl: string
   nvmApiKey: string
@@ -280,6 +309,20 @@ export async function mintSelfWidgetSession(args: {
   returnUrl?: string
 }): Promise<SelfMintSessionResponse> {
   const url = new URL('/api/v1/widgets/session/self', args.backendUrl)
+
+  // Refuse to send the API key over plaintext to a non-loopback host.
+  // All four built-in environments are `https://`, so this only bites
+  // when a user has set `NVM_BACKEND_URL` to a custom plaintext
+  // endpoint — exactly the case where they'd otherwise leak the key
+  // without realising.
+  if (
+    url.protocol === 'http:' &&
+    !LOOPBACK_HOSTNAMES.has(url.hostname.toLowerCase())
+  ) {
+    throw new Error(
+      `Refusing to send the NVM API key over plaintext to ${url.host}. Set NVM_BACKEND_URL to an https:// endpoint, or use a loopback host (localhost / 127.0.0.1 / [::1]).`,
+    )
+  }
 
   // 15s ceiling for the request — without it, an unreachable backend
   // (DNS failure, TLS handshake hang, network partition) leaves the CLI

--- a/cli/src/utils/widget-redirect-flow.ts
+++ b/cli/src/utils/widget-redirect-flow.ts
@@ -1,0 +1,331 @@
+import { createServer, IncomingMessage, ServerResponse } from 'http'
+import { randomBytes, timingSafeEqual } from 'crypto'
+import { execFile } from 'child_process'
+
+const SELF_MINT_FETCH_TIMEOUT_MS = 15_000
+
+/**
+ * Constant-time string equality for the CSRF state nonce. Both sides are
+ * 32 hex chars (16 random bytes), so a length mismatch alone is enough to
+ * reject. timingSafeEqual then compares the bytes without an early
+ * short-circuit — closes a (tiny, loopback-only) timing oracle.
+ */
+function safeEqualString(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  return timingSafeEqual(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8'))
+}
+
+/**
+ * Default timeout for a redirect-mode CLI flow. Mirrors the existing
+ * `nvm login` callback timeout — 5 minutes is enough for the user to
+ * tab into the browser, complete a card enrolment + delegation, and
+ * land back at the CLI.
+ */
+const REDIRECT_TIMEOUT_MS = 5 * 60 * 1000
+
+export interface WidgetRedirectFlowOptions {
+  /** Backend base URL — e.g. `Environments[env].backend`. */
+  backendUrl: string
+  /** Frontend base URL — e.g. `Environments[env].frontend`. */
+  frontendUrl: string
+  /** The session token already minted via `/widgets/session/self`. */
+  sessionToken: string
+  /**
+   * Relative embed path the CLI wants to open, e.g.
+   * `/embed/cards/setup` or `/embed/cards/enroll`.
+   */
+  embedPath: string
+  /** Extra query params to forward to the embed page (e.g. `provider=stripe`, `paymentMethodId=pm_x`). */
+  extraSearchParams?: Record<string, string>
+  /** If true, prints the URL instead of opening the browser. */
+  noBrowser?: boolean
+  /** Caller-supplied logger / printer. The login command uses oclif's formatter; this is the same shape. */
+  log: (msg: string) => void
+  /** Suggested success-page wording — keeps the wording aligned with whichever command is calling. */
+  successPageTitle?: string
+}
+
+export interface WidgetRedirectFlowResult {
+  /** Echoed `state` value — the helper has already verified it matches. */
+  state: string
+  /** All query params the embed page redirected with (paymentMethodId, delegationId, …). */
+  query: Record<string, string>
+}
+
+/**
+ * Shared redirect-mode handshake for any CLI command that hands the user
+ * off to an `/embed/*` page and waits for a localhost callback.
+ *
+ * The flow mirrors `nvm login`: start an ephemeral HTTP server on a
+ * random localhost port, build the embed URL with `sessionToken`,
+ * `returnUrl`, and `state`, open the browser (or print the URL with
+ * `--no-browser`), and resolve when the embed page redirects to
+ * `/callback?<params>&state=<state>`. The helper verifies the echoed
+ * state to bind the callback to this CLI invocation.
+ *
+ * Returns when the callback fires; rejects on timeout (5 min) or on
+ * server bind failure.
+ */
+export async function runWidgetRedirectFlow(
+  opts: WidgetRedirectFlowOptions,
+): Promise<WidgetRedirectFlowResult> {
+  const state = randomBytes(16).toString('hex')
+
+  return new Promise<WidgetRedirectFlowResult>((resolve, reject) => {
+    let resolved = false
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url || '/', 'http://localhost')
+      if (url.pathname !== '/callback') {
+        res.writeHead(404).end('Not found')
+        return
+      }
+
+      const receivedState = url.searchParams.get('state')
+      if (!receivedState || !safeEqualString(receivedState, state)) {
+        res.writeHead(400, { 'Content-Type': 'text/html' }).end(
+          errorHtml(
+            'Callback rejected',
+            'State mismatch. This callback did not match the request that started the flow — close this tab and re-run the command.',
+          ),
+        )
+        return
+      }
+
+      // Convert URLSearchParams → plain object, dropping the bookkeeping
+      // `state` field (the caller doesn't need to re-validate it).
+      const query: Record<string, string> = {}
+      for (const [key, value] of url.searchParams.entries()) {
+        if (key === 'state') continue
+        query[key] = value
+      }
+
+      res.writeHead(200, { 'Content-Type': 'text/html' }).end(
+        successHtml(
+          opts.successPageTitle ?? 'All done',
+          'You can close this tab and return to your terminal.',
+        ),
+      )
+      // Symmetry with the other rejection paths below — also stops the
+      // 5-minute timer from keeping the process alive after we resolve
+      // (#1 in the reviewer's punch list).
+
+      if (resolved) return
+      resolved = true
+      clearTimeout(timeout)
+      server.close()
+      resolve({ state, query })
+    })
+
+    const timeout = setTimeout(() => {
+      if (resolved) return
+      resolved = true
+      // Clear our own handle for symmetry with the other rejection
+      // paths — leaves Jest with no dangling timers (the test runner
+      // would otherwise wait one full tick before exiting).
+      clearTimeout(timeout)
+      server.close()
+      reject(new Error('Browser flow timed out after 5 minutes. Please try again.'))
+    }, REDIRECT_TIMEOUT_MS)
+
+    server.on('error', (err) => {
+      if (resolved) return
+      resolved = true
+      clearTimeout(timeout)
+      server.close()
+      reject(new Error(`Failed to start local callback server: ${err.message}`))
+    })
+
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address()
+      if (!addr || typeof addr === 'string') {
+        if (resolved) return
+        resolved = true
+        clearTimeout(timeout)
+        server.close()
+        reject(new Error('Failed to obtain local callback port'))
+        return
+      }
+
+      const returnUrl = `http://localhost:${addr.port}/callback`
+      const browserUrl = buildEmbedUrl({
+        frontendUrl: opts.frontendUrl,
+        embedPath: opts.embedPath,
+        sessionToken: opts.sessionToken,
+        returnUrl,
+        state,
+        extra: opts.extraSearchParams,
+      })
+
+      if (opts.noBrowser) {
+        opts.log('Open this URL in your browser to continue:')
+        opts.log('')
+        opts.log(browserUrl)
+        opts.log('')
+        opts.log('Waiting for completion...')
+      } else {
+        opts.log('Opening browser...')
+        openBrowser(browserUrl).catch(() => {
+          opts.log('Could not open the browser automatically. Open this URL manually:')
+          opts.log('')
+          opts.log(browserUrl)
+        })
+        opts.log('Waiting for completion...')
+      }
+    })
+  })
+}
+
+interface BuildEmbedUrlOptions {
+  frontendUrl: string
+  embedPath: string
+  sessionToken: string
+  returnUrl: string
+  state: string
+  extra?: Record<string, string>
+}
+
+function buildEmbedUrl(opts: BuildEmbedUrlOptions): string {
+  const url = new URL(opts.embedPath, opts.frontendUrl)
+  url.searchParams.set('sessionToken', opts.sessionToken)
+  url.searchParams.set('returnUrl', opts.returnUrl)
+  url.searchParams.set('state', opts.state)
+  if (opts.extra) {
+    for (const [k, v] of Object.entries(opts.extra)) {
+      url.searchParams.set(k, v)
+    }
+  }
+  return url.toString()
+}
+
+function successHtml(title: string, message: string): string {
+  // Plain HTML, no third-party assets, no scripts. The page is shown
+  // once and the user closes the tab; keep it self-contained so a
+  // captive-portal-style network doesn't break the success state.
+  return buildHtmlPage(title, message, '#f8f9fa', '#0f5132', '#d1e7dd')
+}
+
+function errorHtml(title: string, message: string): string {
+  // Same shell as the success page (so the layout looks consistent if
+  // the user sees both back-to-back), but tinted red so a state mismatch
+  // or other 4xx response is visually distinct from "we're done".
+  return buildHtmlPage(title, message, '#f8f9fa', '#842029', '#f8d7da')
+}
+
+function buildHtmlPage(
+  title: string,
+  message: string,
+  pageBg: string,
+  fgColor: string,
+  panelBg: string,
+): string {
+  return `<!doctype html>
+<html><head><meta charset="utf-8"><title>${escapeHtml(title)}</title></head>
+<body style="font-family: system-ui, sans-serif; display:flex; align-items:center; justify-content:center; min-height:100vh; margin:0; background:${pageBg};">
+  <div style="text-align:center; max-width: 480px; padding: 24px; background:${panelBg}; color:${fgColor}; border-radius:8px;">
+    <h2 style="margin: 0 0 12px;">${escapeHtml(title)}</h2>
+    <p style="margin: 0;">${escapeHtml(message)}</p>
+  </div>
+</body></html>`
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function openBrowser(url: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const platform = process.platform
+    let cmd: string
+    let args: string[]
+    if (platform === 'darwin') {
+      cmd = 'open'
+      args = [url]
+    } else if (platform === 'win32') {
+      cmd = 'cmd'
+      args = ['/c', 'start', '""', url]
+    } else {
+      cmd = 'xdg-open'
+      args = [url]
+    }
+    execFile(cmd, args, (err) => {
+      if (err) reject(err)
+      else resolve()
+    })
+  })
+}
+
+/**
+ * POST to the new `/widgets/session/self` endpoint with the caller's
+ * NVM API key. Lives here (not in the SDK) because v1 only wires this
+ * up for the CLI redirect flow — when the SDK exposes
+ * `payments.widgets.createSelfSession()` we can swap this for the SDK
+ * call without touching command callers.
+ */
+export interface SelfMintSessionResponse {
+  sessionToken: string
+  userId: string
+  userWallet: string
+  apiKeyHash: string
+  expiresAt: string
+  isReturnUrlAllowed?: boolean | null
+}
+
+export async function mintSelfWidgetSession(args: {
+  backendUrl: string
+  nvmApiKey: string
+  orgId: string
+  returnUrl?: string
+}): Promise<SelfMintSessionResponse> {
+  const url = new URL('/api/v1/widgets/session/self', args.backendUrl)
+
+  // 15s ceiling for the request — without it, an unreachable backend
+  // (DNS failure, TLS handshake hang, network partition) leaves the CLI
+  // frozen with no output. The localhost-callback server's own 5-min
+  // timer doesn't cover this pre-server call.
+  const controller = new AbortController()
+  const abortHandle = setTimeout(() => controller.abort(), SELF_MINT_FETCH_TIMEOUT_MS)
+  let response: Response
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${args.nvmApiKey}`,
+      },
+      body: JSON.stringify({
+        orgId: args.orgId,
+        ...(args.returnUrl ? { returnUrl: args.returnUrl } : {}),
+      }),
+      signal: controller.signal,
+    })
+  } catch (cause) {
+    if (controller.signal.aborted) {
+      throw new Error(
+        `Self-mint widget session request timed out after ${SELF_MINT_FETCH_TIMEOUT_MS / 1000}s — check that ${args.backendUrl} is reachable.`,
+      )
+    }
+    throw cause
+  } finally {
+    clearTimeout(abortHandle)
+  }
+
+  if (!response.ok) {
+    const detail = await response
+      .json()
+      .catch(() => ({ message: response.statusText }))
+    const message =
+      (detail as { message?: string }).message ??
+      `Self-mint widget session failed (HTTP ${response.status})`
+    const err = new Error(message) as Error & { status?: number; apiCode?: string }
+    err.status = response.status
+    err.apiCode = (detail as { code?: string }).code
+    throw err
+  }
+  return (await response.json()) as SelfMintSessionResponse
+}

--- a/cli/src/utils/widget-redirect-flow.ts
+++ b/cli/src/utils/widget-redirect-flow.ts
@@ -1,19 +1,9 @@
 import { createServer, IncomingMessage, ServerResponse } from 'http'
 import { randomBytes, timingSafeEqual } from 'crypto'
-import { execFile } from 'child_process'
+
+import { openBrowser } from './browser.js'
 
 const SELF_MINT_FETCH_TIMEOUT_MS = 15_000
-
-/**
- * Constant-time string equality for the CSRF state nonce. Both sides are
- * 32 hex chars (16 random bytes), so a length mismatch alone is enough to
- * reject. timingSafeEqual then compares the bytes without an early
- * short-circuit — closes a (tiny, loopback-only) timing oracle.
- */
-function safeEqualString(a: string, b: string): boolean {
-  if (a.length !== b.length) return false
-  return timingSafeEqual(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8'))
-}
 
 /**
  * Default timeout for a redirect-mode CLI flow. Mirrors the existing
@@ -23,18 +13,40 @@ function safeEqualString(a: string, b: string): boolean {
  */
 const REDIRECT_TIMEOUT_MS = 5 * 60 * 1000
 
+/**
+ * Constant-time string equality for the CSRF `state` nonce. The state we
+ * issue is a 32-char hex string (`randomBytes(16).toString('hex')`), so
+ * we ALWAYS allocate fixed 16-byte buffers from `hex` regardless of the
+ * caller-supplied value's encoding. Computing buffer length from string
+ * length would diverge on non-ASCII input (`a.length` is UTF-16 code
+ * units; `Buffer.from(a, 'utf8').length` is byte count), and a crafted
+ * non-hex `received` could otherwise throw inside `timingSafeEqual`.
+ *
+ * Inputs must already have been verified to be 32 hex chars by the
+ * caller (or we reject up front).
+ */
+function safeEqualHexState(received: string, expected: string): boolean {
+  if (!/^[0-9a-f]{32}$/i.test(received) || !/^[0-9a-f]{32}$/i.test(expected)) return false
+  return timingSafeEqual(Buffer.from(received, 'hex'), Buffer.from(expected, 'hex'))
+}
+
 export interface WidgetRedirectFlowOptions {
-  /** Backend base URL — e.g. `Environments[env].backend`. */
-  backendUrl: string
   /** Frontend base URL — e.g. `Environments[env].frontend`. */
   frontendUrl: string
-  /** The session token already minted via `/widgets/session/self`. */
-  sessionToken: string
   /**
    * Relative embed path the CLI wants to open, e.g.
    * `/embed/cards/setup` or `/embed/cards/enroll`.
    */
   embedPath: string
+  /**
+   * Called once the local callback server is listening, with the bound
+   * `returnUrl`. The caller mints a widget session against that URL and
+   * returns the resulting `sessionToken`. Splitting it this way lets
+   * the backend validate `returnUrl` at session-creation time (the
+   * spec'd contract) — minting before the port is known would leave
+   * the backend's pre-flight allow-list check with no URL to verify.
+   */
+  mintSession: (args: { returnUrl: string }) => Promise<{ sessionToken: string }>
   /** Extra query params to forward to the embed page (e.g. `provider=stripe`, `paymentMethodId=pm_x`). */
   extraSearchParams?: Record<string, string>
   /** If true, prints the URL instead of opening the browser. */
@@ -43,6 +55,8 @@ export interface WidgetRedirectFlowOptions {
   log: (msg: string) => void
   /** Suggested success-page wording — keeps the wording aligned with whichever command is calling. */
   successPageTitle?: string
+  /** Suggested timeout-error wording — keeps it specific to the calling command instead of "Card setup ..." for everything. */
+  timeoutMessage?: string
 }
 
 export interface WidgetRedirectFlowResult {
@@ -56,15 +70,19 @@ export interface WidgetRedirectFlowResult {
  * Shared redirect-mode handshake for any CLI command that hands the user
  * off to an `/embed/*` page and waits for a localhost callback.
  *
- * The flow mirrors `nvm login`: start an ephemeral HTTP server on a
- * random localhost port, build the embed URL with `sessionToken`,
- * `returnUrl`, and `state`, open the browser (or print the URL with
- * `--no-browser`), and resolve when the embed page redirects to
- * `/callback?<params>&state=<state>`. The helper verifies the echoed
- * state to bind the callback to this CLI invocation.
+ * Flow:
+ *   1. Bind a one-shot HTTP server on `127.0.0.1:0` (the OS picks a free port).
+ *   2. Compute `returnUrl = http://localhost:<port>/callback` and hand it
+ *      to `opts.mintSession`. The caller mints a widget session bound to
+ *      that exact returnUrl (which the backend can validate against the
+ *      session-specific allow-list at creation time).
+ *   3. Open the browser at `{frontend}/embed/<path>?sessionToken=…&returnUrl=…&state=<rand>`.
+ *   4. Resolve when the embed page redirects to `/callback?…&state=<echo>`.
+ *      `state` is compared in constant time.
  *
- * Returns when the callback fires; rejects on timeout (5 min) or on
- * server bind failure.
+ * Rejects on bind failure, mint failure, 5-minute timeout, or
+ * state-mismatched callback (the bad request gets a styled error page
+ * and the server stays alive — the legitimate callback can still land).
  */
 export async function runWidgetRedirectFlow(
   opts: WidgetRedirectFlowOptions,
@@ -73,6 +91,16 @@ export async function runWidgetRedirectFlow(
 
   return new Promise<WidgetRedirectFlowResult>((resolve, reject) => {
     let resolved = false
+    let timeout: ReturnType<typeof setTimeout> | undefined
+
+    const finalize = (err?: Error, value?: WidgetRedirectFlowResult): void => {
+      if (resolved) return
+      resolved = true
+      if (timeout) clearTimeout(timeout)
+      server.close()
+      if (err) reject(err)
+      else if (value) resolve(value)
+    }
 
     const server = createServer((req: IncomingMessage, res: ServerResponse) => {
       const url = new URL(req.url || '/', 'http://localhost')
@@ -82,7 +110,7 @@ export async function runWidgetRedirectFlow(
       }
 
       const receivedState = url.searchParams.get('state')
-      if (!receivedState || !safeEqualString(receivedState, state)) {
+      if (!receivedState || !safeEqualHexState(receivedState, state)) {
         res.writeHead(400, { 'Content-Type': 'text/html' }).end(
           errorHtml(
             'Callback rejected',
@@ -106,72 +134,63 @@ export async function runWidgetRedirectFlow(
           'You can close this tab and return to your terminal.',
         ),
       )
-      // Symmetry with the other rejection paths below — also stops the
-      // 5-minute timer from keeping the process alive after we resolve
-      // (#1 in the reviewer's punch list).
-
-      if (resolved) return
-      resolved = true
-      clearTimeout(timeout)
-      server.close()
-      resolve({ state, query })
+      finalize(undefined, { state, query })
     })
 
-    const timeout = setTimeout(() => {
-      if (resolved) return
-      resolved = true
-      // Clear our own handle for symmetry with the other rejection
-      // paths — leaves Jest with no dangling timers (the test runner
-      // would otherwise wait one full tick before exiting).
-      clearTimeout(timeout)
-      server.close()
-      reject(new Error('Browser flow timed out after 5 minutes. Please try again.'))
+    timeout = setTimeout(() => {
+      finalize(new Error(opts.timeoutMessage ?? 'Browser flow timed out after 5 minutes. Please try again.'))
     }, REDIRECT_TIMEOUT_MS)
 
     server.on('error', (err) => {
-      if (resolved) return
-      resolved = true
-      clearTimeout(timeout)
-      server.close()
-      reject(new Error(`Failed to start local callback server: ${err.message}`))
+      finalize(new Error(`Failed to start local callback server: ${err.message}`))
     })
 
     server.listen(0, '127.0.0.1', () => {
       const addr = server.address()
       if (!addr || typeof addr === 'string') {
-        if (resolved) return
-        resolved = true
-        clearTimeout(timeout)
-        server.close()
-        reject(new Error('Failed to obtain local callback port'))
+        finalize(new Error('Failed to obtain local callback port'))
         return
       }
-
       const returnUrl = `http://localhost:${addr.port}/callback`
-      const browserUrl = buildEmbedUrl({
-        frontendUrl: opts.frontendUrl,
-        embedPath: opts.embedPath,
-        sessionToken: opts.sessionToken,
-        returnUrl,
-        state,
-        extra: opts.extraSearchParams,
-      })
 
-      if (opts.noBrowser) {
-        opts.log('Open this URL in your browser to continue:')
-        opts.log('')
-        opts.log(browserUrl)
-        opts.log('')
-        opts.log('Waiting for completion...')
-      } else {
-        opts.log('Opening browser...')
-        openBrowser(browserUrl).catch(() => {
-          opts.log('Could not open the browser automatically. Open this URL manually:')
+      // Mint the session now that returnUrl is known. The backend's
+      // allow-list check at session creation can validate the URL the
+      // browser will actually be redirected to.
+      void (async () => {
+        let sessionToken: string
+        try {
+          const minted = await opts.mintSession({ returnUrl })
+          sessionToken = minted.sessionToken
+        } catch (mintErr) {
+          finalize(mintErr instanceof Error ? mintErr : new Error(String(mintErr)))
+          return
+        }
+
+        const browserUrl = buildEmbedUrl({
+          frontendUrl: opts.frontendUrl,
+          embedPath: opts.embedPath,
+          sessionToken,
+          returnUrl,
+          state,
+          extra: opts.extraSearchParams,
+        })
+
+        if (opts.noBrowser) {
+          opts.log('Open this URL in your browser to continue:')
           opts.log('')
           opts.log(browserUrl)
-        })
-        opts.log('Waiting for completion...')
-      }
+          opts.log('')
+          opts.log('Waiting for completion...')
+        } else {
+          opts.log('Opening browser...')
+          openBrowser(browserUrl).catch(() => {
+            opts.log('Could not open the browser automatically. Open this URL manually:')
+            opts.log('')
+            opts.log(browserUrl)
+          })
+          opts.log('Waiting for completion...')
+        }
+      })()
     })
   })
 }
@@ -238,32 +257,10 @@ function escapeHtml(value: string): string {
     .replace(/'/g, '&#39;')
 }
 
-function openBrowser(url: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const platform = process.platform
-    let cmd: string
-    let args: string[]
-    if (platform === 'darwin') {
-      cmd = 'open'
-      args = [url]
-    } else if (platform === 'win32') {
-      cmd = 'cmd'
-      args = ['/c', 'start', '""', url]
-    } else {
-      cmd = 'xdg-open'
-      args = [url]
-    }
-    execFile(cmd, args, (err) => {
-      if (err) reject(err)
-      else resolve()
-    })
-  })
-}
-
 /**
- * POST to the new `/widgets/session/self` endpoint with the caller's
- * NVM API key. Lives here (not in the SDK) because v1 only wires this
- * up for the CLI redirect flow — when the SDK exposes
+ * POST to the `/widgets/session/self` endpoint with the caller's NVM
+ * API key. Lives here (not in the SDK) because v1 only wires this up
+ * for the CLI redirect flow — when the SDK exposes
  * `payments.widgets.createSelfSession()` we can swap this for the SDK
  * call without touching command callers.
  */
@@ -286,10 +283,8 @@ export async function mintSelfWidgetSession(args: {
 
   // 15s ceiling for the request — without it, an unreachable backend
   // (DNS failure, TLS handshake hang, network partition) leaves the CLI
-  // frozen with no output. The localhost-callback server's own 5-min
-  // timer doesn't cover this pre-server call.
-  const controller = new AbortController()
-  const abortHandle = setTimeout(() => controller.abort(), SELF_MINT_FETCH_TIMEOUT_MS)
+  // frozen with no output. `AbortSignal.timeout` (Node 17.3+) is the
+  // idiomatic replacement for a hand-rolled `AbortController` + setTimeout.
   let response: Response
   try {
     response = await fetch(url, {
@@ -302,17 +297,15 @@ export async function mintSelfWidgetSession(args: {
         orgId: args.orgId,
         ...(args.returnUrl ? { returnUrl: args.returnUrl } : {}),
       }),
-      signal: controller.signal,
+      signal: AbortSignal.timeout(SELF_MINT_FETCH_TIMEOUT_MS),
     })
   } catch (cause) {
-    if (controller.signal.aborted) {
+    if (cause instanceof Error && (cause.name === 'TimeoutError' || cause.name === 'AbortError')) {
       throw new Error(
         `Self-mint widget session request timed out after ${SELF_MINT_FETCH_TIMEOUT_MS / 1000}s — check that ${args.backendUrl} is reachable.`,
       )
     }
     throw cause
-  } finally {
-    clearTimeout(abortHandle)
   }
 
   if (!response.ok) {

--- a/cli/test/unit/orgs.test.ts
+++ b/cli/test/unit/orgs.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, jest, test } from '@jest/globals'
+
+import { resolveOrgIdInteractive } from '../../src/utils/orgs.js'
+
+type FakeMembership = {
+  orgId: string
+  orgName: string
+  role: string
+  orgType: string
+  isAdmin: boolean
+  hasSubscriptionHistory: boolean
+}
+
+const makeMembership = (overrides: Partial<FakeMembership>): FakeMembership => ({
+  orgId: 'org-1',
+  orgName: 'Acme',
+  role: 'Admin',
+  orgType: 'Company',
+  isAdmin: true,
+  hasSubscriptionHistory: false,
+  ...overrides,
+})
+
+const makePayments = (memberships: FakeMembership[]) =>
+  ({
+    organizations: {
+      getMyMemberships: jest.fn<() => Promise<FakeMembership[]>>().mockResolvedValue(memberships),
+    },
+  }) as unknown as Parameters<typeof resolveOrgIdInteractive>[0]['payments']
+
+describe('resolveOrgIdInteractive', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('honours --org and skips the membership lookup entirely', async () => {
+    const payments = makePayments([])
+    const result = await resolveOrgIdInteractive({
+      payments,
+      flagOrgId: 'org-flag-wins',
+      log: () => undefined,
+      isTTY: true,
+    })
+    expect(result).toEqual({ orgId: 'org-flag-wins', orgName: '' })
+    expect(
+      (
+        payments as unknown as {
+          organizations: { getMyMemberships: jest.Mock }
+        }
+      ).organizations.getMyMemberships,
+    ).not.toHaveBeenCalled()
+  })
+
+  test('throws a member-only message when the user has no memberships', async () => {
+    const payments = makePayments([])
+    await expect(
+      resolveOrgIdInteractive({ payments, log: () => undefined, isTTY: true }),
+    ).rejects.toThrow(/only available to members of an organization/i)
+  })
+
+  test('silently uses the single membership when exactly one exists', async () => {
+    const payments = makePayments([makeMembership({ orgId: 'org-only', orgName: 'Only' })])
+    const logged: string[] = []
+    const result = await resolveOrgIdInteractive({
+      payments,
+      log: (m) => logged.push(m),
+      isTTY: true,
+    })
+    expect(result).toEqual({ orgId: 'org-only', orgName: 'Only' })
+    // Should not have printed the interactive picker when only one is
+    // available — surprises the user in CI.
+    expect(logged.join('\n')).not.toMatch(/Select an organization/)
+  })
+
+  test('requires --org in non-TTY mode when the user has multiple memberships', async () => {
+    const payments = makePayments([
+      makeMembership({ orgId: 'org-a', orgName: 'A' }),
+      makeMembership({ orgId: 'org-b', orgName: 'B' }),
+    ])
+    await expect(
+      resolveOrgIdInteractive({ payments, log: () => undefined, isTTY: false }),
+    ).rejects.toThrow(/Pass --org/)
+  })
+
+  test('promotes flagOrgId over interactive picker even when multiple memberships exist', async () => {
+    const payments = makePayments([
+      makeMembership({ orgId: 'org-a', orgName: 'A' }),
+      makeMembership({ orgId: 'org-b', orgName: 'B' }),
+    ])
+    const result = await resolveOrgIdInteractive({
+      payments,
+      flagOrgId: 'org-b',
+      log: () => undefined,
+      isTTY: false,
+    })
+    // Note: by design we do NOT cross-check the flagged orgId against
+    // memberships locally — the backend's `isOrganizationMember` is the
+    // ground truth. The 403 from the backend is the right place to fail.
+    expect(result).toEqual({ orgId: 'org-b', orgName: '' })
+  })
+})

--- a/cli/test/unit/widget-redirect-flow.test.ts
+++ b/cli/test/unit/widget-redirect-flow.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, jest, test } from '@jest/globals'
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals'
 import { runWidgetRedirectFlow } from '../../src/utils/widget-redirect-flow.js'
 
 /**
@@ -12,39 +12,128 @@ import { runWidgetRedirectFlow } from '../../src/utils/widget-redirect-flow.js'
  * server has bound, so `returnUrl` is known at session-creation time.
  * Each test stubs that callback with a synchronous resolver that hands
  * back a fake `sessionToken`.
+ *
+ * Cleanup: `runWidgetRedirectFlow` only closes its ephemeral server
+ * after a state-matched good callback. Without an `afterEach` that
+ * forces such a callback on every test, an early assertion failure
+ * leaks the server and a real 5-minute timer until Jest's suite-wide
+ * `testTimeout` fires. The `inFlight` registry below records every
+ * spawned flow's `(returnUrl, state, promise)` and the `afterEach`
+ * sends the success callback to whichever ones haven't resolved yet.
  */
+type InFlightFlow = {
+  promise: Promise<unknown>
+  returnUrlPromise: Promise<{ returnUrl: string; state: string }>
+  resolved: boolean
+}
+
 describe('runWidgetRedirectFlow', () => {
-  test('mints with the actual returnUrl AFTER the server binds, then resolves with the callback IDs', async () => {
+  const inFlight = new Set<InFlightFlow>()
+
+  beforeEach(() => {
+    inFlight.clear()
+  })
+
+  afterEach(async () => {
+    // Force-resolve any flow whose assertions threw early. The helper
+    // only releases its server after a valid `state`-matched callback,
+    // so we send one with `__cleanup=1` as the extra payload field.
+    for (const flow of inFlight) {
+      if (flow.resolved) continue
+      try {
+        const { returnUrl, state } = await flow.returnUrlPromise
+        const u = new URL(returnUrl)
+        u.searchParams.set('__cleanup', '1')
+        u.searchParams.set('state', state)
+        await fetch(u.toString()).catch(() => undefined)
+        await flow.promise.catch(() => undefined)
+      } catch {
+        // The flow never reached the listen step (e.g. mintSession
+        // threw synchronously). Nothing to clean up.
+      }
+    }
+    inFlight.clear()
+  })
+
+  /**
+   * Start a `runWidgetRedirectFlow` and register it for cleanup. The
+   * returned `promise` resolves when the helper resolves; the returned
+   * `returnUrlPromise` resolves with the URL the helper logged plus
+   * the issued `state`, so callers can fire callbacks against them.
+   */
+  function startFlow(opts: {
+    embedPath?: string
+    mintSession?: (args: { returnUrl: string }) => Promise<{ sessionToken: string }>
+  } = {}) {
     const logs: string[] = []
+    const flow: InFlightFlow = {
+      promise: undefined as unknown as Promise<unknown>,
+      returnUrlPromise: undefined as unknown as Promise<{
+        returnUrl: string
+        state: string
+      }>,
+      resolved: false,
+    }
+    flow.promise = runWidgetRedirectFlow({
+      frontendUrl: 'http://frontend.test',
+      embedPath: opts.embedPath ?? '/embed/cards/setup',
+      mintSession: opts.mintSession ?? (async () => ({ sessionToken: 'tok_abc' })),
+      log: (msg: string) => logs.push(msg),
+      noBrowser: true,
+    })
+    // Track resolution without swallowing the rejection — the per-test
+    // `await` still observes the original promise's outcome. Attaching
+    // a no-op `.catch` here only stops Node from reporting an
+    // "unhandledRejection" before the test runner awaits the flow.
+    flow.promise.then(
+      () => {
+        flow.resolved = true
+      },
+      () => {
+        flow.resolved = true
+      },
+    )
+    flow.returnUrlPromise = (async () => {
+      const start = Date.now()
+      while (Date.now() - start < 2000) {
+        // Stop polling early if the flow has already settled — e.g. when
+        // `mintSession` throws before the helper gets a chance to log
+        // the URL.
+        if (flow.resolved) {
+          throw new Error('Flow resolved before logging a URL')
+        }
+        const url = logs.find((l) => l.startsWith('http://') || l.startsWith('https://'))
+        if (url) {
+          const parsed = new URL(url)
+          return {
+            returnUrl: parsed.searchParams.get('returnUrl') as string,
+            state: parsed.searchParams.get('state') as string,
+          }
+        }
+        await new Promise((r) => setTimeout(r, 10))
+      }
+      throw new Error('Timed out waiting for the helper to log the embed URL')
+    })()
+    // Pre-attach a no-op handler so a flow that aborts before logging a
+    // URL doesn't surface as an `unhandledRejection` in the per-test
+    // event loop. The afterEach still awaits the promise via try/catch.
+    flow.returnUrlPromise.catch(() => undefined)
+    inFlight.add(flow)
+    return { ...flow, logs }
+  }
+
+  test('mints with the actual returnUrl AFTER the server binds, then resolves with the callback IDs', async () => {
     const mintSession = jest
       .fn<(args: { returnUrl: string }) => Promise<{ sessionToken: string }>>()
       .mockResolvedValue({ sessionToken: 'tok_abc' })
 
-    const promise = runWidgetRedirectFlow({
-      frontendUrl: 'http://frontend.test',
-      embedPath: '/embed/cards/setup',
-      mintSession,
-      log: (msg: string) => logs.push(msg),
-      noBrowser: true,
-    })
+    const flow = startFlow({ mintSession })
+    const { returnUrl, state } = await flow.returnUrlPromise
 
-    const url = await waitForLoggedUrl(logs)
-    const parsed = new URL(url)
-    expect(parsed.host).toBe('frontend.test')
-    expect(parsed.pathname).toBe('/embed/cards/setup')
-    expect(parsed.searchParams.get('sessionToken')).toBe('tok_abc')
-    expect(parsed.searchParams.get('state')).toMatch(/^[0-9a-f]{32}$/i)
-
-    // `mintSession` MUST have been called with the bound returnUrl —
-    // this is the post-review contract: the backend can now validate
-    // the URL at session-creation time.
     expect(mintSession).toHaveBeenCalledTimes(1)
-    const callArg = mintSession.mock.calls[0][0]
-    expect(callArg.returnUrl).toMatch(/^http:\/\/localhost:\d+\/callback$/)
-    expect(callArg.returnUrl).toBe(parsed.searchParams.get('returnUrl'))
-
-    const returnUrl = new URL(callArg.returnUrl)
-    const state = parsed.searchParams.get('state') as string
+    expect(mintSession.mock.calls[0][0].returnUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/callback$/)
+    expect(mintSession.mock.calls[0][0].returnUrl).toBe(returnUrl)
+    expect(state).toMatch(/^[0-9a-f]{32}$/i)
 
     const callback = new URL(returnUrl)
     callback.searchParams.set('paymentMethodId', 'pm_x')
@@ -53,30 +142,22 @@ describe('runWidgetRedirectFlow', () => {
     const res = await fetch(callback.toString())
     expect(res.status).toBe(200)
 
-    const result = await promise
+    const result = (await flow.promise) as { state: string; query: Record<string, string> }
     expect(result.state).toBe(state)
     expect(result.query.paymentMethodId).toBe('pm_x')
     expect(result.query.delegationId).toBe('del_y')
     expect(result.query.state).toBeUndefined()
   })
 
-  test('rejects a callback whose state does not match the issued one (hex regex + timingSafeEqual)', async () => {
-    const logs: string[] = []
-    const promise = runWidgetRedirectFlow({
-      frontendUrl: 'http://frontend.test',
-      embedPath: '/embed/cards/setup',
-      mintSession: async () => ({ sessionToken: 'tok_abc' }),
-      log: (msg: string) => logs.push(msg),
-      noBrowser: true,
-    })
-    const url = await waitForLoggedUrl(logs)
-    const parsed = new URL(url)
-    const returnUrl = new URL(parsed.searchParams.get('returnUrl') as string)
+  test('rejects callbacks whose state does not match the issued one (hex regex + timingSafeEqual)', async () => {
+    const flow = startFlow()
+    const { returnUrl } = await flow.returnUrlPromise
 
-    // Two flavours of bad state: a non-hex string (caught by regex) and
-    // a hex string of the wrong length. Both must 400 without throwing
-    // (Copilot review #7: pre-fix, `safeEqualString` could crash on
-    // non-ASCII input).
+    // Three flavours of bad state: non-hex, wrong-length hex, and a
+    // non-ASCII 32-char string. Pre-fix the last one would crash
+    // `timingSafeEqual` because string `.length` is UTF-16 code units
+    // while the buffers are UTF-8 bytes. All three must 400 without
+    // throwing (Copilot review #7 + eruizgar91 follow-up).
     for (const badState of ['not-hex-at-all', 'abcd', 'ÿ'.repeat(32)]) {
       const bad = new URL(returnUrl)
       bad.searchParams.set('paymentMethodId', 'pm_x')
@@ -84,66 +165,25 @@ describe('runWidgetRedirectFlow', () => {
       const badRes = await fetch(bad.toString())
       expect(badRes.status).toBe(400)
     }
-
-    const good = new URL(returnUrl)
-    good.searchParams.set('paymentMethodId', 'pm_x')
-    good.searchParams.set('state', parsed.searchParams.get('state') as string)
-    const goodRes = await fetch(good.toString())
-    expect(goodRes.status).toBe(200)
-
-    const result = await promise
-    expect(result.query.paymentMethodId).toBe('pm_x')
+    // afterEach cleans up the still-open server via the good callback.
   })
 
   test('returns 404 for any path other than /callback (server is single-purpose)', async () => {
-    const logs: string[] = []
-    const promise = runWidgetRedirectFlow({
-      frontendUrl: 'http://frontend.test',
-      embedPath: '/embed/cards/enroll',
-      mintSession: async () => ({ sessionToken: 'tok_abc' }),
-      log: (msg: string) => logs.push(msg),
-      noBrowser: true,
-    })
-    const url = await waitForLoggedUrl(logs)
-    const returnUrl = new URL(new URL(url).searchParams.get('returnUrl') as string)
+    const flow = startFlow({ embedPath: '/embed/cards/enroll' })
+    const { returnUrl } = await flow.returnUrlPromise
     const notCallback = new URL(returnUrl)
     notCallback.pathname = '/other'
     const res = await fetch(notCallback.toString())
     expect(res.status).toBe(404)
-
-    // Close out the helper so the test process can exit cleanly.
-    const ok = new URL(returnUrl)
-    ok.searchParams.set('paymentMethodId', 'pm_x')
-    ok.searchParams.set('state', new URL(url).searchParams.get('state') as string)
-    await fetch(ok.toString())
-    await promise
+    // afterEach cleans up via the good callback.
   })
 
   test('rejects when mintSession throws (e.g. backend rejects returnUrl) before opening a browser', async () => {
-    const logs: string[] = []
-    const promise = runWidgetRedirectFlow({
-      frontendUrl: 'http://frontend.test',
-      embedPath: '/embed/cards/setup',
+    const flow = startFlow({
       mintSession: async () => {
-        throw new Error('Backend rejected returnUrl http://localhost:0/callback')
+        throw new Error('Backend rejected returnUrl http://127.0.0.1:0/callback')
       },
-      log: (msg: string) => logs.push(msg),
-      noBrowser: true,
     })
-
-    await expect(promise).rejects.toThrow(/Backend rejected returnUrl/)
-    // Nothing should have been logged either — the helper aborts before
-    // it prints the URL or attempts to open a browser.
-    expect(logs.every((l) => !l.startsWith('http'))).toBe(true)
+    await expect(flow.promise).rejects.toThrow(/Backend rejected returnUrl/)
   })
 })
-
-async function waitForLoggedUrl(logs: string[]): Promise<string> {
-  const start = Date.now()
-  while (Date.now() - start < 2000) {
-    const url = logs.find((line) => line.startsWith('http://') || line.startsWith('https://'))
-    if (url) return url
-    await new Promise((r) => setTimeout(r, 10))
-  }
-  throw new Error('Timed out waiting for the helper to log the embed URL')
-}

--- a/cli/test/unit/widget-redirect-flow.test.ts
+++ b/cli/test/unit/widget-redirect-flow.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from '@jest/globals'
+import { createServer, IncomingMessage, ServerResponse } from 'http'
+import { runWidgetRedirectFlow } from '../../src/utils/widget-redirect-flow.js'
+
+/**
+ * Unit-test the redirect-flow helper end to end against an actual
+ * localhost server it spins up. We don't open a browser (the helper
+ * accepts `noBrowser: true`); instead the test grabs the URL printed
+ * via `log` and fires the callback by hand. This exercises the same
+ * code path a real CLI invocation does, without the browser dependency.
+ */
+describe('runWidgetRedirectFlow', () => {
+  test('resolves with paymentMethodId + delegationId when the callback fires with the matching state', async () => {
+    const logs: string[] = []
+    const promise = runWidgetRedirectFlow({
+      backendUrl: 'http://backend.test',
+      frontendUrl: 'http://frontend.test',
+      sessionToken: 'tok_abc',
+      embedPath: '/embed/cards/setup',
+      log: (msg: string) => logs.push(msg),
+      noBrowser: true,
+    })
+
+    // The helper logs the URL after the server is listening, so wait
+    // for the URL to appear. Polling avoids racing the server-bind
+    // callback in the helper.
+    const url = await waitForLoggedUrl(logs)
+    const parsed = new URL(url)
+    expect(parsed.host).toBe('frontend.test')
+    expect(parsed.pathname).toBe('/embed/cards/setup')
+    expect(parsed.searchParams.get('sessionToken')).toBe('tok_abc')
+    expect(parsed.searchParams.get('state')).toBeTruthy()
+
+    const returnUrl = new URL(parsed.searchParams.get('returnUrl') as string)
+    const state = parsed.searchParams.get('state') as string
+
+    // Fire the callback as the embed page would.
+    const callback = new URL(returnUrl)
+    callback.searchParams.set('paymentMethodId', 'pm_x')
+    callback.searchParams.set('delegationId', 'del_y')
+    callback.searchParams.set('state', state)
+    const res = await fetch(callback.toString())
+    expect(res.status).toBe(200)
+
+    const result = await promise
+    expect(result.state).toBe(state)
+    expect(result.query.paymentMethodId).toBe('pm_x')
+    expect(result.query.delegationId).toBe('del_y')
+    // state should be stripped from `query` (the helper has already
+    // verified it).
+    expect(result.query.state).toBeUndefined()
+  })
+
+  test('rejects a callback whose state does not match the issued one', async () => {
+    const logs: string[] = []
+    const promise = runWidgetRedirectFlow({
+      backendUrl: 'http://backend.test',
+      frontendUrl: 'http://frontend.test',
+      sessionToken: 'tok_abc',
+      embedPath: '/embed/cards/setup',
+      log: (msg: string) => logs.push(msg),
+      noBrowser: true,
+    })
+    const url = await waitForLoggedUrl(logs)
+    const parsed = new URL(url)
+    const returnUrl = new URL(parsed.searchParams.get('returnUrl') as string)
+
+    // Fire callback with a forged state. The 400 returned by the helper
+    // tells us it did NOT resolve the promise — to confirm the helper
+    // stays pending we then send a correctly-stated callback, which is
+    // the only thing that should make `promise` resolve.
+    const bad = new URL(returnUrl)
+    bad.searchParams.set('paymentMethodId', 'pm_x')
+    bad.searchParams.set('state', 'wrong-state')
+    const badRes = await fetch(bad.toString())
+    expect(badRes.status).toBe(400)
+
+    const good = new URL(returnUrl)
+    good.searchParams.set('paymentMethodId', 'pm_x')
+    good.searchParams.set('state', parsed.searchParams.get('state') as string)
+    const goodRes = await fetch(good.toString())
+    expect(goodRes.status).toBe(200)
+
+    const result = await promise
+    expect(result.query.paymentMethodId).toBe('pm_x')
+  })
+
+  test('returns 404 for any path other than /callback (server is single-purpose)', async () => {
+    const logs: string[] = []
+    const promise = runWidgetRedirectFlow({
+      backendUrl: 'http://backend.test',
+      frontendUrl: 'http://frontend.test',
+      sessionToken: 'tok_abc',
+      embedPath: '/embed/cards/enroll',
+      log: (msg: string) => logs.push(msg),
+      noBrowser: true,
+    })
+    const url = await waitForLoggedUrl(logs)
+    const returnUrl = new URL(new URL(url).searchParams.get('returnUrl') as string)
+    const notCallback = new URL(returnUrl)
+    notCallback.pathname = '/other'
+    const res = await fetch(notCallback.toString())
+    expect(res.status).toBe(404)
+
+    // Close out the helper so the test process can exit cleanly.
+    const ok = new URL(returnUrl)
+    ok.searchParams.set('paymentMethodId', 'pm_x')
+    ok.searchParams.set('state', new URL(url).searchParams.get('state') as string)
+    await fetch(ok.toString())
+    await promise
+  })
+})
+
+// Suppress "createServer / IncomingMessage / ServerResponse imported but
+// only used in type position" lint by referencing them in a no-op type
+// alias — they document the contract the helper relies on even though
+// the test itself goes through fetch.
+type _DocOnly = [typeof createServer, IncomingMessage, ServerResponse]
+
+async function waitForLoggedUrl(logs: string[]): Promise<string> {
+  const start = Date.now()
+  while (Date.now() - start < 2000) {
+    const url = logs.find((line) => line.startsWith('http://') || line.startsWith('https://'))
+    if (url) return url
+    await new Promise((r) => setTimeout(r, 10))
+  }
+  throw new Error('Timed out waiting for the helper to log the embed URL')
+}

--- a/cli/test/unit/widget-redirect-flow.test.ts
+++ b/cli/test/unit/widget-redirect-flow.test.ts
@@ -1,5 +1,4 @@
-import { describe, expect, test } from '@jest/globals'
-import { createServer, IncomingMessage, ServerResponse } from 'http'
+import { describe, expect, jest, test } from '@jest/globals'
 import { runWidgetRedirectFlow } from '../../src/utils/widget-redirect-flow.js'
 
 /**
@@ -8,33 +7,45 @@ import { runWidgetRedirectFlow } from '../../src/utils/widget-redirect-flow.js'
  * accepts `noBrowser: true`); instead the test grabs the URL printed
  * via `log` and fires the callback by hand. This exercises the same
  * code path a real CLI invocation does, without the browser dependency.
+ *
+ * The helper takes a `mintSession` callback that runs AFTER the local
+ * server has bound, so `returnUrl` is known at session-creation time.
+ * Each test stubs that callback with a synchronous resolver that hands
+ * back a fake `sessionToken`.
  */
 describe('runWidgetRedirectFlow', () => {
-  test('resolves with paymentMethodId + delegationId when the callback fires with the matching state', async () => {
+  test('mints with the actual returnUrl AFTER the server binds, then resolves with the callback IDs', async () => {
     const logs: string[] = []
+    const mintSession = jest
+      .fn<(args: { returnUrl: string }) => Promise<{ sessionToken: string }>>()
+      .mockResolvedValue({ sessionToken: 'tok_abc' })
+
     const promise = runWidgetRedirectFlow({
-      backendUrl: 'http://backend.test',
       frontendUrl: 'http://frontend.test',
-      sessionToken: 'tok_abc',
       embedPath: '/embed/cards/setup',
+      mintSession,
       log: (msg: string) => logs.push(msg),
       noBrowser: true,
     })
 
-    // The helper logs the URL after the server is listening, so wait
-    // for the URL to appear. Polling avoids racing the server-bind
-    // callback in the helper.
     const url = await waitForLoggedUrl(logs)
     const parsed = new URL(url)
     expect(parsed.host).toBe('frontend.test')
     expect(parsed.pathname).toBe('/embed/cards/setup')
     expect(parsed.searchParams.get('sessionToken')).toBe('tok_abc')
-    expect(parsed.searchParams.get('state')).toBeTruthy()
+    expect(parsed.searchParams.get('state')).toMatch(/^[0-9a-f]{32}$/i)
 
-    const returnUrl = new URL(parsed.searchParams.get('returnUrl') as string)
+    // `mintSession` MUST have been called with the bound returnUrl —
+    // this is the post-review contract: the backend can now validate
+    // the URL at session-creation time.
+    expect(mintSession).toHaveBeenCalledTimes(1)
+    const callArg = mintSession.mock.calls[0][0]
+    expect(callArg.returnUrl).toMatch(/^http:\/\/localhost:\d+\/callback$/)
+    expect(callArg.returnUrl).toBe(parsed.searchParams.get('returnUrl'))
+
+    const returnUrl = new URL(callArg.returnUrl)
     const state = parsed.searchParams.get('state') as string
 
-    // Fire the callback as the embed page would.
     const callback = new URL(returnUrl)
     callback.searchParams.set('paymentMethodId', 'pm_x')
     callback.searchParams.set('delegationId', 'del_y')
@@ -46,18 +57,15 @@ describe('runWidgetRedirectFlow', () => {
     expect(result.state).toBe(state)
     expect(result.query.paymentMethodId).toBe('pm_x')
     expect(result.query.delegationId).toBe('del_y')
-    // state should be stripped from `query` (the helper has already
-    // verified it).
     expect(result.query.state).toBeUndefined()
   })
 
-  test('rejects a callback whose state does not match the issued one', async () => {
+  test('rejects a callback whose state does not match the issued one (hex regex + timingSafeEqual)', async () => {
     const logs: string[] = []
     const promise = runWidgetRedirectFlow({
-      backendUrl: 'http://backend.test',
       frontendUrl: 'http://frontend.test',
-      sessionToken: 'tok_abc',
       embedPath: '/embed/cards/setup',
+      mintSession: async () => ({ sessionToken: 'tok_abc' }),
       log: (msg: string) => logs.push(msg),
       noBrowser: true,
     })
@@ -65,15 +73,17 @@ describe('runWidgetRedirectFlow', () => {
     const parsed = new URL(url)
     const returnUrl = new URL(parsed.searchParams.get('returnUrl') as string)
 
-    // Fire callback with a forged state. The 400 returned by the helper
-    // tells us it did NOT resolve the promise — to confirm the helper
-    // stays pending we then send a correctly-stated callback, which is
-    // the only thing that should make `promise` resolve.
-    const bad = new URL(returnUrl)
-    bad.searchParams.set('paymentMethodId', 'pm_x')
-    bad.searchParams.set('state', 'wrong-state')
-    const badRes = await fetch(bad.toString())
-    expect(badRes.status).toBe(400)
+    // Two flavours of bad state: a non-hex string (caught by regex) and
+    // a hex string of the wrong length. Both must 400 without throwing
+    // (Copilot review #7: pre-fix, `safeEqualString` could crash on
+    // non-ASCII input).
+    for (const badState of ['not-hex-at-all', 'abcd', 'ÿ'.repeat(32)]) {
+      const bad = new URL(returnUrl)
+      bad.searchParams.set('paymentMethodId', 'pm_x')
+      bad.searchParams.set('state', badState)
+      const badRes = await fetch(bad.toString())
+      expect(badRes.status).toBe(400)
+    }
 
     const good = new URL(returnUrl)
     good.searchParams.set('paymentMethodId', 'pm_x')
@@ -88,10 +98,9 @@ describe('runWidgetRedirectFlow', () => {
   test('returns 404 for any path other than /callback (server is single-purpose)', async () => {
     const logs: string[] = []
     const promise = runWidgetRedirectFlow({
-      backendUrl: 'http://backend.test',
       frontendUrl: 'http://frontend.test',
-      sessionToken: 'tok_abc',
       embedPath: '/embed/cards/enroll',
+      mintSession: async () => ({ sessionToken: 'tok_abc' }),
       log: (msg: string) => logs.push(msg),
       noBrowser: true,
     })
@@ -109,13 +118,25 @@ describe('runWidgetRedirectFlow', () => {
     await fetch(ok.toString())
     await promise
   })
-})
 
-// Suppress "createServer / IncomingMessage / ServerResponse imported but
-// only used in type position" lint by referencing them in a no-op type
-// alias — they document the contract the helper relies on even though
-// the test itself goes through fetch.
-type _DocOnly = [typeof createServer, IncomingMessage, ServerResponse]
+  test('rejects when mintSession throws (e.g. backend rejects returnUrl) before opening a browser', async () => {
+    const logs: string[] = []
+    const promise = runWidgetRedirectFlow({
+      frontendUrl: 'http://frontend.test',
+      embedPath: '/embed/cards/setup',
+      mintSession: async () => {
+        throw new Error('Backend rejected returnUrl http://localhost:0/callback')
+      },
+      log: (msg: string) => logs.push(msg),
+      noBrowser: true,
+    })
+
+    await expect(promise).rejects.toThrow(/Backend rejected returnUrl/)
+    // Nothing should have been logged either — the helper aborts before
+    // it prints the URL or attempts to open a browser.
+    expect(logs.every((l) => !l.startsWith('http'))).toBe(true)
+  })
+})
 
 async function waitForLoggedUrl(logs: string[]): Promise<string> {
   const start = Date.now()

--- a/markdown/README.md
+++ b/markdown/README.md
@@ -15,6 +15,7 @@ This directory contains the markdown documentation for the Nevermined Payments T
 9. **mcp-integration.md** - Model Context Protocol integration
 10. **a2a-integration.md** - Agent-to-Agent protocol integration
 11. **x402.md** - X402 payment protocol specification
+12. **cli-card-setup.md** - White-labeled card enrolment + delegation for CLI / top-level integrators
 
 ## Automation Workflows
 

--- a/markdown/cli-card-setup.md
+++ b/markdown/cli-card-setup.md
@@ -1,0 +1,287 @@
+---
+title: "CLI Card Setup (Top-Level Redirect Flow)"
+description: "Hand a user off to the Nevermined webapp to enrol a card and create a spending delegation from a CLI or other top-level browser-tab integration"
+icon: "browser"
+---
+
+# CLI Card Setup (Top-Level Redirect Flow)
+
+The Nevermined webapp ships a chromeless **card setup** page at `/embed/cards/setup` that walks a user through:
+
+1. Enrolling a credit / debit card (via Stripe Elements — sensitive data never touches your servers).
+2. Creating a spending delegation against that card (a per-card budget the user pre-authorises for agent spend).
+
+This guide explains how a **CLI or any other non-iframe integrator** can drive that page in a top-level browser tab and receive `paymentMethodId` + `delegationId` back at a localhost HTTP callback. The pattern mirrors `nvm login`: print a URL, the user clicks it, the browser redirects back to a one-shot port on the user's machine, your process resolves with the result.
+
+The official `nvm` CLI ships three commands implementing this flow out of the box — see [`nvm cards setup`](#using-the-nvm-cli) below. If you are building your own CLI or backend integration, the rest of this guide is the contract you need to honour.
+
+## When to Use This Flow
+
+- You are building a CLI, terminal tool, or other application that runs on the user's machine and wants to attach a card to the user's Nevermined account without forcing them into your own UI for the tokenization step.
+- You want a **white-labeled** card setup page that respects the parent organisation's branding (logo, panel colours, button colours), but you do not want to host an iframe.
+- You need both the `paymentMethodId` and the `delegationId` in one round-trip — the combined `setup` flow emits both in a single callback.
+
+For the classic iframe integration (a website embedding `/embed/cards/enroll` etc. inside an `<iframe>` and listening for `postMessage`), see the `@nevermined-io/ui-widgets` package instead.
+
+## Two Authentication Paths
+
+| Path | Who uses it | Authentication |
+|------|-------------|---------------|
+| **Widget-key** | A third-party (website backend, CLI) acting on behalf of an organisation's own end-users. The end-users do not necessarily have their own Nevermined accounts. | Server signs an init-token with the organisation's widget-key secret and exchanges it at `POST /widgets/session` for a session token. |
+| **Self-mint** | A user with their own NVM API key (typically after running `nvm login`) who wants to attach a card to their *own* Nevermined identity. | `POST /widgets/session/self` with `Authorization: Bearer <nvmApiKey>`. |
+
+Both paths produce the same response shape (`WidgetSessionResponse`); the embed routes don't branch on which one was used.
+
+Card setup is **organization-scoped**. Self-mint callers must be members of at least one Nevermined organisation. Widget-key sessions are inherently org-scoped through the widget key itself.
+
+## Basic Flow
+
+```text
+┌──────┐                            ┌────────────┐                             ┌─────────────┐                     ┌────────────────┐
+│ CLI  │                            │ Backend    │                             │ User Browser│                     │ Local Callback │
+│      │                            │ (Nevermined│                             │             │                     │  HTTP Server   │
+└──┬───┘                            └─────┬──────┘                             └──────┬──────┘                     └────────┬───────┘
+   │                                      │                                           │                                     │
+   │ start one-shot server on             │                                           │                                     │
+   │ 127.0.0.1:<random> /callback ───────────────────────────────────────────────────────────────────────────────────────────▶ listening
+   │                                      │                                           │                                     │
+   │ POST /widgets/session/self           │                                           │                                     │
+   │   Bearer <nvmApiKey>                 │                                           │                                     │
+   │   body { orgId, returnUrl }          │                                           │                                     │
+   ├────────────────────────────────────▶│ verify org membership                     │                                     │
+   │                                      │ mint session JWT (kind:'self-mint')       │                                     │
+   │◀────────────────────────────────────┤ { sessionToken, isReturnUrlAllowed }      │                                     │
+   │                                      │                                           │                                     │
+   │ open browser at                      │                                           │                                     │
+   │ {frontend}/embed/cards/setup         │                                           │                                     │
+   │  ?sessionToken=...                   │                                           │                                     │
+   │  &returnUrl=http://localhost:<port>  │                                           │                                     │
+   │  &state=<rand>  &provider=stripe     │                                           │                                     │
+   ├──────────────────────────────────────────────────────────────────────────────────▶ navigate                            │
+   │                                      │                                           │                                     │
+   │                                      │ GET /widgets/session/validate            │                                     │
+   │                                      │  Bearer <sessionToken>                   │                                     │
+   │                                      │  X-Nvm-Widget-Return-Url: <returnUrl>    │                                     │
+   │                                      │◀──────────────────────────────────────────│                                     │
+   │                                      │ { valid, isReturnUrlAllowed, ... }       │                                     │
+   │                                      │──────────────────────────────────────────▶│                                     │
+   │                                      │                                           │                                     │
+   │                                      │ Step 1: Enroll card                      │                                     │
+   │                                      │   Stripe Elements + SetupIntent          │                                     │
+   │                                      │   POST /delegation/setup-intent          │                                     │
+   │                                      │   POST /delegation/finalize-enrollment   │                                     │
+   │                                      │   → paymentMethodId                      │                                     │
+   │                                      │                                           │                                     │
+   │                                      │ Step 2: Create delegation                │                                     │
+   │                                      │   POST /delegation/create                │                                     │
+   │                                      │   → delegationId                         │                                     │
+   │                                      │                                           │                                     │
+   │                                      │ window.location.replace(returnUrl + ?    │                                     │
+   │                                      │   paymentMethodId&delegationId&state)    │                                     │
+   │                                      │──────────────────────────────────────────▶ GET callback                         │
+   │                                      │                                           │                                     │
+   │◀──────────────────────────────────────────────────────────────────────────────────────────────────resolved { ids, state }
+   │                                      │                                           │                                     │
+   │ verify state matches → resolve        │                                           │                                     │
+   │ shutdown server                       │                                           │                                     │
+```
+
+The browser ends up on a friendly "All done — close this tab" page so the user knows the flow finished; your CLI prints the IDs and exits.
+
+## Using the `nvm` CLI
+
+Three commands are available out of the box:
+
+```bash
+# Combined: enroll a card AND create a delegation in one flow.
+# Returns both paymentMethodId and delegationId.
+nvm cards setup
+
+# Single-purpose: only enroll a card. Returns paymentMethodId.
+nvm cards enroll
+
+# Single-purpose: only create a delegation against an already-enrolled card.
+# Returns delegationId.
+nvm cards delegate --card pm_1234
+```
+
+All three accept:
+- `--org <id>` — Required if you belong to multiple organisations and the terminal is non-interactive (CI). Inferred silently when you belong to exactly one org. In an interactive terminal with two or more memberships, the CLI prompts you to pick.
+- `--no-browser` — Print the URL instead of opening the browser automatically (useful over SSH or in CI).
+- `--provider stripe|braintree|visa` — Tokenization provider for the enrolment step. Defaults to `stripe`.
+
+Pre-requisite: run `nvm login` first to authenticate against the target environment.
+
+```bash
+$ nvm cards setup
+ℹ Using organization: Acme AI (org-abc-123)
+Opening browser...
+Waiting for completion...
+✓ Card setup complete!
+  paymentMethodId: pm_1ABCD…
+  delegationId:    9719d8b5-…
+  organization:    org-abc-123
+```
+
+## Implementing the Flow Yourself
+
+If you are building your own CLI (in a non-Node language, or with stricter packaging requirements), implement the four steps below. The pattern works in any language with an HTTP client, a way to open a browser, and the ability to bind a local TCP port.
+
+### 1. Start a one-shot localhost HTTP server
+
+Bind to `127.0.0.1:0` (the OS picks a free port). Listen on `/callback`. Note the port — you need it for `returnUrl`.
+
+Bind to `127.0.0.1` only, **never `0.0.0.0`** — your callback should not be reachable from the network.
+
+### 2. Mint a session token
+
+For the **self-mint** path (a user with their own `nvmApiKey`):
+
+```http
+POST {api}/api/v1/widgets/session/self
+Authorization: Bearer <nvmApiKey>
+Content-Type: application/json
+
+{
+  "orgId": "org-abc-123",
+  "returnUrl": "http://localhost:54321/callback"
+}
+```
+
+Response:
+
+```json
+{
+  "sessionToken": "eyJ...",
+  "userId": "us-...",
+  "userWallet": "0x...",
+  "apiKeyHash": "sandbox:eyJ...",
+  "expiresAt": "2026-05-22T19:00:00.000Z",
+  "isReturnUrlAllowed": true
+}
+```
+
+If the user is not a member of the requested org you get `403 BCK.WIDGET_SESSION.0019`. If they have no org memberships at all, `403 BCK.WIDGET_SESSION.0018`.
+
+For the **widget-key** path, see the existing `POST /widgets/session` documentation in the `@nevermined-io/ui-widgets-server` SDK.
+
+### 3. Open the browser
+
+Construct the URL and open it (`xdg-open` / `open` / `start`):
+
+```
+{frontend}/embed/cards/setup?sessionToken=<token>&returnUrl=<urlEncoded callback>&state=<random>&provider=stripe
+```
+
+Required query parameters:
+- `sessionToken` — from step 2.
+- `returnUrl` — your localhost callback URL.
+- `state` — a cryptographically random nonce (16+ bytes, hex-encoded). The browser echoes it back in the redirect; you reject any callback that doesn't echo this value (CSRF binding).
+- `provider` — `stripe`, `braintree`, or `visa`.
+
+Three other routes exist if you only need one step of the flow:
+
+| Route | Result fields in the callback |
+|-------|--------------------------------|
+| `/embed/cards/setup` | `paymentMethodId`, `delegationId` |
+| `/embed/cards/enroll` | `paymentMethodId` |
+| `/embed/cards/delegate?paymentMethodId=<id>` | `delegationId` |
+
+### 4. Wait for the callback
+
+The browser redirects to `<returnUrl>?paymentMethodId=…&delegationId=…&state=<echo>` on success. Your local server should:
+
+1. Verify the `state` query parameter matches the one you issued. Use a constant-time string comparison (the `nvm` CLI uses `crypto.timingSafeEqual`).
+2. Extract `paymentMethodId` and `delegationId` (or just one, depending on which embed route you opened).
+3. Respond `200 OK` with a friendly "you can close this tab" HTML page.
+4. Close the server.
+
+Recommended timeout: **5 minutes**. Match the `nvm login` flow so users have time to switch contexts in their browser.
+
+### Pseudocode
+
+```ts
+// TypeScript / Node — the same shape works in any language.
+import { createServer } from 'http'
+import { randomBytes, timingSafeEqual } from 'crypto'
+
+const orgId = process.env.NVM_ORG_ID!
+const nvmApiKey = process.env.NVM_API_KEY!
+const state = randomBytes(16).toString('hex')
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url!, 'http://localhost')
+  if (url.pathname !== '/callback') {
+    res.writeHead(404).end()
+    return
+  }
+  const received = url.searchParams.get('state') ?? ''
+  if (
+    received.length !== state.length ||
+    !timingSafeEqual(Buffer.from(received), Buffer.from(state))
+  ) {
+    res.writeHead(400, { 'Content-Type': 'text/html' }).end(
+      '<h2>State mismatch</h2><p>Close this tab and re-run the command.</p>',
+    )
+    return
+  }
+  const paymentMethodId = url.searchParams.get('paymentMethodId')
+  const delegationId = url.searchParams.get('delegationId')
+  res.writeHead(200, { 'Content-Type': 'text/html' }).end(
+    '<h2>Card setup complete</h2><p>You can close this tab.</p>',
+  )
+  console.log({ paymentMethodId, delegationId })
+  server.close()
+})
+
+server.listen(0, '127.0.0.1', async () => {
+  const port = (server.address() as { port: number }).port
+  const returnUrl = `http://localhost:${port}/callback`
+
+  // Mint a session token bound to one of the user's orgs.
+  const mint = await fetch('https://api.sandbox.nevermined.app/api/v1/widgets/session/self', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${nvmApiKey}` },
+    body: JSON.stringify({ orgId, returnUrl }),
+  }).then((r) => r.json())
+
+  const setupUrl = new URL('/embed/cards/setup', 'https://nevermined.app')
+  setupUrl.searchParams.set('sessionToken', mint.sessionToken)
+  setupUrl.searchParams.set('returnUrl', returnUrl)
+  setupUrl.searchParams.set('state', state)
+  setupUrl.searchParams.set('provider', 'stripe')
+
+  console.log('Open this URL in your browser:\n')
+  console.log(setupUrl.toString())
+})
+```
+
+## Allowed `returnUrl` Hosts
+
+The server validates `returnUrl` against the session's allow-list. The same allow-list runs at **session-creation time** (response field `isReturnUrlAllowed`) and again at **page-load time** (via the `X-Nvm-Widget-Return-Url` header the embed page forwards on `/validate`). The page refuses to mount if the URL is not allowed, so a stale or wrong `returnUrl` can never leak the result IDs to an unauthorised destination.
+
+Rules:
+- `localhost`, `127.0.0.1`, `[::1]` (any port, any path) — accepted for **both** session kinds.
+- Other `https://` origins — accepted only for **widget-key** sessions whose key has the origin in its `allowedOrigins` list. **Self-mint sessions reject any non-localhost host** (there is no widget-key allow-list to widen).
+
+## Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `BCK.WIDGET_SESSION.0018` | Caller has no active organisation memberships. Self-mint is members-only — create or join an organisation in the dashboard first. |
+| `BCK.WIDGET_SESSION.0019` | The `orgId` in the request is not one of the caller's memberships. |
+| `BCK.WIDGET_SESSION.0001` | Invalid widget credentials (widget-key path only). |
+| `BCK.APIKEY.0004` | Invalid or expired NVM API key (self-mint path only). |
+
+## Security Notes
+
+- **Bind only to `127.0.0.1`**, not `0.0.0.0`. Your callback server is for the local user, not the network.
+- **Use a per-flow random `state` value** (16+ bytes, hex-encoded). Compare callbacks in constant time. Reject any callback whose `state` does not match.
+- **Treat the session token like a bearer credential.** It carries the user's `apiKeyHash` and expires in 2 hours. Don't log it, don't persist it past the flow.
+- **Page lifecycle is single-use.** The embed page strips `sessionToken` from the URL immediately after the page consumes it, so it never lands in the browser back-forward history or in any later `document.referrer`. If the user hits "back" after the redirect, they will not land on a re-playable URL.
+
+## See Also
+
+- [`nvm login`](./installation.md) — the equivalent flow for authentication.
+- [Payment Plans](./payment-plans.md) — once a card is delegated, you can use it to subscribe to plans.
+- [Initialising the Library](./initializing-the-library.md) — bootstrap the SDK.

--- a/markdown/cli-card-setup.md
+++ b/markdown/cli-card-setup.md
@@ -55,7 +55,7 @@ Card setup is **organization-scoped**. Self-mint callers must be members of at l
    │ open browser at                      │                                           │                                     │
    │ {frontend}/embed/cards/setup         │                                           │                                     │
    │  ?sessionToken=...                   │                                           │                                     │
-   │  &returnUrl=http://localhost:<port>  │                                           │                                     │
+   │  &returnUrl=http://127.0.0.1:<port>  │                                           │                                     │
    │  &state=<rand>  &provider=stripe     │                                           │                                     │
    ├──────────────────────────────────────────────────────────────────────────────────▶ navigate                            │
    │                                      │                                           │                                     │
@@ -144,7 +144,7 @@ Content-Type: application/json
 
 {
   "orgId": "org-abc-123",
-  "returnUrl": "http://localhost:54321/callback"
+  "returnUrl": "http://127.0.0.1:54321/callback"
 }
 ```
 
@@ -240,7 +240,10 @@ const server = createServer(async (req, res) => {
 
 server.listen(0, '127.0.0.1', async () => {
   const port = (server.address() as { port: number }).port
-  const returnUrl = `http://localhost:${port}/callback`
+  // Use 127.0.0.1 (not the `localhost` alias) to match the server bind
+  // above. Node 17+ prefers ::1 for `localhost` on IPv6-capable hosts
+  // and the browser would stall on the IPv6 attempt before falling back.
+  const returnUrl = `http://127.0.0.1:${port}/callback`
 
   // Mint a session token bound to one of the user's orgs.
   const mint = await fetch('https://api.sandbox.nevermined.app/api/v1/widgets/session/self', {

--- a/markdown/cli-card-setup.md
+++ b/markdown/cli-card-setup.md
@@ -216,9 +216,13 @@ const server = createServer(async (req, res) => {
     return
   }
   const received = url.searchParams.get('state') ?? ''
+  // Validate hex shape FIRST so we never feed UTF-8 buffers of unequal
+  // byte length into timingSafeEqual (it throws on length mismatch).
+  // Both sides are 32-char hex (16 random bytes) by construction.
+  const HEX_32 = /^[0-9a-f]{32}$/i
   if (
-    received.length !== state.length ||
-    !timingSafeEqual(Buffer.from(received), Buffer.from(state))
+    !HEX_32.test(received) ||
+    !timingSafeEqual(Buffer.from(received, 'hex'), Buffer.from(state, 'hex'))
   ) {
     res.writeHead(400, { 'Content-Type': 'text/html' }).end(
       '<h2>State mismatch</h2><p>Close this tab and re-run the command.</p>',


### PR DESCRIPTION
Companion to **nevermined-io/nvm-monorepo#1716** (which adds the `POST /widgets/session/self` endpoint and the `/embed/cards/setup` redirect-mode page this CLI drives).

## Summary

Three new commands that hand the user off to the Nevermined webapp's chromeless `/embed/cards/*` pages in their browser, wait on a one-shot localhost HTTP server for the result, and return `paymentMethodId` and `delegationId` to the terminal. Same callback pattern as the existing `nvm login` flow.

## Commands

```bash
# Combined: enroll a card AND create a delegation. Returns both IDs.
nvm cards setup [--org <id>] [--no-browser] [--provider stripe|braintree|visa]

# Single-purpose: only enroll a card.
nvm cards enroll [--org <id>] [--no-browser] [--provider ...]

# Single-purpose: only create a delegation against an already-enrolled card.
nvm cards delegate --card <paymentMethodId> [--org <id>] [--no-browser]
```

All three:
- Require the user to have run `nvm login` first.
- Are organisation-scoped — the backend's `POST /widgets/session/self` rejects callers with no org memberships (`BCK.WIDGET_SESSION.0018`).
- Resolve the org silently when the user belongs to exactly one; interactive picker on 2+ in a TTY; hard error in non-TTY without `--org`.

## What's in this PR

- `cli/src/commands/cards/{setup,enroll,delegate}.ts` — the three commands. Each is a thin shim (~80 lines) around the shared helpers below.
- `cli/src/utils/widget-redirect-flow.ts` — shared callback-server + URL-open helper. One-shot HTTP server on `127.0.0.1:0` (random port), 5-minute timeout, **128-bit random `state`** compared via `crypto.timingSafeEqual` (constant time), separate **error HTML page** (red panel) distinct from the success page, `AbortSignal.timeout(15s)` on the `POST /widgets/session/self` fetch so an unreachable backend doesn't hang the CLI silently.
- `cli/src/utils/orgs.ts` — `resolveOrgIdInteractive` via `payments.organizations.getMyMemberships()`.
- `cli/test/unit/widget-redirect-flow.test.ts` — end-to-end against a real localhost server.
- `cli/test/unit/orgs.test.ts` — five branches of org resolution (flag, 0 / 1 / 2+ memberships, TTY / non-TTY).
- `markdown/cli-card-setup.md` — full integrator guide for third parties building their own CLIs in other languages.

## Test plan

- [x] `pnpm test:unit` — all unit tests green (existing + new).
- [x] `pnpm build` green.
- [x] End-to-end on a local stack: `nvm cards setup --profile local-cards` → browser flow with the Stripe test card → CLI exited cleanly with both IDs, rows persisted in `paymentMethods` and `delegations`.
- [ ] CI green.

## Independent code review

Reviewed by `code-reviewer` agent with no context on the design. 3 HIGH + 2 MEDIUM addressed in-branch:
- Timeout handler now `clearTimeout`s itself (no leaked process tick).
- State comparison uses `crypto.timingSafeEqual` (closes a loopback-only timing oracle).
- Dedicated `errorHtml` for the state-mismatch path (no more success-styled error page).
- `mintSelfWidgetSession` has a 15s `AbortSignal.timeout` (no silent hangs on unreachable backends).
- Full unit test coverage for `orgs.ts`.

## Backend dependency

This CLI needs **nevermined-io/nvm-monorepo#1716** merged + deployed before the commands will work against any environment. The endpoint `POST /api/v1/widgets/session/self` does not exist on `main` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)