### PR TITLE
fix: #1724 staging feedback — middleware settlement + json safety + docs

### DIFF
--- a/markdown/x402.md
+++ b/markdown/x402.md
@@ -75,9 +75,6 @@ const tokenOptions: X402TokenOptions = {
 const { accessToken } = await subscriberPayments.x402.getX402AccessToken(
   planId, // Required: Plan ID
   agentId, // Optional: Agent ID (restricts token to specific agent)
-  undefined, // redemptionLimit (optional)
-  undefined, // orderLimit (optional)
-  undefined, // expiration (optional, ISO 8601)
   tokenOptions, // Required: scheme + delegationConfig
 )
 
@@ -135,20 +132,14 @@ const eurTokenOptions: X402TokenOptions = {
 const { accessToken } = await subscriberPayments.x402.getX402AccessToken(
   planId,
   agentId,
-  undefined,  // redemptionLimit
-  undefined,  // orderLimit
-  undefined,  // expiration
-  tokenOptions
+  tokenOptions,
 )
 
 // EUR card delegation token
 const { accessToken: eurAccessToken } = await subscriberPayments.x402.getX402AccessToken(
   planId,
   agentId,
-  undefined,
-  undefined,
-  undefined,
-  eurTokenOptions
+  eurTokenOptions,
 )
 ```
 
@@ -165,7 +156,9 @@ const tokenOptions: X402TokenOptions = {
 }
 
 const { accessToken } = await subscriberPayments.x402.getX402AccessToken(
-  planId, agentId, undefined, undefined, undefined, tokenOptions
+  planId,
+  agentId,
+  tokenOptions,
 )
 ```
 
@@ -600,11 +593,11 @@ const subscriberPayments = Payments.getInstance({
   environment: 'sandbox' as EnvironmentName,
 })
 
-// 1. Generate access token
-const { accessToken } = await subscriberPayments.x402.getX402AccessToken(
-  planId,
-  agentId
-)
+// 1. Generate access token (delegationConfig is required for both schemes)
+const { accessToken } = await subscriberPayments.x402.getX402AccessToken(planId, agentId, {
+  scheme: 'nvm:erc4337',
+  delegationConfig: { spendingLimitCents: 1000, durationSecs: 86_400 },
+})
 
 // 2. Make request with payment-signature header
 const response = await fetch('https://agent.example.com/api/v1/tasks', {

--- a/markdown/x402.md
+++ b/markdown/x402.md
@@ -49,27 +49,44 @@ The Nevermined Payments Library implements X402 v2, which uses:
 
 ## Generate X402 Access Tokens
 
-Subscribers generate access tokens to query agents:
+Subscribers generate access tokens to query agents. **Both schemes
+(`nvm:erc4337` and `nvm:card-delegation`) require a `delegationConfig`** —
+the older "just pass planId + agentId" shape no longer mints a token and
+will surface `BCK.X402.0005` ("delegationConfig is required …") at the
+backend.
 
 ```typescript
-import { Payments, EnvironmentName } from '@nevermined-io/payments'
+import { Payments, EnvironmentName, X402TokenOptions } from '@nevermined-io/payments'
 
 const subscriberPayments = Payments.getInstance({
   nvmApiKey: process.env.SUBSCRIBER_API_KEY!,
   environment: 'sandbox' as EnvironmentName,
 })
 
-// Generate X402 access token
+// Crypto (nvm:erc4337) example — auto-creates a delegation on first call
+const tokenOptions: X402TokenOptions = {
+  scheme: 'nvm:erc4337',
+  delegationConfig: {
+    spendingLimitCents: 1000, // $10 cap
+    durationSecs: 86_400, // 1 day
+  },
+}
+
 const { accessToken } = await subscriberPayments.x402.getX402AccessToken(
-  planId,              // Required: Plan ID
-  agentId,             // Optional: Agent ID (restricts token to specific agent)
-  redemptionLimit,     // Optional: Max credits this token can burn
-  orderLimit,          // Optional: Order limit
-  expiration           // Optional: Expiration date (ISO 8601 string)
+  planId, // Required: Plan ID
+  agentId, // Optional: Agent ID (restricts token to specific agent)
+  undefined, // redemptionLimit (optional)
+  undefined, // orderLimit (optional)
+  undefined, // expiration (optional, ISO 8601)
+  tokenOptions, // Required: scheme + delegationConfig
 )
 
 console.log('X402 access token generated')
 ```
+
+To reuse a previously-minted delegation rather than auto-creating one,
+pass `delegationConfig: { delegationId: '<uuid>' }` — the backend
+verifies the delegation is still active and returns its bound token.
 
 ### Generate Tokens via Nevermined App
 

--- a/src/api/agents-api.ts
+++ b/src/api/agents-api.ts
@@ -1,3 +1,4 @@
+import { safeParseJson } from '../common/helper.js'
 import { PaymentsError } from '../common/payments.error.js'
 import {
   AgentAPIAttributes,
@@ -84,7 +85,7 @@ export class AgentsAPI extends BasePaymentsAPI {
 
     const response = await fetch(url, options)
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Unable to register agent', await response.json())
+      throw PaymentsError.fromBackend('Unable to register agent', await safeParseJson(response))
     }
     const agentData = await response.json()
     return { agentId: agentData.data.agentId }
@@ -167,7 +168,7 @@ export class AgentsAPI extends BasePaymentsAPI {
 
     const response = await fetch(url, options)
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Unable to register agent & plan', await response.json())
+      throw PaymentsError.fromBackend('Unable to register agent & plan', await safeParseJson(response))
     }
     const result = await response.json()
     return {
@@ -193,7 +194,7 @@ export class AgentsAPI extends BasePaymentsAPI {
     const url = new URL(API_URL_GET_AGENT.replace(':agentId', agentId), this.environment.backend)
     const response = await fetch(url)
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Agent not found', await response.json())
+      throw PaymentsError.fromBackend('Agent not found', await safeParseJson(response))
     }
     return response.json()
   }
@@ -228,7 +229,7 @@ export class AgentsAPI extends BasePaymentsAPI {
     const options = this.getBackendHTTPOptions('PUT', body)
     const response = await fetch(url, options)
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Error updating agent', await response.json())
+      throw PaymentsError.fromBackend('Error updating agent', await safeParseJson(response))
     }
     return response.json()
   }
@@ -258,7 +259,7 @@ export class AgentsAPI extends BasePaymentsAPI {
     const url = new URL(query, this.environment.backend)
     const response = await fetch(url)
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Agent not found', await response.json())
+      throw PaymentsError.fromBackend('Agent not found', await safeParseJson(response))
     }
     return response.json()
   }
@@ -290,7 +291,7 @@ export class AgentsAPI extends BasePaymentsAPI {
     const url = new URL(endpoint, this.environment.backend)
     const response = await fetch(url, options)
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Unable to add plan to agent', await response.json())
+      throw PaymentsError.fromBackend('Unable to add plan to agent', await safeParseJson(response))
     }
 
     return response.json()
@@ -326,7 +327,7 @@ export class AgentsAPI extends BasePaymentsAPI {
     const url = new URL(endpoint, this.environment.backend)
     const response = await fetch(url, options)
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Unable to remove plan from agent', await response.json())
+      throw PaymentsError.fromBackend('Unable to remove plan from agent', await safeParseJson(response))
     }
 
     return response.json()

--- a/src/api/plans-api.ts
+++ b/src/api/plans-api.ts
@@ -1,3 +1,4 @@
+import { safeParseJson } from '../common/helper.js'
 import { PaymentsError } from '../common/payments.error.js'
 import {
   Address,
@@ -44,7 +45,11 @@ export class PlansAPI extends BasePaymentsAPI {
   /**
    * Builds a Fiat price configuration for a plan.
    *
-   * @param amount - Amount to charge in minor units (e.g., cents) as bigint.
+   * `amount` is in **6-decimal units** (USDC convention, NOT cents). To
+   * charge $2.00, pass `2_000_000n`. Minimum is `1_000_000n` ($1.00) —
+   * lower values are rejected server-side with `BCK.PROTOCOL.0047`.
+   *
+   * @param amount - Amount to charge in 6-decimal units (e.g. `2_000_000n` for $2.00) as bigint.
    * @param receiver - Wallet address that will receive the payment.
    * @param currency - Fiat currency code (default: 'USD'). Any ISO 4217 code accepted by Stripe.
    * @returns The PlanPriceConfig representing a fiat price.
@@ -510,7 +515,7 @@ export class PlansAPI extends BasePaymentsAPI {
     const url = new URL(query, this.environment.backend)
     const response = await fetch(url)
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Plan not found', await response.json())
+      throw PaymentsError.fromBackend('Plan not found', await safeParseJson(response))
     }
     return response.json()
   }
@@ -532,7 +537,7 @@ export class PlansAPI extends BasePaymentsAPI {
     const options = this.getBackendHTTPOptions('GET')
     const response = await fetch(url, options)
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Unable to get plans', await response.json())
+      throw PaymentsError.fromBackend('Unable to get plans', await safeParseJson(response))
     }
 
     const data = await response.json()
@@ -565,7 +570,7 @@ export class PlansAPI extends BasePaymentsAPI {
     const url = new URL(query, this.environment.backend)
     const response = await fetch(url)
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Plan not found', await response.json())
+      throw PaymentsError.fromBackend('Plan not found', await safeParseJson(response))
     }
     return response.json()
   }
@@ -615,7 +620,7 @@ export class PlansAPI extends BasePaymentsAPI {
     const url = new URL(balanceUrl, this.environment.backend)
     const response = await fetch(url, options)
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Unable to get balance', await response.json())
+      throw PaymentsError.fromBackend('Unable to get balance', await safeParseJson(response))
     }
 
     return response.json()
@@ -645,7 +650,7 @@ export class PlansAPI extends BasePaymentsAPI {
     const url = new URL(API_URL_ORDER_PLAN.replace(':planId', planId), this.environment.backend)
     const response = await fetch(url, options)
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Unable to order plan', await response.json())
+      throw PaymentsError.fromBackend('Unable to order plan', await safeParseJson(response))
     }
 
     return response.json()
@@ -677,7 +682,7 @@ export class PlansAPI extends BasePaymentsAPI {
     const url = new URL(API_URL_STRIPE_CHECKOUT, this.environment.backend)
     const response = await fetch(url, options)
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Unable to order fiat plan', await response.json())
+      throw PaymentsError.fromBackend('Unable to order fiat plan', await safeParseJson(response))
     }
 
     return response.json()
@@ -714,7 +719,7 @@ export class PlansAPI extends BasePaymentsAPI {
     const url = new URL(API_URL_MINT_PLAN, this.environment.backend)
     const response = await fetch(url, options)
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Unable to mint plan credits', await response.json())
+      throw PaymentsError.fromBackend('Unable to mint plan credits', await safeParseJson(response))
     }
 
     return response.json()
@@ -758,7 +763,10 @@ export class PlansAPI extends BasePaymentsAPI {
     const url = new URL(API_URL_MINT_EXPIRABLE_PLAN, this.environment.backend)
     const response = await fetch(url, options)
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Unable to mint expirable credits', await response.json())
+      throw PaymentsError.fromBackend(
+        'Unable to mint expirable credits',
+        await safeParseJson(response),
+      )
     }
 
     return response.json()

--- a/src/api/requests-api.ts
+++ b/src/api/requests-api.ts
@@ -12,6 +12,7 @@ import {
   API_URL_SIMULATE_REDEEM_AGENT_REQUEST,
 } from './nvm-api.js'
 import { PaymentsError } from '../common/payments.error.js'
+import { safeParseJson } from '../common/helper.js'
 
 /**
  * The AgentRequestsAPI class provides methods to manage the requests received by AI Agents integrated with Nevermined.
@@ -27,7 +28,6 @@ export class AgentRequestsAPI extends BasePaymentsAPI {
   static getInstance(options: PaymentOptions): AgentRequestsAPI {
     return new AgentRequestsAPI(options)
   }
-
 
   /**
    * This method simulates an agent request.
@@ -57,7 +57,10 @@ export class AgentRequestsAPI extends BasePaymentsAPI {
     const options = this.getBackendHTTPOptions('POST', opts)
     const response = await fetch(url, options)
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Unable to start simulation request', await response.json())
+      throw PaymentsError.fromBackend(
+        'Unable to start simulation request',
+        await safeParseJson(response),
+      )
     }
     return response.json()
   }
@@ -107,7 +110,7 @@ export class AgentRequestsAPI extends BasePaymentsAPI {
         if (!response.ok) {
           lastError = PaymentsError.fromBackend(
             'Unable to finish simulation request',
-            await response.json(),
+            await safeParseJson(response),
           )
           if (attempt < maxRetries - 1) {
             await new Promise((resolve) => setTimeout(resolve, 1000))
@@ -135,7 +138,6 @@ export class AgentRequestsAPI extends BasePaymentsAPI {
     // This should never be reached, but TypeScript requires it
     throw lastError || new PaymentsError('Unable to finish simulation request')
   }
-
 
   /**
    * Tracks an agent sub task.
@@ -178,7 +180,10 @@ export class AgentRequestsAPI extends BasePaymentsAPI {
     const response = await fetch(url, options)
 
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Unable to track agent sub task', await response.json())
+      throw PaymentsError.fromBackend(
+        'Unable to track agent sub task',
+        await safeParseJson(response),
+      )
     }
 
     return response.json()

--- a/src/common/helper.ts
+++ b/src/common/helper.ts
@@ -2,6 +2,37 @@ import { Endpoint } from './types.js'
 
 export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
+/**
+ * Safe JSON parse for fetch responses. Reads the body once and tolerates
+ * non-JSON payloads (e.g. NGINX HTML 5xx gateway pages) by returning a
+ * `{ message }` shell that downstream error code paths can still consume.
+ *
+ * Prevents the failure mode tracked in #1727: callers doing
+ * `throw PaymentsError.fromBackend('...', await response.json())` would
+ * otherwise let a SyntaxError from `.json()` escape and surface as an
+ * `unhandledRejection` that can take the host Node process down.
+ */
+export async function safeParseJson(response: Response): Promise<unknown> {
+  const contentType = response.headers.get('content-type') ?? ''
+  // Always consume the body so the underlying socket can be released, even
+  // when we decide we can't parse it as JSON.
+  const text = await response.text().catch(() => '')
+  if (!text) return {}
+  if (!contentType.toLowerCase().includes('json')) {
+    // Truncate to keep the payload bounded — a full HTML gateway page is
+    // noise in an error log.
+    const snippet = text.length > 200 ? `${text.slice(0, 200)}…` : text
+    return { message: `Non-JSON response (${contentType || 'no content-type'}): ${snippet}` }
+  }
+  try {
+    return JSON.parse(text)
+  } catch (cause) {
+    return {
+      message: `Malformed JSON response: ${cause instanceof Error ? cause.message : String(cause)}`,
+    }
+  }
+}
+
 export const jsonReplacer = (_key: any, value: { toString: () => any }) => {
   return typeof value === 'bigint' ? value.toString() : value
 }

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -14,6 +14,30 @@ export const ONE_WEEK_DURATION = 604_800n // 7 * 24 * 60 * 60 seconds
 export const ONE_MONTH_DURATION = 2_629_746n // (365.25 days/year ÷ 12 months/year) × 24 × 60 × 60 ≈ 2,629,746 seconds
 export const ONE_YEAR_DURATION = 31_557_600n // 365.25 * 24 * 60 * 60 seconds
 
+/**
+ * Builds a price configuration for fiat-denominated plans (Stripe / Braintree).
+ *
+ * `amount` is in **6-decimal units** (the USDC convention used across the
+ * Nevermined protocol — NOT cents). To charge $2.00, pass `2_000_000n`;
+ * `200n` would be read as $0.0002 and rejected by the backend.
+ *
+ * Minimum charge enforced server-side is **$1.00** (`1_000_000n`) — fiat
+ * processor fixed fees make smaller amounts uneconomic. Passing below the
+ * minimum surfaces as `BCK.PROTOCOL.0047`.
+ *
+ * @param amount - Amount in 6-decimal units (e.g. `2_000_000n` for $2.00)
+ * @param receiver - Wallet address that will receive the settled funds
+ * @param currency - ISO currency code (defaults to `USD`)
+ *
+ * @example
+ * ```ts
+ * // Charge $9.99 in USD
+ * getFiatPriceConfig(9_990_000n, sellerWallet)
+ *
+ * // Charge €29.00 in EUR
+ * getFiatPriceConfig(29_000_000n, sellerWallet, Currency.EUR)
+ * ```
+ */
 export const getFiatPriceConfig = (
   amount: bigint,
   receiver: Address,

--- a/src/x402/express/middleware.ts
+++ b/src/x402/express/middleware.ts
@@ -360,57 +360,84 @@ export function paymentMiddleware(
         // Attach to request for potential use by route handler
         ;(req as Request & { paymentContext?: PaymentContext }).paymentContext = paymentContext
 
-        // Override res.json to settle BEFORE sending response
-        // This ensures credits are burned and payment-response header is included
-        const originalJson = res.json.bind(res)
-        res.json = function (body: unknown) {
-          // Re-evaluate dynamic credits now that the handler has run and
-          // res.locals is populated. For fixed (numeric) credits this is a no-op.
-          const settlePromise = (
+        // Wrap res.end so settlement runs no matter how the handler responds
+        // (res.json, res.send, res.sendFile, res.end, res.pipe → res.end).
+        // Previously only res.json was intercepted, so any other response
+        // method would deliver the resource without burning credits and
+        // without emitting the payment-response receipt header (#1728).
+        const originalEnd = res.end.bind(res) as (...args: Parameters<Response['end']>) => Response
+        let settlementStarted = false
+
+        const runSettlement = (): Promise<void> => {
+          return (
             typeof credits === 'function'
               ? Promise.resolve(credits(req, res))
               : Promise.resolve(creditsToVerify)
-          ).then((creditsToSettle) => {
-            // Update payment context so downstream consumers see the actual value
-            paymentContext.creditsToSettle = creditsToSettle
-
-            // Settle credits before sending response
-            // Pass agentRequestId to enable observability updates
-            return payments.facilitator
-              .settlePermissions({
-                paymentRequired,
-                x402AccessToken: token,
-                maxAmount: BigInt(creditsToSettle),
-                agentRequestId: paymentContext.agentRequestId,
-              })
-              .then((settlement) => {
-                // Add settlement response header (base64-encoded per x402 spec)
-                const settlementBase64 = Buffer.from(JSON.stringify(settlement)).toString('base64')
-                res.setHeader(X402_HEADERS.PAYMENT_RESPONSE, settlementBase64)
-
-                // Hook: after settlement
-                if (onAfterSettle) {
-                  return Promise.resolve(onAfterSettle(req, creditsToSettle, settlement)).then(
-                    () => settlement,
-                  )
-                }
-                return settlement
-              })
-          })
-
-          settlePromise
+          )
+            .then((creditsToSettle) => {
+              paymentContext.creditsToSettle = creditsToSettle
+              return payments.facilitator
+                .settlePermissions({
+                  paymentRequired,
+                  x402AccessToken: token,
+                  maxAmount: BigInt(creditsToSettle),
+                  agentRequestId: paymentContext.agentRequestId,
+                })
+                .then((settlement) => {
+                  // Only attach the receipt header if headers haven't flushed
+                  // yet — streaming responses fire writeHead on the first
+                  // chunk and may have already sent them by the time we land
+                  // here.
+                  if (!res.headersSent) {
+                    const settlementBase64 = Buffer.from(JSON.stringify(settlement)).toString(
+                      'base64',
+                    )
+                    res.setHeader(X402_HEADERS.PAYMENT_RESPONSE, settlementBase64)
+                  } else {
+                    console.warn(
+                      '[paymentMiddleware] headers already flushed; payment-response receipt not attached',
+                    )
+                  }
+                  if (onAfterSettle) {
+                    return Promise.resolve(onAfterSettle(req, creditsToSettle, settlement)).then(
+                      () => {},
+                    )
+                  }
+                  return undefined
+                })
+            })
             .catch((settleError) => {
               console.error('Payment settlement failed:', settleError)
-              // Still send response even if settlement fails
             })
-            .finally(() => {
-              // Send the actual response after settlement completes
-              originalJson(body)
-            })
-
-          // Return res for chaining (Express pattern)
-          return res
         }
+
+        ;(res as unknown as { end: Response['end'] }).end = function (
+          this: Response,
+          ...args: Parameters<Response['end']>
+        ): Response {
+          // Don't bill for client/server error responses. The handler is
+          // signalling failure, and `payment-required` errors return a 4xx
+          // through sendPaymentRequired which also lands here.
+          if (settlementStarted || res.statusCode >= 400) {
+            return originalEnd(...args)
+          }
+          settlementStarted = true
+
+          // If the handler streamed before calling end, headers were already
+          // flushed. Settle anyway (so we still charge the card) but accept
+          // we cannot inject the receipt header.
+          if (res.headersSent) {
+            void runSettlement()
+            return originalEnd(...args)
+          }
+
+          // Buffered response path: defer the real `end` until settlement
+          // finishes so the receipt header makes it into the same response.
+          runSettlement().finally(() => {
+            originalEnd(...args)
+          })
+          return res
+        } as Response['end']
 
         // Continue to route handler
         next()

--- a/src/x402/express/middleware.ts
+++ b/src/x402/express/middleware.ts
@@ -400,7 +400,7 @@ export function paymentMiddleware(
                   }
                   if (onAfterSettle) {
                     return Promise.resolve(onAfterSettle(req, creditsToSettle, settlement)).then(
-                      () => {},
+                      () => undefined,
                     )
                   }
                   return undefined

--- a/src/x402/express/middleware.ts
+++ b/src/x402/express/middleware.ts
@@ -415,10 +415,12 @@ export function paymentMiddleware(
           this: Response,
           ...args: Parameters<Response['end']>
         ): Response {
-          // Don't bill for client/server error responses. The handler is
-          // signalling failure, and `payment-required` errors return a 4xx
-          // through sendPaymentRequired which also lands here.
-          if (settlementStarted || res.statusCode >= 400) {
+          // Only bill on 2xx success. Skipping 3xx avoids charging when the
+          // handler redirects (e.g. `res.redirect(...)`), 304 Not Modified,
+          // etc. Skipping 4xx/5xx avoids charging when the handler signals
+          // failure — including `sendPaymentRequired`'s 402 which lands here.
+          const isSuccess = res.statusCode >= 200 && res.statusCode < 300
+          if (settlementStarted || !isSuccess) {
             return originalEnd(...args)
           }
           settlementStarted = true

--- a/tests/unit/x402-middleware-settlement.test.ts
+++ b/tests/unit/x402-middleware-settlement.test.ts
@@ -9,25 +9,17 @@
  * regardless of how the handler responds.
  */
 
-import { EventEmitter } from 'events'
 import express from 'express'
 import type { Request, Response } from 'express'
 import http from 'http'
-import {
-  paymentMiddleware,
-  X402_HEADERS,
-} from '../../src/x402/express/index.js'
+import { paymentMiddleware, X402_HEADERS } from '../../src/x402/express/index.js'
 
 // Use the same mock token shape the rest of the test suite uses so the
 // middleware's verify call gets past the shape checks.
 const MOCK_TOKEN = 'mock-x402-token'
 
 // Minimal stub of the Payments API surface the middleware reaches into.
-function buildMockPayments(opts: {
-  scheme?: string
-  settleSpy: jest.Mock
-  verifySpy?: jest.Mock
-}) {
+function buildMockPayments(opts: { settleSpy: jest.Mock; verifySpy?: jest.Mock }) {
   const verify =
     opts.verifySpy ??
     jest.fn().mockResolvedValue({ isValid: true, agentRequest: undefined, agentRequestId: 'req-1' })
@@ -89,7 +81,8 @@ async function postWithToken(port: number): Promise<{
           resolve({
             status: res.statusCode ?? 0,
             body: Buffer.concat(chunks).toString(),
-            paymentResponseHeader: (res.headers[X402_HEADERS.PAYMENT_RESPONSE] as string) ?? undefined,
+            paymentResponseHeader:
+              (res.headers[X402_HEADERS.PAYMENT_RESPONSE] as string) ?? undefined,
           })
         })
       },

--- a/tests/unit/x402-middleware-settlement.test.ts
+++ b/tests/unit/x402-middleware-settlement.test.ts
@@ -183,4 +183,22 @@ describe('paymentMiddleware settlement coverage (#1728)', () => {
       await close()
     }
   })
+
+  test('does NOT settle when handler redirects (3xx)', async () => {
+    // Regression for #359 review: the old res.json-only interception never
+    // fired on res.redirect(...); the res.end wrapper must keep that
+    // behaviour and skip 3xx so a redirect doesn't burn credits.
+    const settleSpy = jest.fn().mockResolvedValue(baseSettlement)
+    const { port, close } = await startServer((req, res) => {
+      res.redirect(302, '/elsewhere')
+    }, settleSpy)
+
+    try {
+      const result = await postWithToken(port)
+      expect(result.status).toBe(302)
+      expect(settleSpy).not.toHaveBeenCalled()
+    } finally {
+      await close()
+    }
+  })
 })

--- a/tests/unit/x402-middleware-settlement.test.ts
+++ b/tests/unit/x402-middleware-settlement.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Unit tests for the x402 paymentMiddleware settlement hook.
+ *
+ * Regression coverage for #1728: settlement used to be wired through a
+ * `res.json` monkey-patch only, so handlers responding with `res.send`,
+ * `res.sendFile`, `res.end`, or a stream pipe delivered the resource
+ * without burning credits. The current implementation wraps `res.end`
+ * (the common terminator for all response methods) so settlement runs
+ * regardless of how the handler responds.
+ */
+
+import { EventEmitter } from 'events'
+import express from 'express'
+import type { Request, Response } from 'express'
+import http from 'http'
+import {
+  paymentMiddleware,
+  X402_HEADERS,
+} from '../../src/x402/express/index.js'
+
+// Use the same mock token shape the rest of the test suite uses so the
+// middleware's verify call gets past the shape checks.
+const MOCK_TOKEN = 'mock-x402-token'
+
+// Minimal stub of the Payments API surface the middleware reaches into.
+function buildMockPayments(opts: {
+  scheme?: string
+  settleSpy: jest.Mock
+  verifySpy?: jest.Mock
+}) {
+  const verify =
+    opts.verifySpy ??
+    jest.fn().mockResolvedValue({ isValid: true, agentRequest: undefined, agentRequestId: 'req-1' })
+  return {
+    facilitator: {
+      verifyPermissions: verify,
+      settlePermissions: opts.settleSpy,
+    },
+    getEnvironmentName: () => 'staging_sandbox',
+    plans: { getPlan: jest.fn().mockResolvedValue({ registry: { price: { isCrypto: false } } }) },
+  } as any
+}
+
+async function startServer(handler: (req: Request, res: Response) => void, settleSpy: jest.Mock) {
+  const app = express()
+  app.use(express.json())
+  app.use(
+    paymentMiddleware(buildMockPayments({ settleSpy }), {
+      'POST /protected': { planId: '12345', credits: 1, scheme: 'nvm:card-delegation' },
+    }),
+  )
+  app.post('/protected', handler)
+
+  const server = http.createServer(app)
+  await new Promise<void>((r) => server.listen(0, r))
+  const address = server.address()
+  const port = typeof address === 'object' && address ? address.port : 0
+  return {
+    server,
+    port,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  }
+}
+
+async function postWithToken(port: number): Promise<{
+  status: number
+  body: string
+  paymentResponseHeader: string | undefined
+}> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: '/protected',
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          [X402_HEADERS.PAYMENT_SIGNATURE]: MOCK_TOKEN,
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', (c: Buffer) => chunks.push(c))
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString(),
+            paymentResponseHeader: (res.headers[X402_HEADERS.PAYMENT_RESPONSE] as string) ?? undefined,
+          })
+        })
+      },
+    )
+    req.on('error', reject)
+    req.end(JSON.stringify({ ask: 'hello' }))
+  })
+}
+
+describe('paymentMiddleware settlement coverage (#1728)', () => {
+  const baseSettlement = {
+    success: true,
+    creditsRedeemed: '1',
+    orderTx: '0xabc',
+  }
+
+  test('settles when handler uses res.json', async () => {
+    const settleSpy = jest.fn().mockResolvedValue(baseSettlement)
+    const { port, close } = await startServer((req, res) => {
+      res.json({ ok: true })
+    }, settleSpy)
+
+    try {
+      const result = await postWithToken(port)
+      expect(result.status).toBe(200)
+      expect(settleSpy).toHaveBeenCalledTimes(1)
+      expect(result.paymentResponseHeader).toBeDefined()
+    } finally {
+      await close()
+    }
+  })
+
+  test('settles when handler uses res.send', async () => {
+    const settleSpy = jest.fn().mockResolvedValue(baseSettlement)
+    const { port, close } = await startServer((req, res) => {
+      res.send('plain text body')
+    }, settleSpy)
+
+    try {
+      const result = await postWithToken(port)
+      expect(result.status).toBe(200)
+      expect(result.body).toBe('plain text body')
+      expect(settleSpy).toHaveBeenCalledTimes(1)
+      expect(result.paymentResponseHeader).toBeDefined()
+    } finally {
+      await close()
+    }
+  })
+
+  test('settles when handler uses res.end directly', async () => {
+    const settleSpy = jest.fn().mockResolvedValue(baseSettlement)
+    const { port, close } = await startServer((req, res) => {
+      res.status(200).end('raw end body')
+    }, settleSpy)
+
+    try {
+      const result = await postWithToken(port)
+      expect(result.status).toBe(200)
+      expect(result.body).toBe('raw end body')
+      expect(settleSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      await close()
+    }
+  })
+
+  test('settles when handler streams via res.write + res.end', async () => {
+    const settleSpy = jest.fn().mockResolvedValue(baseSettlement)
+    const { port, close } = await startServer((req, res) => {
+      res.setHeader('content-type', 'text/plain')
+      res.write('chunk-1')
+      res.write('-chunk-2')
+      res.end()
+    }, settleSpy)
+
+    try {
+      const result = await postWithToken(port)
+      expect(result.status).toBe(200)
+      expect(result.body).toBe('chunk-1-chunk-2')
+      // Headers were flushed before settlement so the receipt cannot be
+      // attached, but settlement MUST still run so the buyer is billed.
+      expect(settleSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      await close()
+    }
+  })
+
+  test('does NOT settle when handler returns 4xx', async () => {
+    const settleSpy = jest.fn().mockResolvedValue(baseSettlement)
+    const { port, close } = await startServer((req, res) => {
+      res.status(422).send({ error: 'bad shape' })
+    }, settleSpy)
+
+    try {
+      const result = await postWithToken(port)
+      expect(result.status).toBe(422)
+      expect(settleSpy).not.toHaveBeenCalled()
+    } finally {
+      await close()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Bundles the payments SDK fixes for [nevermined-io/nvm-monorepo#1724](https://github.com/nevermined-io/nvm-monorepo/issues/1724).

- **F4 (nvm-monorepo#1728) — settlement on every response method**: \`paymentMiddleware\` now wraps \`res.end\` (the common terminator for every Express response method) instead of only \`res.json\`, so settlement runs for \`res.send\`, \`res.sendFile\`, \`res.end\`, and stream pipes too. Previously a handler responding via any non-json method delivered the protected resource without burning credits. The receipt header is still attached on buffered responses; streamed responses emit a warning when headers were already flushed before settlement landed.
- **F3 (nvm-monorepo#1727) — JSON safety**: adds \`safeParseJson\` in \`common/helper.ts\`. It consumes the body once, tolerates non-JSON gateway pages (HTML 5xx), and returns a \`{ message }\` shell instead of letting a SyntaxError escape. Applied to error paths in \`agents-api.ts\`, \`plans-api.ts\`, \`requests-api.ts\` that previously ran \`.json()\` outside any try/catch.
- **F9 (nvm-monorepo#1733) — \`getFiatPriceConfig\` unit doc**: explicit JSDoc on both the standalone helper and the \`PlansAPI\` wrapper, calling out 6-decimal USDC units (NOT cents) and the \$1.00 minimum.
- **F11 (nvm-monorepo#1735) — quickstart \`delegationConfig\`**: \`markdown/x402.md\` now shows the \`delegationConfig\` argument; the old "planId + agentId" shape fails at runtime on erc4337 plans.

## Test plan

- [x] \`pnpm build\` — TypeScript compiles
- [x] \`pnpm test:unit\` — 154/155 pass (1 pre-existing skip), including the new \`tests/unit/x402-middleware-settlement.test.ts\` (5/5)
- [ ] Smoke against staging once nvm-monorepo PR is deployed: \`res.send\` from a protected handler now burns credits and emits \`payment-response\`
- [ ] Smoke against a non-JSON 5xx response — SDK throws a typed \`PaymentsError\`, not a SyntaxError
- [ ] Quickstart copy-paste runs end-to-end against staging for crypto and fiat plans

Closes nvm-monorepo#1727, nvm-monorepo#1728, nvm-monorepo#1733, nvm-monorepo#1735.