### PR TITLE
fix(cli): #1816 repoint card flows to the standalone embed app

### DIFF
--- a/cli/src/commands/cards/delegate.ts
+++ b/cli/src/commands/cards/delegate.ts
@@ -9,7 +9,8 @@ import {
 
 /**
  * Single-purpose delegation creation. Opens the chromeless
- * `/embed/cards/delegate?paymentMethodId=<id>` page where the user
+ * `/cards/delegate?paymentMethodId=<id>` page of the standalone embed
+ * app (`embed.<tier>`) where the user
  * fills in spending limit / duration / max-transactions and submits;
  * the resulting `delegationId` is redirected back to a localhost
  * callback.
@@ -64,8 +65,8 @@ export default class CardsDelegate extends BaseCommand {
       }
 
       const result = await runWidgetRedirectFlow({
-        frontendUrl: env.frontend,
-        embedPath: '/embed/cards/delegate',
+        embedUrl: env.embed,
+        embedPath: '/cards/delegate',
         mintSession: async ({ returnUrl }) => {
           const session = await mintSelfWidgetSession({
             backendUrl: env.backend,

--- a/cli/src/commands/cards/enroll.ts
+++ b/cli/src/commands/cards/enroll.ts
@@ -9,7 +9,8 @@ import {
 
 /**
  * Single-purpose card enrolment. Opens the chromeless
- * `/embed/cards/enroll` page in the browser, completes the
+ * `/cards/enroll` page of the standalone embed app (`embed.<tier>`)
+ * in the browser, completes the
  * tokenization step against the chosen provider, and redirects the
  * resulting `paymentMethodId` back to a localhost callback.
  *
@@ -65,8 +66,8 @@ export default class CardsEnroll extends BaseCommand {
       }
 
       const result = await runWidgetRedirectFlow({
-        frontendUrl: env.frontend,
-        embedPath: '/embed/cards/enroll',
+        embedUrl: env.embed,
+        embedPath: '/cards/enroll',
         mintSession: async ({ returnUrl }) => {
           const session = await mintSelfWidgetSession({
             backendUrl: env.backend,

--- a/cli/src/commands/cards/setup.ts
+++ b/cli/src/commands/cards/setup.ts
@@ -9,7 +9,8 @@ import {
 
 /**
  * Combined "set up a card for agent spend" flow. Opens the user's
- * browser at the chromeless `/embed/cards/setup` page, where they
+ * browser at the chromeless `/cards/setup` page of the standalone embed
+ * app (`embed.<tier>`), where they
  * enrol a card and create a spending delegation in one session, and
  * receives `paymentMethodId` + `delegationId` back at a localhost
  * callback the CLI starts for the duration of the flow.
@@ -80,8 +81,8 @@ export default class CardsSetup extends BaseCommand {
       }
 
       const result = await runWidgetRedirectFlow({
-        frontendUrl: env.frontend,
-        embedPath: '/embed/cards/setup',
+        embedUrl: env.embed,
+        embedPath: '/cards/setup',
         // Mint AFTER the local server binds — `runWidgetRedirectFlow`
         // gives us the actual returnUrl so the backend can validate it
         // at session-creation time (per the documented `isReturnUrlAllowed`

--- a/cli/src/utils/widget-redirect-flow.ts
+++ b/cli/src/utils/widget-redirect-flow.ts
@@ -31,11 +31,11 @@ function safeEqualHexState(received: string, expected: string): boolean {
 }
 
 export interface WidgetRedirectFlowOptions {
-  /** Frontend base URL — e.g. `Environments[env].frontend`. */
-  frontendUrl: string
+  /** Embed app base URL — e.g. `Environments[env].embed` (`embed.<tier>`). */
+  embedUrl: string
   /**
-   * Relative embed path the CLI wants to open, e.g.
-   * `/embed/cards/setup` or `/embed/cards/enroll`.
+   * Relative path on the embed app the CLI wants to open, e.g.
+   * `/cards/setup` or `/cards/enroll`.
    */
   embedPath: string
   /**
@@ -68,7 +68,8 @@ export interface WidgetRedirectFlowResult {
 
 /**
  * Shared redirect-mode handshake for any CLI command that hands the user
- * off to an `/embed/*` page and waits for a localhost callback.
+ * off to a `/cards/*` page on the standalone embed app (`embed.<tier>`)
+ * and waits for a localhost callback.
  *
  * Flow:
  *   1. Bind a one-shot HTTP server on `127.0.0.1:0` (the OS picks a free port).
@@ -80,7 +81,7 @@ export interface WidgetRedirectFlowResult {
  *      `127.0.0.1` and Node 17+ resolves `localhost` to `::1` first on
  *      modern hosts — the browser would stall on the IPv6 attempt before
  *      falling back to IPv4.
- *   3. Open the browser at `{frontend}/embed/<path>?sessionToken=…&returnUrl=…&state=<rand>`.
+ *   3. Open the browser at `{embed}/<path>?sessionToken=…&returnUrl=…&state=<rand>`.
  *   4. Resolve when the embed page redirects to `/callback?…&state=<echo>`.
  *      `state` is compared in constant time.
  *
@@ -181,7 +182,7 @@ export async function runWidgetRedirectFlow(
         }
 
         const browserUrl = buildEmbedUrl({
-          frontendUrl: opts.frontendUrl,
+          embedUrl: opts.embedUrl,
           embedPath: opts.embedPath,
           sessionToken,
           returnUrl,
@@ -210,7 +211,7 @@ export async function runWidgetRedirectFlow(
 }
 
 interface BuildEmbedUrlOptions {
-  frontendUrl: string
+  embedUrl: string
   embedPath: string
   sessionToken: string
   returnUrl: string
@@ -219,7 +220,7 @@ interface BuildEmbedUrlOptions {
 }
 
 function buildEmbedUrl(opts: BuildEmbedUrlOptions): string {
-  const url = new URL(opts.embedPath, opts.frontendUrl)
+  const url = new URL(opts.embedPath, opts.embedUrl)
   url.searchParams.set('sessionToken', opts.sessionToken)
   url.searchParams.set('returnUrl', opts.returnUrl)
   url.searchParams.set('state', opts.state)

--- a/cli/test/unit/widget-redirect-flow.test.ts
+++ b/cli/test/unit/widget-redirect-flow.test.ts
@@ -75,8 +75,8 @@ describe('runWidgetRedirectFlow', () => {
       resolved: false,
     }
     flow.promise = runWidgetRedirectFlow({
-      frontendUrl: 'http://frontend.test',
-      embedPath: opts.embedPath ?? '/embed/cards/setup',
+      embedUrl: 'http://embed.test',
+      embedPath: opts.embedPath ?? '/cards/setup',
       mintSession: opts.mintSession ?? (async () => ({ sessionToken: 'tok_abc' })),
       log: (msg: string) => logs.push(msg),
       noBrowser: true,
@@ -169,7 +169,7 @@ describe('runWidgetRedirectFlow', () => {
   })
 
   test('returns 404 for any path other than /callback (server is single-purpose)', async () => {
-    const flow = startFlow({ embedPath: '/embed/cards/enroll' })
+    const flow = startFlow({ embedPath: '/cards/enroll' })
     const { returnUrl } = await flow.returnUrlPromise
     const notCallback = new URL(returnUrl)
     notCallback.pathname = '/other'

--- a/markdown/cli-card-setup.md
+++ b/markdown/cli-card-setup.md
@@ -6,7 +6,7 @@ icon: "browser"
 
 # CLI Card Setup (Top-Level Redirect Flow)
 
-The Nevermined webapp ships a chromeless **card setup** page at `/embed/cards/setup` that walks a user through:
+Nevermined ships a standalone embed app (served at `embed.<tier>` — e.g. `embed.nevermined.app`) with a chromeless **card setup** page at `/cards/setup` that walks a user through:
 
 1. Enrolling a credit / debit card (via Stripe Elements — sensitive data never touches your servers).
 2. Creating a spending delegation against that card (a per-card budget the user pre-authorises for agent spend).
@@ -21,7 +21,7 @@ The official `nvm` CLI ships three commands implementing this flow out of the bo
 - You want a **white-labeled** card setup page that respects the parent organisation's branding (logo, panel colours, button colours), but you do not want to host an iframe.
 - You need both the `paymentMethodId` and the `delegationId` in one round-trip — the combined `setup` flow emits both in a single callback.
 
-For the classic iframe integration (a website embedding `/embed/cards/enroll` etc. inside an `<iframe>` and listening for `postMessage`), see the `@nevermined-io/ui-widgets` package instead.
+For the classic iframe integration (a website embedding `/cards/enroll` etc. inside an `<iframe>` and listening for `postMessage`), see the `@nevermined-io/ui-widgets` package instead.
 
 ## Two Authentication Paths
 
@@ -53,7 +53,7 @@ Card setup is **organization-scoped**. Self-mint callers must be members of at l
    │◀────────────────────────────────────┤ { sessionToken, isReturnUrlAllowed }      │                                     │
    │                                      │                                           │                                     │
    │ open browser at                      │                                           │                                     │
-   │ {frontend}/embed/cards/setup         │                                           │                                     │
+   │ {embed}/cards/setup                  │                                           │                                     │
    │  ?sessionToken=...                   │                                           │                                     │
    │  &returnUrl=http://127.0.0.1:<port>  │                                           │                                     │
    │  &state=<rand>  &provider=stripe     │                                           │                                     │
@@ -170,8 +170,10 @@ For the **widget-key** path, see the existing `POST /widgets/session` documentat
 Construct the URL and open it (`xdg-open` / `open` / `start`):
 
 ```
-{frontend}/embed/cards/setup?sessionToken=<token>&returnUrl=<urlEncoded callback>&state=<random>&provider=stripe
+{embed}/cards/setup?sessionToken=<token>&returnUrl=<urlEncoded callback>&state=<random>&provider=stripe
 ```
+
+`{embed}` is the standalone embed app origin for your environment (`https://embed.nevermined.app` for live/sandbox, `https://embed.nevermined.dev` for staging) — formed by prepending `embed.` to the webapp host.
 
 Required query parameters:
 - `sessionToken` — from step 2.
@@ -183,9 +185,9 @@ Three other routes exist if you only need one step of the flow:
 
 | Route | Result fields in the callback |
 |-------|--------------------------------|
-| `/embed/cards/setup` | `paymentMethodId`, `delegationId` |
-| `/embed/cards/enroll` | `paymentMethodId` |
-| `/embed/cards/delegate?paymentMethodId=<id>` | `delegationId` |
+| `/cards/setup` | `paymentMethodId`, `delegationId` |
+| `/cards/enroll` | `paymentMethodId` |
+| `/cards/delegate?paymentMethodId=<id>` | `delegationId` |
 
 ### 4. Wait for the callback
 
@@ -252,7 +254,7 @@ server.listen(0, '127.0.0.1', async () => {
     body: JSON.stringify({ orgId, returnUrl }),
   }).then((r) => r.json())
 
-  const setupUrl = new URL('/embed/cards/setup', 'https://nevermined.app')
+  const setupUrl = new URL('/cards/setup', 'https://embed.nevermined.app')
   setupUrl.searchParams.set('sessionToken', mint.sessionToken)
   setupUrl.searchParams.set('returnUrl', returnUrl)
   setupUrl.searchParams.set('state', state)

--- a/src/environments.ts
+++ b/src/environments.ts
@@ -1,5 +1,13 @@
 export interface EnvironmentInfo {
   frontend: string
+  /**
+   * Base URL of the standalone, Privy-free embed app (the `embed.<tier>`
+   * origin that serves the chromeless `/cards/*` and `/checkout/*` pages).
+   * Formed by prepending `embed.` to the webapp host. The CLI redirect-mode
+   * card flows open `${embed}/cards/setup` here — the old webapp
+   * `/embed/cards/*` routes were removed in the #1787 cutover.
+   */
+  embed: string
   backend: string
   proxy: string
   heliconeUrl: string
@@ -18,12 +26,14 @@ export const Environments: Record<EnvironmentName, EnvironmentInfo> = {
    */
   staging_sandbox: {
     frontend: 'https://nevermined.dev',
+    embed: 'https://embed.nevermined.dev',
     backend: 'https://api.sandbox.nevermined.dev/',
     proxy: 'https://proxy.sandbox.nevermined.dev',
     heliconeUrl: 'https://helicone.nevermined.dev',
   },
   staging_live: {
     frontend: 'https://nevermined.dev',
+    embed: 'https://embed.nevermined.dev',
     backend: 'https://api.live.nevermined.dev/',
     proxy: 'https://proxy.live.nevermined.dev',
     heliconeUrl: 'https://helicone.nevermined.dev',
@@ -33,6 +43,7 @@ export const Environments: Record<EnvironmentName, EnvironmentInfo> = {
    */
   sandbox: {
     frontend: 'https://nevermined.app',
+    embed: 'https://embed.nevermined.app',
     backend: 'https://api.sandbox.nevermined.app/',
     proxy: 'https://proxy.sandbox.nevermined.app',
     heliconeUrl: 'https://helicone.nevermined.dev',
@@ -42,6 +53,7 @@ export const Environments: Record<EnvironmentName, EnvironmentInfo> = {
    */
   live: {
     frontend: 'https://nevermined.app',
+    embed: 'https://embed.nevermined.app',
     backend: 'https://api.live.nevermined.app/',
     proxy: 'https://proxy.live.nevermined.app',
     heliconeUrl: 'https://helicone.nevermined.dev',
@@ -51,6 +63,7 @@ export const Environments: Record<EnvironmentName, EnvironmentInfo> = {
    */
   custom: {
     frontend: process.env.NVM_FRONTEND_URL || 'http://localhost:4200',
+    embed: process.env.NVM_EMBED_URL || process.env.NVM_FRONTEND_URL || 'http://localhost:4200',
     backend: process.env.NVM_BACKEND_URL || 'http://localhost:3001',
     proxy: process.env.NVM_PROXY_URL || 'https://localhost:443',
     heliconeUrl: process.env.HELICONE_URL || 'http://localhost:8585',

--- a/src/environments.ts
+++ b/src/environments.ts
@@ -63,7 +63,12 @@ export const Environments: Record<EnvironmentName, EnvironmentInfo> = {
    */
   custom: {
     frontend: process.env.NVM_FRONTEND_URL || 'http://localhost:4200',
-    embed: process.env.NVM_EMBED_URL || process.env.NVM_FRONTEND_URL || 'http://localhost:4200',
+    // No fallback to NVM_FRONTEND_URL: the webapp host no longer serves
+    // the card pages post-#1787 cutover, so silently reusing it would
+    // reintroduce a dead-route footgun. The embed app runs on its own
+    // port (4250, matching nvm-monorepo#1824); set NVM_EMBED_URL to
+    // override.
+    embed: process.env.NVM_EMBED_URL || 'http://localhost:4250',
     backend: process.env.NVM_BACKEND_URL || 'http://localhost:3001',
     proxy: process.env.NVM_PROXY_URL || 'https://localhost:443',
     heliconeUrl: process.env.HELICONE_URL || 'http://localhost:8585',


### PR DESCRIPTION
Closes nevermined-io/nvm-monorepo#1816 (and part of the #1787 dedicated Privy-free embed app).

> Cross-repo `Closes` does not auto-close on merge — the linked issue will need to be closed manually once this lands and the staging E2E check below is done.

## Context

The non-iframe, top-level **redirect/CLI** card-enrollment flow (PR #355) opened the webapp's chromeless `/embed/cards/*` pages. Those routes were **removed** in the #1787 cutover that extracted the embed into a dedicated, Privy-free app served at its own origin (`embed.<tier>`), so the old URLs no longer exist. This repoints the CLI to the new app.

## Changes

- **SDK — `src/environments.ts`**: add an `embed` field to `EnvironmentInfo`, formed by prepending `embed.` to the webapp host:
  - `sandbox` / `live` → `https://embed.nevermined.app`
  - `staging_sandbox` / `staging_live` → `https://embed.nevermined.dev`
  - `custom` → `$NVM_EMBED_URL || http://localhost:4250` (no fallback to the webapp host — that's the dead route the cutover removed; `4250` matches the embed app's local port in nvm-monorepo#1824)
- **CLI — `cards setup` / `enroll` / `delegate`**: open `${embed}/cards/*` instead of `${frontend}/embed/cards/*`.
- **CLI — `widget-redirect-flow.ts`**: rename the helper option `frontendUrl` → `embedUrl`; update comments.
- **Docs / tests**: update `markdown/cli-card-setup.md` and the redirect-flow unit test to the new origin and `/cards/*` paths.

The `nvm login` (`/auth/cli`) flow still targets the webapp `frontend` — unchanged.

## Validation

- `pnpm build` (SDK): compiles. `pnpm test:unit` (SDK): 155 tests green.
- CLI compiled against the local SDK (symlink, as CI does); CI gate green: `test:unit` (10) + `test:integration` (28); `widget-redirect-flow` suite (4).
- OpenClaw unaffected — it doesn't use the `embed` URL or card flows.
- Docs structure validation (`generate-docs.sh`) passes.

## Note on versioning

Adding a required `embed` field to the public `EnvironmentInfo` interface is a TS breaking change for any consumer constructing one directly. Release should be dispatched as a **minor** bump with a changelog note ("direct `EnvironmentInfo` constructors now need an `embed` field"). `CHANGELOG.md` / `package.json` left untouched here since the release flow regenerates/bumps them.

## Remaining (task 2 of the issue)

End-to-end validation on staging with the real CLI (self-mint → top-level redirect to `embed.nevermined.dev/cards/setup` → localhost `returnUrl` callback) depends on the embed app being deployed per tier and must be done manually before closing the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)