### PR TITLE
feat: add provider filter to listPaymentMethods

### DIFF
--- a/markdown/x402.md
+++ b/markdown/x402.md
@@ -232,8 +232,13 @@ import { DelegationAPI, PaymentMethodSummary } from '@nevermined-io/payments'
 
 const delegationApi = DelegationAPI.getInstance(payments.options)
 
-// List enrolled payment methods
+// List enrolled payment methods (every provider)
 const methods: PaymentMethodSummary[] = await delegationApi.listPaymentMethods()
+
+// Restrict the result to a single provider with the optional `provider` filter
+const stripeMethods: PaymentMethodSummary[] = await delegationApi.listPaymentMethods({
+  provider: 'stripe',
+})
 
 for (const method of methods) {
   console.log(`${method.brand} ****${method.last4} (expires ${method.expMonth}/${method.expYear})`)
@@ -242,6 +247,13 @@ for (const method of methods) {
   }
 }
 ```
+
+`listPaymentMethods` accepts an optional `ListOptions`:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `provider` | `DelegationProvider` (`'stripe' \| 'braintree' \| 'visa' \| 'erc4337'`) | Server-side filter that restricts the result to payment methods backed by this provider. Omit it (the default) to return methods from every provider. |
+| `accessible` | `boolean` | When `true`, return only methods accessible to the requesting API key. |
 
 #### Update Payment Method
 

--- a/src/x402/delegation-api.ts
+++ b/src/x402/delegation-api.ts
@@ -114,6 +114,13 @@ export interface UpdatePaymentMethodDto {
 export interface ListOptions {
   /** When true, return only items accessible to the requesting API key */
   accessible?: boolean
+  /**
+   * Restrict the result to payment methods backed by this provider
+   * (e.g. `'stripe'`). Server-side filter for
+   * {@link DelegationAPI.listPaymentMethods}; omit to return methods from every
+   * provider (default). Has no effect on {@link DelegationAPI.listDelegations}.
+   */
+  provider?: DelegationProvider
 }
 
 /**
@@ -127,10 +134,13 @@ export class DelegationAPI extends BasePaymentsAPI {
   /**
    * List the user's enrolled payment methods for card delegation.
    * When `accessible: true`, only cards accessible to the requesting API key are returned.
+   * When `provider` is set, only methods backed by that provider are returned
+   * (server-side filter); omit it to return methods from every provider.
    */
   async listPaymentMethods(options?: ListOptions): Promise<PaymentMethodSummary[]> {
     const url = new URL('/api/v1/payment-methods', this.environment.backend)
     if (options?.accessible) url.searchParams.set('accessible', 'true')
+    if (options?.provider) url.searchParams.set('provider', options.provider)
     return this.fetchJSON(url, 'GET', 'list payment methods')
   }
 

--- a/tests/unit/delegation-list-payment-methods-filter.test.ts
+++ b/tests/unit/delegation-list-payment-methods-filter.test.ts
@@ -9,9 +9,13 @@
 import { Payments } from '../../src/payments.js'
 import type { PaymentMethodSummary } from '../../src/x402/delegation-api.js'
 
+// The test mocks global.fetch (installFetch), so this key is never transmitted.
+// It only has to satisfy `decodeJwt` in Payments.getInstance (reads `sub`/`o11y`,
+// no signature/expiry check), so the fallback is a structurally-valid JWT with
+// dummy claims — a zero-address subject and a fake signature — NOT a live token.
 const TEST_API_KEY =
   process.env.TEST_PROXY_BEARER_TOKEN ||
-  'sandbox-staging:eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweDU4MzhCNTUxMmNGOWYxMkZFOWYyYmVjY0IyMGViNDcyMTFGOUIwYmMiLCJzdWIiOiIweDIxRjc5ZjlkM2I2ZDUyZUY4Y2M4QjFhN0YyNjFCY2Y1ZjJFRjM1NGEiLCJqdGkiOiIweGUxMjIwMmRkMzZlZmQ4N2FkMjE1MmRlMjlkM2MwNmE5ZDU5N2M4NWJhOGMxOTQ1YjQ5MjlkYTYyYTRiZjQ1NGYiLCJleHAiOjE3OTEwNDc0OTcsIm8xMXkiOiJzay1oZWxpY29uZS13amUzYXdpLW5ud2V5M2EtdzdndnY3YS1oYmh3bm1pIn0.JI14qfSWHCWRvHOK9TAg3HEXWX7oKEI6fU6gaaWlyDl5btBWLh8FQo1ZnuzixPmgsUR3gc4oRlenLPUuTy-mORw'
+  'sandbox-staging:eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiIweDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAiLCJzdWIiOiIweDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAiLCJqdGkiOiIweDAiLCJleHAiOjk5OTk5OTk5OTksIm8xMXkiOiJ0ZXN0LW8xMXkta2V5In0.test-signature'
 
 interface CapturedCall {
   url: string

--- a/tests/unit/delegation-list-payment-methods-filter.test.ts
+++ b/tests/unit/delegation-list-payment-methods-filter.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for the optional `provider` filter on
+ * `payments.delegation.listPaymentMethods({ provider })`.
+ *
+ * The SDK forwards the provider as a `?provider=` query string when set, and
+ * omits it entirely otherwise (preserving the default "all methods" behaviour).
+ * Depends on the backend `?provider=` filter (nevermined-io/nvm-monorepo#1715).
+ */
+import { Payments } from '../../src/payments.js'
+import type { PaymentMethodSummary } from '../../src/x402/delegation-api.js'
+
+const TEST_API_KEY =
+  process.env.TEST_PROXY_BEARER_TOKEN ||
+  'sandbox-staging:eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweDU4MzhCNTUxMmNGOWYxMkZFOWYyYmVjY0IyMGViNDcyMTFGOUIwYmMiLCJzdWIiOiIweDIxRjc5ZjlkM2I2ZDUyZUY4Y2M4QjFhN0YyNjFCY2Y1ZjJFRjM1NGEiLCJqdGkiOiIweGUxMjIwMmRkMzZlZmQ4N2FkMjE1MmRlMjlkM2MwNmE5ZDU5N2M4NWJhOGMxOTQ1YjQ5MjlkYTYyYTRiZjQ1NGYiLCJleHAiOjE3OTEwNDc0OTcsIm8xMXkiOiJzay1oZWxpY29uZS13amUzYXdpLW5ud2V5M2EtdzdndnY3YS1oYmh3bm1pIn0.JI14qfSWHCWRvHOK9TAg3HEXWX7oKEI6fU6gaaWlyDl5btBWLh8FQo1ZnuzixPmgsUR3gc4oRlenLPUuTy-mORw'
+
+interface CapturedCall {
+  url: string
+  init?: RequestInit
+}
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+describe('listPaymentMethods provider filter', () => {
+  let originalFetch: typeof fetch
+  let calls: CapturedCall[]
+  let payments: Payments
+
+  const stripeCard: PaymentMethodSummary = {
+    id: 'pm_1abc',
+    type: 'card',
+    brand: 'visa',
+    last4: '4242',
+    expMonth: 12,
+    expYear: 27,
+    alias: 'Personal',
+    provider: 'stripe',
+    status: 'Active',
+    allowedApiKeyIds: null,
+  }
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+    calls = []
+    payments = Payments.getInstance({
+      nvmApiKey: TEST_API_KEY,
+      environment: 'staging_sandbox',
+    })
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  const installFetch = (handler: (call: CapturedCall) => Response | Promise<Response>): void => {
+    global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const call: CapturedCall = { url, init }
+      calls.push(call)
+      return handler(call)
+    }) as unknown as typeof fetch
+  }
+
+  test('forwards provider as a ?provider= query string when set', async () => {
+    installFetch(() => jsonResponse([stripeCard]))
+
+    const methods = await payments.delegation.listPaymentMethods({ provider: 'stripe' })
+
+    expect(calls).toHaveLength(1)
+    const url = new URL(calls[0].url)
+    expect(url.pathname).toContain('/api/v1/payment-methods')
+    expect(url.searchParams.get('provider')).toBe('stripe')
+    expect(methods).toEqual([stripeCard])
+  })
+
+  test('omits the provider query string when not set (default = all methods)', async () => {
+    installFetch(() => jsonResponse([stripeCard]))
+
+    await payments.delegation.listPaymentMethods()
+
+    expect(calls).toHaveLength(1)
+    expect(new URL(calls[0].url).searchParams.has('provider')).toBe(false)
+  })
+
+  test('combines provider with the accessible flag', async () => {
+    installFetch(() => jsonResponse([stripeCard]))
+
+    await payments.delegation.listPaymentMethods({ accessible: true, provider: 'braintree' })
+
+    const url = new URL(calls[0].url)
+    expect(url.searchParams.get('accessible')).toBe('true')
+    expect(url.searchParams.get('provider')).toBe('braintree')
+  })
+
+  test('forwards the erc4337 provider value', async () => {
+    installFetch(() => jsonResponse([]))
+
+    await payments.delegation.listPaymentMethods({ provider: 'erc4337' })
+
+    expect(new URL(calls[0].url).searchParams.get('provider')).toBe('erc4337')
+  })
+})


### PR DESCRIPTION
Part of nevermined-io/nvm-monorepo#1549. Backend: nevermined-io/nvm-monorepo#1715 (must land first).

Adds an optional `provider` to `ListOptions`; forwarded as the `?provider=` query param to the backend list-payment-methods endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)