### PR TITLE
feat(x402): send NVM API-key auth header on facilitator verify/settle

### DIFF
--- a/src/x402/facilitator-api.ts
+++ b/src/x402/facilitator-api.ts
@@ -390,7 +390,11 @@ export class FacilitatorAPI extends BasePaymentsAPI {
       body.maxAmount = maxAmount.toString()
     }
 
-    const options = this.getPublicHTTPOptions('POST', body)
+    // Send the NVM API-key auth header (Authorization: Bearer <nvmApiKey>).
+    // The backend /verify endpoint runs an OPTIONAL guard that tolerates the
+    // header's absence today, so this is non-breaking; it pre-positions for
+    // the later strict-guard flip. See nevermined-io/nvm-monorepo#1570.
+    const options = this.getBackendHTTPOptions('POST', body)
 
     try {
       const response = await fetch(url, options)
@@ -465,7 +469,11 @@ export class FacilitatorAPI extends BasePaymentsAPI {
       body.marginPercent = marginPercent
     }
 
-    const options = this.getPublicHTTPOptions('POST', body)
+    // Send the NVM API-key auth header (Authorization: Bearer <nvmApiKey>).
+    // The backend /settle endpoint runs an OPTIONAL guard that tolerates the
+    // header's absence today, so this is non-breaking; it pre-positions for
+    // the later strict-guard flip. See nevermined-io/nvm-monorepo#1570.
+    const options = this.getBackendHTTPOptions('POST', body)
 
     try {
       const response = await fetch(url, options)

--- a/tests/unit/x402-visa.test.ts
+++ b/tests/unit/x402-visa.test.ts
@@ -228,6 +228,49 @@ describe('Visa provider surface', () => {
     }
   })
 
+  // The facilitator verify/settle endpoints carry money side effects
+  // (Stripe/VGS/Braintree on settle), so the SDK now authenticates them with
+  // the NVM API key instead of calling them unauthenticated. The backend's
+  // optional guard tolerates the header today; this pre-positions for the
+  // later strict-guard flip. See nevermined-io/nvm-monorepo#1570.
+  test('verifyPermissions sends the NVM API-key authorization header', async () => {
+    installFetch(() => jsonResponse({ isValid: true }))
+
+    await payments.facilitator.verifyPermissions({
+      paymentRequired: {
+        x402Version: 2,
+        resource: { url: '/tools/echo' },
+        accepts: [{ scheme: 'nvm:card-delegation', network: 'visa', planId: 'plan-123' }],
+        extensions: {},
+      },
+      x402AccessToken: 'eyJ.visa.token',
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toContain('/api/v1/x402/verify')
+    const auth = (calls[0].init?.headers as Record<string, string> | undefined)?.Authorization
+    expect(auth).toBe(`Bearer ${TEST_API_KEY}`)
+  })
+
+  test('settlePermissions sends the NVM API-key authorization header', async () => {
+    installFetch(() => jsonResponse({ success: true }))
+
+    await payments.facilitator.settlePermissions({
+      paymentRequired: {
+        x402Version: 2,
+        resource: { url: '/tools/echo' },
+        accepts: [{ scheme: 'nvm:card-delegation', network: 'visa', planId: 'plan-123' }],
+        extensions: {},
+      },
+      x402AccessToken: 'eyJ.visa.token',
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toContain('/api/v1/x402/settle')
+    const auth = (calls[0].init?.headers as Record<string, string> | undefined)?.Authorization
+    expect(auth).toBe(`Bearer ${TEST_API_KEY}`)
+  })
+
   test("getInstance rejects scheme:'visa' with a migration message", () => {
     expect(() =>
       Payments.getInstance({

--- a/tests/unit/x402-visa.test.ts
+++ b/tests/unit/x402-visa.test.ts
@@ -271,6 +271,32 @@ describe('Visa provider surface', () => {
     expect(auth).toBe(`Bearer ${TEST_API_KEY}`)
   })
 
+  // Switching to the authed HTTP options means an org-pinned caller now also
+  // sends X-Current-Org-Id, so the money-adjacent settle becomes org-scoped.
+  // See nevermined-io/nvm-monorepo#1570.
+  test('settlePermissions sends X-Current-Org-Id for an org-pinned caller', async () => {
+    installFetch(() => jsonResponse({ success: true }))
+
+    payments.setOrganizationId('org-123')
+
+    await payments.facilitator.settlePermissions({
+      paymentRequired: {
+        x402Version: 2,
+        resource: { url: '/tools/echo' },
+        accepts: [{ scheme: 'nvm:card-delegation', network: 'visa', planId: 'plan-123' }],
+        extensions: {},
+      },
+      x402AccessToken: 'eyJ.visa.token',
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toContain('/api/v1/x402/settle')
+    const headers = calls[0].init?.headers as Record<string, string> | undefined
+    expect(headers?.['X-Current-Org-Id']).toBe('org-123')
+    // Authorization is still the Bearer key alongside the org scope.
+    expect(headers?.Authorization).toBe(`Bearer ${TEST_API_KEY}`)
+  })
+
   test("getInstance rejects scheme:'visa' with a migration message", () => {
     expect(() =>
       Payments.getInstance({


### PR DESCRIPTION
## Description

Switch `FacilitatorAPI.verifyPermissions` and `settlePermissions` (`src/x402/facilitator-api.ts`) from the public (no-auth) HTTP options to the authed ones, so the SDK now sends `Authorization: Bearer <nvmApiKey>` on the x402 `/verify` and `/settle` facilitator calls.

The authed options also emit `X-Current-Org-Id` for org-pinned callers (`setOrganizationId(...)`), so verify/settle now become org-scoped for those callers — not just `Authorization`.

Part of nevermined-io/nvm-monorepo#1570 (rollout step 2: SDKs send the NVM API-key header on x402 verify/settle; non-breaking — backend's optional guard tolerates it; enables the later strict-guard flip).

**Why non-breaking:** the backend `/verify`+`/settle` currently run the OPTIONAL `NvmApiHashKeyGuard` (accepts the header if present, tolerates absence), and the SDK's `nvmApiKey` is required at instantiation (always valid). Sending it now is harmless; it pre-positions for the later (breaking, separately-gated) backend flip to the strict guard.

No user-facing API change — method signatures are unchanged (internal HTTP-option swap), so no `markdown/` docs update is required and in-tree consumers (`openclaw/`, `cli/`) are unaffected.

## Is this PR related with an open issue?

Related to Issue nevermined-io/nvm-monorepo#1570

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation (no doc change needed — signatures unchanged)

#### Funny gif

![](https://media.giphy.com/media/3o7TKtnuHOHHUjR38Y/giphy.gif)
