### PR TITLE
docs(x402): correct missing-delegationConfig error code to BCK.X402.0030

### DIFF
--- a/markdown/x402.md
+++ b/markdown/x402.md
@@ -52,8 +52,9 @@ The Nevermined Payments Library implements X402 v2, which uses:
 Subscribers generate access tokens to query agents. **Both schemes
 (`nvm:erc4337` and `nvm:card-delegation`) require a `delegationConfig`** —
 the older "just pass planId + agentId" shape no longer mints a token and
-will surface `BCK.X402.0005` ("delegationConfig is required …") at the
-backend.
+will surface `BCK.X402.0030` ("Required token-generation input is missing
+or incomplete"; the `details` field names the missing input, e.g.
+"delegationConfig is required …") at the backend.
 
 ```typescript
 import { Payments, EnvironmentName, X402TokenOptions } from '@nevermined-io/payments'


### PR DESCRIPTION
## What

`markdown/x402.md` documented that the "older just-pass-planId+agentId" token shape surfaces `BCK.X402.0005` ("delegationConfig is required …"). The backend has since **diversified `BCK.X402.0005`** (nevermined-io/nvm-monorepo#1676): missing/incomplete token-generation input — including a missing `delegationConfig` — is now **`BCK.X402.0030`** ("Required token-generation input is missing or incomplete"; the `details` field names the specific missing input).

## Change

One-line doc correction: `BCK.X402.0005` → `BCK.X402.0030` for that case, with a note that `details` names the missing input.

No code or runtime impact — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)