### PR TITLE
feat(langsmith): emit nvm:verify/nvm:settlement spans from requiresPayment (TS-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,15 @@ The Nevermined Payments Library is a TypeScript SDK that allows AI Builders and 
 
 The Payments Library enables:
 
-* Easy registration and discovery of AI agents and the payment plans required to access them. All agents registered in Nevermined expose their metadata in a generic way, making them searchable and discoverable for specific purposes.
-* Flexible definition of pricing options and how AI agents can be queried. This is achieved through payment plans (based on time or credits) and consumption costs (fixed per request or dynamic). All of this can be defined by the AI builder or agent during the registration process.
-* Subscribers (humans or other agents) to purchase credits that grant access to AI agent services. Payments can be made in crypto or fiat via Stripe integration. The protocol registers the payment and credits distribution settlement on-chain.
-* Agents or users with access credits to query other AI agents. Nevermined authorizes only users with sufficient balance and keeps track of their credit usage.
-
+- Easy registration and discovery of AI agents and the payment plans required to access them. All agents registered in Nevermined expose their metadata in a generic way, making them searchable and discoverable for specific purposes.
+- Flexible definition of pricing options and how AI agents can be queried. This is achieved through payment plans (based on time or credits) and consumption costs (fixed per request or dynamic). All of this can be defined by the AI builder or agent during the registration process.
+- Subscribers (humans or other agents) to purchase credits that grant access to AI agent services. Payments can be made in crypto or fiat via Stripe integration. The protocol registers the payment and credits distribution settlement on-chain.
+- Agents or users with access credits to query other AI agents. Nevermined authorizes only users with sufficient balance and keeps track of their credit usage.
 
 The library is designed for use in browser environments or as part of AI Agents:
 
-* In a browser, the library provides a simple way to connect to the Nevermined protocol, allowing users to query AI Agents or publish their own.
-* As part of an AI Agent, the library allows the agent to query other agents programmatically. Additionally, agents can use the library to expose their own services and make them available to other agents or humans.
+- In a browser, the library provides a simple way to connect to the Nevermined protocol, allowing users to query AI Agents or publish their own.
+- As part of an AI Agent, the library allows the agent to query other agents programmatically. Additionally, agents can use the library to expose their own services and make them available to other agents or humans.
 
 ## Quickstart
 
@@ -41,6 +40,7 @@ npm install @nevermined-io/payments@^1.1
 ```
 
 > Pin the major version (or rely on a committed lockfile) so SDK upgrades are explicit. Always commit `package-lock.json` / `pnpm-lock.yaml`.
+
 ## A2A Integration (Agents‑to‑Agents)
 
 Nevermined Payments integrates with the A2A protocol to authorize and charge per request between agents:
@@ -78,19 +78,28 @@ Add a payment extension under `capabilities.extensions` carrying Nevermined meta
 ```
 
 Important notes:
+
 - The `url` must match exactly the URL registered in Nevermined for the agent/plan.
 - The final streaming event must include `metadata.creditsUsed` with the consumed cost.
 
-
 ## Requirements
 
-To use the Nevermined Payments Library, you need to get your Nevermined API key. You can get yours freely from the  [Nevermined App](https://nevermined.app).
+To use the Nevermined Payments Library, you need to get your Nevermined API key. You can get yours freely from the [Nevermined App](https://nevermined.app).
 
 ### Environments
 
 - Available environments: `sandbox`, `live`.
 
 Pick the environment that matches where your agent and plans are registered. The agent card `url` must belong to that environment.
+
+### Optional peer dependencies
+
+The core SDK has no required runtime peers. Some integrations are gated behind optional peer dependencies you install only if you use them:
+
+- **LangChain tool protection** (`@nevermined-io/payments/langchain`) — requires `@langchain/core` and `@langchain/langgraph >=1.0.0 <2`.
+- **LangSmith observability** (`@nevermined-io/payments/langsmith`, and the spans the `requiresPayment` wrapper emits when `LANGSMITH_TRACING=true`) — requires **`langsmith >=0.7`**. The spans rely on `getCurrentRunTree` (exported from `langsmith/singletons/traceable`) and the merging `RunTree.metadata` setter, both of which are only reliably present from `0.7` onward. Install it yourself: `pnpm add langsmith`.
+
+These are declared as optional peers, so npm/pnpm will not pull them in automatically and the SDK no-ops cleanly when they are absent.
 
 ### Initialize the Payments library in the Browser
 
@@ -124,7 +133,7 @@ export default function Home() {
 ### Initialize the Payments library in an AI Agent
 
 ```typescript
-import { Payments } from "@nevermined-io/payments";
+import { Payments } from '@nevermined-io/payments'
 
 const payments = Payments.getInstance({
   nvmApiKey,
@@ -138,19 +147,29 @@ Once the app is initialized we can create a payment plan:
 
 ```typescript
 const planMetadata: PlanMetadata = {
-    name: 'E2E test Payments Plan',
-  }
+  name: 'E2E test Payments Plan',
+}
 const priceConfig = payments.plans.getERC20PriceConfig(20n, ERC20_ADDRESS, builderAddress)
 const creditsConfig = payments.plans.getFixedCreditsConfig(100n)
-const { planId } = await payments.plans.registerCreditsPlan(planMetadata, priceConfig, creditsConfig)
+const { planId } = await payments.plans.registerCreditsPlan(
+  planMetadata,
+  priceConfig,
+  creditsConfig,
+)
 ```
 
 Or register a plan limited by time:
 
 ```typescript
 const priceConfig = payments.plans.getERC20PriceConfig(50n, ERC20_ADDRESS, builderAddress)
-const expirablePlanConfig = payments.plans.getExpirableDurationConfig(payments.plans.ONE_DAY_DURATION) // 1 day
-const response = await payments.plans.registerTimePlan(planMetadata, priceConfig, expirablePlanConfig)
+const expirablePlanConfig = payments.plans.getExpirableDurationConfig(
+  payments.plans.ONE_DAY_DURATION,
+) // 1 day
+const response = await payments.plans.registerTimePlan(
+  planMetadata,
+  priceConfig,
+  expirablePlanConfig,
+)
 ```
 
 You can also create trial plans (free plans that can only be purchased once):
@@ -166,7 +185,7 @@ const trialCreditsConfig = payments.plans.getFixedCreditsConfig(10n)
 const trialPlan = await payments.plans.registerCreditsTrialPlan(
   trialPlanMetadata,
   freePriceConfig,
-  trialCreditsConfig
+  trialCreditsConfig,
 )
 
 // Time-based trial plan
@@ -174,7 +193,7 @@ const timeTrialConfig = payments.plans.getExpirableDurationConfig(ONE_DAY_DURATI
 const timeTrialPlan = await payments.plans.registerTimeTrialPlan(
   trialPlanMetadata,
   freePriceConfig,
-  timeTrialConfig
+  timeTrialConfig,
 )
 ```
 
@@ -192,12 +211,13 @@ const agentMetadata = {
 // The API that the agent will expose
 const agentApi = {
   endpoints: [
-    { 'POST': `https://example.com/api/v1/agents/:agentId/tasks` },
-    { 'GET': `https://example.com/api/v1/agents/:agentId/tasks/invoke` }
-]}
+    { POST: `https://example.com/api/v1/agents/:agentId/tasks` },
+    { GET: `https://example.com/api/v1/agents/:agentId/tasks/invoke` },
+  ],
+}
 
 // This is the list of payment plans that the agent will accept
-const paymentPlans = [ creditsPlanId, expirablePlanId ]
+const paymentPlans = [creditsPlanId, expirablePlanId]
 const result = await payments.agents.registerAgent(agentMetadata, agentApi, paymentPlans)
 ```
 
@@ -212,9 +232,7 @@ const agentMetadata = {
 }
 
 const agentApi = {
-  endpoints: [
-    { 'POST': 'https://example.com/api/v1/agents/:agentId/tasks' }
-  ]
+  endpoints: [{ POST: 'https://example.com/api/v1/agents/:agentId/tasks' }],
 }
 
 const planMetadata = { name: 'Basic Plan' }
@@ -228,11 +246,12 @@ const { agentId, planId, txHash } = await payments.agents.registerAgentAndPlan(
   planMetadata,
   priceConfig,
   creditsConfig,
-  'time' // Optionally set access limit to 'time' or 'credits'
+  'time', // Optionally set access limit to 'time' or 'credits'
 )
 ```
 
 The `accessLimit` parameter is optional. If not specified, it's automatically inferred:
+
 - `'credits'` if `creditsConfig.durationSecs === 0n` (non-expirable)
 - `'time'` if `creditsConfig.durationSecs > 0n` (expirable)
 
@@ -261,7 +280,7 @@ const agentHTTPOptions = {
   headers: {
     Accept: 'application/json',
     'Content-Type': 'application/json',
-    'payment-signature': accessToken
+    'payment-signature': accessToken,
   },
 }
 const response = await fetch(new URL(agentURL), agentHTTPOptions)
@@ -281,7 +300,7 @@ MCP servers expose handlers (tools/resources/prompts) with their logical URLs, s
 
 ### Why Nevermined Payments?
 
-While MCP defines *what* an agent can do, it doesn't specify *who* can access it or *how* to charge for it. **Nevermined Payments** adds:
+While MCP defines _what_ an agent can do, it doesn't specify _who_ can access it or _how_ to charge for it. **Nevermined Payments** adds:
 
 - **Authentication**: Validates user tokens via `Authorization` header
 - **Credit System**: Checks and deducts credits per request
@@ -292,77 +311,77 @@ While MCP defines *what* an agent can do, it doesn't specify *who* can access it
 #### 1. Initialize Nevermined Payments
 
 ```typescript
-import { Payments, EnvironmentName } from "@nevermined-io/payments";
+import { Payments, EnvironmentName } from '@nevermined-io/payments'
 
 const payments = Payments.getInstance({
   nvmApiKey: process.env.NVM_API_KEY!,
   environment: process.env.NVM_ENVIRONMENT! as EnvironmentName,
-});
+})
 ```
 
 #### 2. Register Protected Tools
 
 ```typescript
-import { z } from "zod";
+import { z } from 'zod'
 
 const schema = z.object({
-  city: z.string().describe("City name"),
-}) as any;
+  city: z.string().describe('City name'),
+}) as any
 
 payments.mcp.registerTool(
-  "weather.today",
+  'weather.today',
   {
     title: "Today's Weather",
-    description: "Get weather for a city",
+    description: 'Get weather for a city',
     inputSchema: schema,
   },
   async (args) => {
-    const { city } = args as { city: string };
+    const { city } = args as { city: string }
     return {
-      content: [{ type: "text", text: `Weather for ${city}: Sunny, 25C` }],
-    };
+      content: [{ type: 'text', text: `Weather for ${city}: Sunny, 25C` }],
+    }
   },
-  { credits: 1n }
-);
+  { credits: 1n },
+)
 ```
 
 #### 3. Register Protected Resources
 
 ```typescript
 payments.mcp.registerResource(
-  "Weather Data",
-  "weather://today",
+  'Weather Data',
+  'weather://today',
   {
     title: "Today's Weather",
-    description: "JSON weather data",
-    mimeType: "application/json",
+    description: 'JSON weather data',
+    mimeType: 'application/json',
   },
   async (uri) => {
     return {
-      contents: [{ uri: uri.href, text: "{...}", mimeType: "application/json" }],
-    };
+      contents: [{ uri: uri.href, text: '{...}', mimeType: 'application/json' }],
+    }
   },
-  { credits: 5n }
-);
+  { credits: 5n },
+)
 ```
 
 #### 4. Register Protected Prompts
 
 ```typescript
 payments.mcp.registerPrompt(
-  "weather.ensureCity",
+  'weather.ensureCity',
   {
-    title: "Ensure city",
-    description: "Guide to call weather.today",
+    title: 'Ensure city',
+    description: 'Guide to call weather.today',
     argsSchema: schema,
   },
   (args) => {
     return {
-      messages: [{ role: "user", content: { type: "text", text: "..." } }],
-    };
+      messages: [{ role: 'user', content: { type: 'text', text: '...' } }],
+    }
   },
-  { credits: (ctx) => ctx.result.length > 100 ? 2n : 1n }  // Dynamic credits
-);
+  { credits: (ctx) => (ctx.result.length > 100 ? 2n : 1n) }, // Dynamic credits
+)
 ```
 
 #### 5. Start the Server
@@ -371,9 +390,9 @@ payments.mcp.registerPrompt(
 const { info, stop } = await payments.mcp.start({
   port: 3002,
   agentId: process.env.NVM_AGENT_ID!,
-  serverName: "weather-mcp",
-  version: "0.1.0",
-});
+  serverName: 'weather-mcp',
+  version: '0.1.0',
+})
 ```
 
 ### Credit Configuration
@@ -382,22 +401,32 @@ All registration functions support fixed or dynamic credits:
 
 ```typescript
 // Fixed credits
-{ credits: 1n }
-{ credits: 5n }
+{
+  credits: 1n
+}
+{
+  credits: 5n
+}
 
 // Dynamic credits based on input
-{ credits: (ctx) => ctx.args.premium ? 5n : 1n }
+{
+  credits: (ctx) => (ctx.args.premium ? 5n : 1n)
+}
 
 // Dynamic credits based on result
-{ credits: (ctx) => ctx.result.length > 1000 ? 3n : 1n }
+{
+  credits: (ctx) => (ctx.result.length > 1000 ? 3n : 1n)
+}
 
 // Tiered pricing
-{ credits: (ctx) => {
-  const size = JSON.stringify(ctx.result).length;
-  if (size > 1000) return 5n;
-  if (size > 500) return 3n;
-  return 1n;
-}}
+{
+  credits: (ctx) => {
+    const size = JSON.stringify(ctx.result).length
+    if (size > 1000) return 5n
+    if (size > 500) return 3n
+    return 1n
+  }
+}
 ```
 
 ### Client Usage
@@ -405,55 +434,54 @@ All registration functions support fixed or dynamic credits:
 #### Get Access Token
 
 ```typescript
-import { Payments } from "@nevermined-io/payments";
+import { Payments } from '@nevermined-io/payments'
 
 const payments = Payments.getInstance({
   nvmApiKey: process.env.NVM_API_KEY!,
-  environment: "sandbox",
-});
+  environment: 'sandbox',
+})
 
 const { accessToken } = await payments.x402.getX402AccessToken(
   process.env.NVM_PLAN_ID!,
-  process.env.NVM_AGENT_ID!
-);
+  process.env.NVM_AGENT_ID!,
+)
 ```
 
 #### Call Protected Tools
 
 ```typescript
-import { Client } from "@modelcontextprotocol/sdk/client";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp";
+import { Client } from '@modelcontextprotocol/sdk/client'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp'
 
-const transport = new StreamableHTTPClientTransport(
-  new URL("http://localhost:3002/mcp"),
-  { requestInit: { headers: { Authorization: `Bearer ${accessToken}` } } }
-);
+const transport = new StreamableHTTPClientTransport(new URL('http://localhost:3002/mcp'), {
+  requestInit: { headers: { Authorization: `Bearer ${accessToken}` } },
+})
 
-const client = new Client({ name: "my-client" });
-await client.connect(transport);
+const client = new Client({ name: 'my-client' })
+await client.connect(transport)
 
 const result = await client.callTool({
-  name: "weather.today",
-  arguments: { city: "London" },
-});
+  name: 'weather.today',
+  arguments: { city: 'London' },
+})
 ```
 
 ### Endpoints
 
-| Endpoint | Description |
-|----------|-------------|
-| `POST /mcp` | MCP JSON-RPC requests |
-| `GET /mcp` | SSE stream for notifications |
-| `DELETE /mcp` | Session termination |
-| `GET /health` | Health check |
-| `GET /` | Server info |
+| Endpoint      | Description                  |
+| ------------- | ---------------------------- |
+| `POST /mcp`   | MCP JSON-RPC requests        |
+| `GET /mcp`    | SSE stream for notifications |
+| `DELETE /mcp` | Session termination          |
+| `GET /health` | Health check                 |
+| `GET /`       | Server info                  |
 
 ### Error Codes
 
-| Code | Description |
-|------|-------------|
+| Code     | Description                                                      |
+| -------- | ---------------------------------------------------------------- |
 | `-32003` | Authorization required / Payment required / Insufficient credits |
-| `-32002` | Server error |
+| `-32002` | Server error                                                     |
 
 ### Notes
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,10 @@
     "./langchain": {
       "types": "./dist/x402/langchain/index.d.ts",
       "import": "./dist/x402/langchain/index.js"
+    },
+    "./langsmith": {
+      "types": "./dist/x402/langsmith/index.d.ts",
+      "import": "./dist/x402/langsmith/index.js"
     }
   },
   "scripts": {
@@ -80,6 +84,7 @@
     "eslint-plugin-tsdoc": "^0.5.2",
     "jest": "^29.7.0",
     "langchain": "^0.3.37",
+    "langsmith": "^0.7.4",
     "openai": "^6.2.0",
     "prettier": "^3.2.5",
     "source-map-support": "^0.5.21",
@@ -96,7 +101,8 @@
     "@langchain/core": ">=0.3.0",
     "@langchain/langgraph": ">=1.0.0 <2",
     "@modelcontextprotocol/sdk": ">=1.25.0",
-    "express": ">=4.0.0"
+    "express": ">=4.0.0",
+    "langsmith": ">=0.3.0"
   },
   "peerDependenciesMeta": {
     "@modelcontextprotocol/sdk": {
@@ -109,6 +115,9 @@
       "optional": true
     },
     "@langchain/langgraph": {
+      "optional": true
+    },
+    "langsmith": {
       "optional": true
     }
   },

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@langchain/langgraph": ">=1.0.0 <2",
     "@modelcontextprotocol/sdk": ">=1.25.0",
     "express": ">=4.0.0",
-    "langsmith": ">=0.3.0"
+    "langsmith": ">=0.7.0"
   },
   "peerDependenciesMeta": {
     "@modelcontextprotocol/sdk": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       langchain:
         specifier: ^0.3.37
         version: 0.3.37(@langchain/core@1.1.40(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(axios@1.15.2)(handlebars@4.7.9)(openai@6.35.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      langsmith:
+        specifier: ^0.7.4
+        version: 0.7.4(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       openai:
         specifier: ^6.2.0
         version: 6.35.0(ws@8.20.0)(zod@4.3.6)
@@ -3893,6 +3896,26 @@ packages:
 
   langsmith@0.5.19:
     resolution: {integrity: sha512-5tFoETuFMvGkbPGsINNlIE4Ab86CsPhdPOQZCGwNt/NX0h5NDKQLKOWS/G2XcRUBOQl4mCNbrayUvUTWaIRsCg==}
+    peerDependencies:
+      '@opentelemetry/api': '*'
+      '@opentelemetry/exporter-trace-otlp-proto': '*'
+      '@opentelemetry/sdk-trace-base': '*'
+      openai: '*'
+      ws: '>=7'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-proto':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      openai:
+        optional: true
+      ws:
+        optional: true
+
+  langsmith@0.7.4:
+    resolution: {integrity: sha512-EGYCw85etSarYazeTgj8DICVIFg+26gsVZ0zq8V7kjIb59huURJpZZJqVFkvRpZFxmfyYrpIhtk2qtHgGR8K+w==}
     peerDependencies:
       '@opentelemetry/api': '*'
       '@opentelemetry/exporter-trace-otlp-proto': '*'
@@ -10573,6 +10596,16 @@ snapshots:
     dependencies:
       p-queue: 6.6.2
       uuid: 10.0.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/exporter-trace-otlp-proto': 0.203.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
+      openai: 6.35.0(ws@8.20.0)(zod@4.3.6)
+      ws: 8.20.0
+
+  langsmith@0.7.4(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0):
+    dependencies:
+      p-queue: 6.6.2
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/exporter-trace-otlp-proto': 0.203.0(@opentelemetry/api@1.9.1)

--- a/src/x402/langchain/decorator.ts
+++ b/src/x402/langchain/decorator.ts
@@ -50,6 +50,15 @@ import {
   type VerifyPermissionsResult,
   type SettlePermissionsResult,
 } from '../facilitator-api.js'
+import {
+  activeRunTree,
+  addMetadata,
+  buildSettleMetadata,
+  buildVerifyMetadata,
+  redactMetadataKeys,
+  settlementSpan,
+  verifySpan,
+} from '../langsmith/spans.js'
 
 /**
  * Context passed to a dynamic credits function after tool execution.
@@ -187,7 +196,6 @@ function storeInConfigurable(config: unknown, key: string, value: unknown): void
 
   const configurable = (config as Record<string, unknown>).configurable
   if (configurable == null || typeof configurable !== 'object') return
-
   ;(configurable as Record<string, unknown>)[key] = value
 }
 
@@ -253,12 +261,49 @@ export function requiresPayment<TArgs extends Record<string, unknown>, TResult>(
       agentId,
       network,
     })
+    // The scheme/network the verify span advertises come from the resolved
+    // X402 scheme so the span metadata matches what the buyer paid against.
+    const accepted = paymentRequired.accepts[0]
+    const planIds = paymentRequired.accepts
+      .map((a) => a.planId)
+      .filter((p): p is string => Boolean(p))
+    const resolvedScheme = accepted?.scheme
+    const resolvedNetwork = network ?? accepted?.network
+
+    // LangChain auto-captures every key in config.configurable into the parent
+    // tool span's metadata, and child spans inherit it at construction time.
+    // Strip the full x402 access token from the parent BEFORE opening the verify
+    // span so neither the parent nor the child carries the raw credential — only
+    // the abbreviated nvm.payment_token remains for correlation.
+    const parentRunTree = await activeRunTree()
+    redactMetadataKeys(parentRunTree, 'payment_token')
+
+    const verifyStarted = Date.now()
+    // Open the verify span BEFORE the token-presence check so failed probes
+    // (no payment_token in config) still produce a clearly-named span with the
+    // static nvm.* attrs attached to both the span and the parent tool span.
+    const vspan = await verifySpan({
+      planIds,
+      scheme: resolvedScheme,
+      network: resolvedNetwork,
+      agentId,
+    })
+    // Pre-verify metadata is best-effort and static-only.
+    const preVerifyMd = buildVerifyMetadata({
+      planIds,
+      scheme: resolvedScheme,
+      network: resolvedNetwork,
+      agentId,
+    })
+    vspan.addMetadata(preVerifyMd)
+    addMetadata(parentRunTree, preVerifyMd)
 
     // Extract token from config.configurable.payment_token
     const token = extractPaymentToken(config)
     if (!token) {
+      await vspan.end(new Error('missing payment_token in config.configurable'))
       throw new PaymentRequiredError(
-        "Payment required: missing payment_token in config.configurable",
+        'Payment required: missing payment_token in config.configurable',
         paymentRequired,
       )
     }
@@ -275,18 +320,37 @@ export function requiresPayment<TArgs extends Record<string, unknown>, TResult>(
         maxAmount: BigInt(creditsToVerify),
       })
     } catch (error) {
+      await vspan.end(error)
       throw new PaymentRequiredError(
         `Payment verification failed: ${error instanceof Error ? error.message : String(error)}`,
         paymentRequired,
       )
     }
 
+    // Augment span metadata with verification results + timing (both span and
+    // parent), then close the verify span. Best-effort: a metadata failure must
+    // not mask the PaymentRequiredError that may follow.
+    const verifyMd = buildVerifyMetadata({
+      planIds,
+      scheme: resolvedScheme,
+      network: resolvedNetwork,
+      agentId,
+      verification,
+      durationMs: Date.now() - verifyStarted,
+      token,
+    })
+    vspan.addMetadata(verifyMd)
+    addMetadata(parentRunTree, verifyMd)
+
     if (!verification.isValid) {
+      await vspan.end(new Error(verification.invalidReason || 'verification failed'))
       throw new PaymentRequiredError(
         `Payment verification failed: ${verification.invalidReason || 'Insufficient credits or invalid token'}`,
         paymentRequired,
       )
     }
+
+    await vspan.end()
 
     // Store payment context
     const paymentContext: PaymentContext = {
@@ -308,7 +372,11 @@ export function requiresPayment<TArgs extends Record<string, unknown>, TResult>(
         ? credits({ args: args as Record<string, unknown>, result })
         : credits
 
-    // Settle credits
+    // Settle credits, wrapped in an nvm:settlement span (mirrors Python's
+    // settlement_span around settle_permissions).
+    const settleParentRunTree = await activeRunTree()
+    const settleStarted = Date.now()
+    const sspan = await settlementSpan({ planIds, agentId })
     try {
       const settlement = await payments.facilitator.settlePermissions({
         paymentRequired,
@@ -325,8 +393,20 @@ export function requiresPayment<TArgs extends Record<string, unknown>, TResult>(
       // the receipt — LangGraph copies config.configurable per node, hiding the
       // line above from the buyer's outer scope.
       lastSettlementReceipt = settlement
+
+      const settleMd = buildSettleMetadata({
+        settlement,
+        planIds,
+        agentId,
+        durationMs: Date.now() - settleStarted,
+        token,
+      })
+      sspan.addMetadata(settleMd)
+      addMetadata(settleParentRunTree, settleMd)
+      await sspan.end()
     } catch (settleError) {
       console.error('Payment settlement failed:', settleError)
+      await sspan.end(settleError)
       // Still return result even if settlement fails
     }
 

--- a/src/x402/langchain/decorator.ts
+++ b/src/x402/langchain/decorator.ts
@@ -51,6 +51,7 @@ import {
   type SettlePermissionsResult,
 } from '../facilitator-api.js'
 import {
+  abbreviateToken,
   activeRunTree,
   addMetadata,
   buildSettleMetadata,
@@ -308,6 +309,15 @@ export function requiresPayment<TArgs extends Record<string, unknown>, TResult>(
       )
     }
 
+    // Abbreviate/redact the token ONCE here (mirrors Python's
+    // attach_metadata_safely pre-abbreviation) and pass the result into the
+    // metadata builders. abbreviateToken is idempotent, so the builders leave
+    // it unchanged — this means the short-token warning fires at most once per
+    // call (not once per verify AND once per settle), and the raw token never
+    // reaches the builders' frame locals (defense against exception enrichers
+    // that capture locals).
+    const abbreviatedToken = abbreviateToken(token)
+
     // Resolve pre-execution credits (static only; callable deferred to post-execution)
     const creditsToVerify = typeof credits === 'number' ? credits : 1
 
@@ -337,7 +347,7 @@ export function requiresPayment<TArgs extends Record<string, unknown>, TResult>(
       agentId,
       verification,
       durationMs: Date.now() - verifyStarted,
-      token,
+      token: abbreviatedToken,
     })
     vspan.addMetadata(verifyMd)
     addMetadata(parentRunTree, verifyMd)
@@ -399,7 +409,7 @@ export function requiresPayment<TArgs extends Record<string, unknown>, TResult>(
         planIds,
         agentId,
         durationMs: Date.now() - settleStarted,
-        token,
+        token: abbreviatedToken,
       })
       sspan.addMetadata(settleMd)
       addMetadata(settleParentRunTree, settleMd)

--- a/src/x402/langchain/decorator.ts
+++ b/src/x402/langchain/decorator.ts
@@ -384,7 +384,16 @@ export function requiresPayment<TArgs extends Record<string, unknown>, TResult>(
 
     // Settle credits, wrapped in an nvm:settlement span (mirrors Python's
     // settlement_span around settle_permissions).
+    //
+    // Re-fetch the active run tree: the verify-side redaction at the top of this
+    // function stripped `payment_token` from the run tree active BEFORE `fn()`,
+    // but `fn()` may have opened nested traced runs, so `activeRunTree()` can now
+    // return a different RunTree that LangChain auto-populated with the raw
+    // `payment_token` from `config.configurable`. Redact it again here, BEFORE
+    // opening the settlement span, so the credential never rides into the settle
+    // child span or the (possibly new) parent tree.
     const settleParentRunTree = await activeRunTree()
+    redactMetadataKeys(settleParentRunTree, 'payment_token')
     const settleStarted = Date.now()
     const sspan = await settlementSpan({ planIds, agentId })
     try {

--- a/src/x402/langchain/decorator.ts
+++ b/src/x402/langchain/decorator.ts
@@ -125,7 +125,17 @@ export class PaymentRequiredError extends Error {
  * Payment context stored in `config.configurable.payment_context` after verification.
  */
 export interface PaymentContext {
-  /** The x402 access token */
+  /**
+   * Abbreviated, non-functional reference to the x402 access token — the SAME
+   * redacted form surfaced as `nvm.payment_token` (`<first 16>…<last 4>`, or a
+   * `…(short)` marker for a too-short token). The **full token is deliberately
+   * not persisted here**: this object is written into
+   * `config.configurable.payment_context`, and tracing frameworks (e.g.
+   * LangChain) can capture `config.configurable` into span metadata, so storing
+   * the raw credential would let it ride into any traced run opened during or
+   * after the tool body. Settlement uses the token read from
+   * `config.configurable.payment_token`, never this field.
+   */
   token: string
   /** The payment required object */
   paymentRequired: X402PaymentRequired
@@ -362,9 +372,16 @@ export function requiresPayment<TArgs extends Record<string, unknown>, TResult>(
 
     await vspan.end()
 
-    // Store payment context
+    // Store payment context. The `token` field carries the ABBREVIATED
+    // reference, never the raw credential: `payment_context` is written into
+    // `config.configurable`, which LangChain can capture into span metadata, so
+    // persisting the full token here would reopen the very leak the parent-tree
+    // `redactMetadataKeys('payment_token')` calls close — and a child run opened
+    // *during* the tool body would capture it before any post-hoc redaction
+    // could run. `abbreviatedToken` is always defined past the `!token` guard
+    // above; `?? ''` is a belt-and-suspenders that can never fall back to raw.
     const paymentContext: PaymentContext = {
-      token,
+      token: abbreviatedToken ?? '',
       paymentRequired,
       creditsToSettle: creditsToVerify,
       verified: true,

--- a/src/x402/langsmith/index.ts
+++ b/src/x402/langsmith/index.ts
@@ -1,0 +1,32 @@
+/**
+ * LangSmith observability bridge for Nevermined payments (TypeScript).
+ *
+ * Surfaces the cross-SDK `nvm:verify` / `nvm:settlement` spans defined by the
+ * observability-spans-v1 contract, matching the Python SDK attribute-for-
+ * attribute so a single LangSmith trace can be correlated across both SDKs.
+ *
+ * These helpers are wired into the `requiresPayment` decorator automatically;
+ * they are also exported here for manual use in non-LangChain code paths.
+ *
+ * Requires the optional `langsmith` peer dependency and `LANGSMITH_TRACING=true`;
+ * every helper no-ops when tracing is inactive or `langsmith` is not installed.
+ */
+
+export {
+  abbreviateToken,
+  activeRunTree,
+  addMetadata,
+  buildSettleMetadata,
+  buildVerifyMetadata,
+  redactMetadataKeys,
+  settlementSpan,
+  verifySpan,
+  NVM_VERIFY_SPAN,
+  NVM_SETTLEMENT_SPAN,
+  type NvmSpan,
+  type SpanMetadata,
+  type VerifyMetadataInput,
+  type SettleMetadataInput,
+  type VerifySpanInput,
+  type SettlementSpanInput,
+} from './spans.js'

--- a/src/x402/langsmith/spans.ts
+++ b/src/x402/langsmith/spans.ts
@@ -35,9 +35,24 @@ export const NVM_SETTLEMENT_SPAN = 'nvm:settlement'
 /**
  * Marker appended to a redacted short token. The joining character is the
  * single Unicode ellipsis `…` (U+2026), matching the Python implementation
- * and the spec, NOT three ASCII dots.
+ * and the spec, NOT three ASCII dots. (`…` is one UTF-16 code unit, so this
+ * string has length 8.)
  */
 const SHORT_TOKEN_MARKER = '…(short)'
+
+/**
+ * A redacted short token is exactly `<prefix><marker>` where `prefix` is either
+ * empty (raw length 4 or fewer) or the first 4 chars (raw length over 4) — so a genuine
+ * marker only ever has one of these two lengths. Recognising it by both suffix
+ * AND an exact length stops a raw ≤20-char value that merely *ends* in the
+ * marker (e.g. `"x…(short)"`) from slipping through verbatim.
+ */
+const REDACTED_MARKER_LENGTHS = new Set([SHORT_TOKEN_MARKER.length, 4 + SHORT_TOKEN_MARKER.length])
+
+/** True if `token` is already a value produced by the short-token branch. */
+function isRedactedMarker(token: string): boolean {
+  return token.endsWith(SHORT_TOKEN_MARKER) && REDACTED_MARKER_LENGTHS.has(token.length)
+}
 
 /**
  * Cached result of the lazy `langsmith` import.
@@ -51,13 +66,35 @@ type LangsmithModule = {
 }
 let cachedLangsmith: LangsmithModule | null | undefined
 
+/** True when the dynamic-import error means the package is simply not installed. */
+function isModuleNotFound(err: unknown): boolean {
+  const code = (err as { code?: string } | null)?.code
+  return code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND'
+}
+
 async function loadLangsmith(): Promise<LangsmithModule | null> {
   if (cachedLangsmith !== undefined) return cachedLangsmith
   try {
     const mod = (await import('langsmith')) as unknown as LangsmithModule
-    cachedLangsmith = typeof mod?.getCurrentRunTree === 'function' ? mod : null
-  } catch {
+    if (typeof mod?.getCurrentRunTree === 'function') {
+      cachedLangsmith = mod
+    } else {
+      // Installed but missing the API we rely on — a real, diagnosable problem,
+      // distinct from "not installed". Warn once (cached null prevents repeats).
+      cachedLangsmith = null
+      console.warn(
+        'nvm-langsmith: `langsmith` is installed but does not export ' +
+          'getCurrentRunTree; Nevermined spans are disabled.',
+      )
+    }
+  } catch (err) {
     cachedLangsmith = null
+    // "Not installed" is the expected optional-peer path → stay silent. Any
+    // other failure (a broken install, a transitive load error) disables all
+    // spans with no other signal, so surface it once.
+    if (!isModuleNotFound(err)) {
+      console.warn('nvm-langsmith: failed to load `langsmith`; spans disabled', err)
+    }
   }
   return cachedLangsmith
 }
@@ -74,7 +111,8 @@ export async function activeRunTree(): Promise<RunTree | undefined> {
     // there is no active run, mirroring Python's `get_current_run_tree()` used
     // behind a try/except.
     return ls.getCurrentRunTree(true)
-  } catch {
+  } catch (err) {
+    console.debug('nvm-langsmith: getCurrentRunTree failed (ignored)', err)
     return undefined
   }
 }
@@ -90,8 +128,9 @@ export function addMetadata(runTree: RunTree | undefined, metadata: SpanMetadata
   if (!runTree || !metadata || Object.keys(metadata).length === 0) return
   try {
     runTree.metadata = metadata
-  } catch {
+  } catch (err) {
     // observability hygiene must never disrupt the payment flow
+    console.debug('nvm-langsmith: addMetadata failed (ignored)', err)
   }
 }
 
@@ -104,8 +143,12 @@ export function addMetadata(runTree: RunTree | undefined, metadata: SpanMetadata
  * the full `payment_token` from the parent tool span's metadata, since the raw
  * access token grants access to the protected tool until it expires.
  *
- * No-op when `runTree` is absent or no keys are provided. All errors are
- * swallowed.
+ * No-op when `runTree` is absent or no keys are provided. Errors are swallowed
+ * so observability never disrupts the payment flow — but, unlike the other
+ * swallow paths, a failure here is **security-sensitive**: if the parent run
+ * tree still holds the raw `payment_token`, that credential rides into the
+ * parent tree and the inherited verify/settle child spans. So this path warns
+ * (not just debug) to keep the leak diagnosable.
  */
 export function redactMetadataKeys(runTree: RunTree | undefined, ...keys: string[]): void {
   if (!runTree || keys.length === 0) return
@@ -115,32 +158,40 @@ export function redactMetadataKeys(runTree: RunTree | undefined, ...keys: string
     if (metadata && typeof metadata === 'object') {
       for (const key of keys) delete metadata[key]
     }
-  } catch {
-    // best-effort
+  } catch (err) {
+    console.warn(
+      `nvm-langsmith: failed to redact metadata keys [${keys.join(', ')}] from ` +
+        'the parent run tree — a raw credential may remain in the trace',
+      err,
+    )
   }
 }
 
 /**
  * Return a short, non-functional reference to a payment token for span
- * metadata. Mirrors `payments_py/langsmith/spans.py::abbreviate_token` incl.
- * the redact-and-warn behavior finalized in nvm-monorepo#1747
- * (payments-py PR #217).
+ * metadata. Mirrors `payments_py/langsmith/spans.py::abbreviate_token` and the
+ * redaction contract in nvm-monorepo#1746 §4 (short-token hardening from
+ * nvm-monorepo#1747, tracked in payments-py PR #217).
  *
  * - `undefined`/empty input → `undefined` (and silent — no token at all is not
  *   a "wrong token" mistake).
- * - Already-redacted input (ends with the `…(short)` marker) → returned
+ * - Already-redacted input (a genuine `<prefix>…(short)` marker) → returned
  *   unchanged and silent, so the helper stays idempotent (the decorator path
- *   abbreviates the same token more than once).
+ *   abbreviates the same token more than once). A raw value that merely *ends*
+ *   in the marker is NOT treated as redacted (see {@link isRedactedMarker}).
  * - A token of length ≤ 20 is almost always a misconfiguration (a plan id, an
  *   opaque handle, etc. passed where the JWT was expected). Because this helper
  *   exists to keep credentials out of a durable trace store, such tokens are
- *   **redacted, not exported**: only `<first 4>…(short)` is returned and a
- *   warning is emitted. The full short value never leaves this function.
+ *   **redacted, not exported**: at most the first 4 chars are revealed (to aid
+ *   debugging the misconfig), followed by the `…(short)` marker — and for a
+ *   token of 4 chars or fewer **nothing** is revealed (the whole value would
+ *   otherwise be the "prefix"), so it collapses to just `…(short)`. A warning
+ *   is emitted. The full short value never leaves this function.
  * - Otherwise (a normal JWT, more than 20 chars) → `<first 16>…<last 4>`.
  */
 export function abbreviateToken(token: string | undefined | null): string | undefined {
   if (!token) return undefined
-  if (token.endsWith(SHORT_TOKEN_MARKER)) {
+  if (isRedactedMarker(token)) {
     // Already redacted (re-applied on the decorator path); re-slicing would let
     // the marker drift, so return unchanged and stay silent — the original
     // short value already triggered the warning.
@@ -152,7 +203,10 @@ export function abbreviateToken(token: string | undefined | null): string | unde
         'access token passed? Short/non-JWT tokens are almost always a ' +
         'misconfiguration and are redacted (not exported).',
     )
-    return `${token.slice(0, 4)}${SHORT_TOKEN_MARKER}`
+    // Reveal at most 4 chars; for a ≤4-char token reveal nothing, since
+    // token.slice(0, 4) would be the entire value — defeating the redaction.
+    const prefix = token.length > 4 ? token.slice(0, 4) : ''
+    return `${prefix}${SHORT_TOKEN_MARKER}`
   }
   return `${token.slice(0, 16)}…${token.slice(-4)}`
 }
@@ -249,8 +303,9 @@ async function openNvmSpan(name: string, inputs: SpanMetadata): Promise<NvmSpan>
   let child: RunTree
   try {
     child = parent.createChild({ name, run_type: 'tool', inputs })
-  } catch {
+  } catch (err) {
     // span setup is pure observability — never let it disrupt the payment flow
+    console.debug(`nvm-langsmith: createChild(${name}) failed (ignored)`, err)
     return inactiveSpan()
   }
   return {
@@ -265,8 +320,9 @@ async function openNvmSpan(name: string, inputs: SpanMetadata): Promise<NvmSpan>
           error === undefined ? undefined : error instanceof Error ? error.message : String(error),
         )
         await child.postRun()
-      } catch {
+      } catch (err) {
         // best-effort flush
+        console.debug(`nvm-langsmith: ${name} span flush failed (ignored)`, err)
       }
     },
   }

--- a/src/x402/langsmith/spans.ts
+++ b/src/x402/langsmith/spans.ts
@@ -75,7 +75,14 @@ function isModuleNotFound(err: unknown): boolean {
 async function loadLangsmith(): Promise<LangsmithModule | null> {
   if (cachedLangsmith !== undefined) return cachedLangsmith
   try {
-    const mod = (await import('langsmith')) as unknown as LangsmithModule
+    // `getCurrentRunTree` is NOT exported from the `langsmith` root entry point —
+    // it lives exclusively at the `langsmith/singletons/traceable` sub-path (true
+    // across every published 0.x). Importing the root and reading
+    // `mod.getCurrentRunTree` always yields `undefined`, which would disable
+    // every span in production while the mocked unit tests stay green. Import the
+    // sub-path directly. (See the un-mocked smoke test in
+    // `langsmith-real-sdk.test.ts`, which fails loudly if this ever moves again.)
+    const mod = (await import('langsmith/singletons/traceable')) as unknown as LangsmithModule
     if (typeof mod?.getCurrentRunTree === 'function') {
       cachedLangsmith = mod
     } else {
@@ -83,8 +90,8 @@ async function loadLangsmith(): Promise<LangsmithModule | null> {
       // distinct from "not installed". Warn once (cached null prevents repeats).
       cachedLangsmith = null
       console.warn(
-        'nvm-langsmith: `langsmith` is installed but does not export ' +
-          'getCurrentRunTree; Nevermined spans are disabled.',
+        'nvm-langsmith: `langsmith` is installed but `langsmith/singletons/traceable` ' +
+          'does not export getCurrentRunTree; Nevermined spans are disabled.',
       )
     }
   } catch (err) {
@@ -119,15 +126,24 @@ export async function activeRunTree(): Promise<RunTree | undefined> {
 
 /**
  * Merge `metadata` into `runTree`, swallowing any error. No-op if `runTree` is
- * absent or `metadata` is empty.
+ * absent or `metadata` is empty. Matches Python's `run_tree.add_metadata`.
  *
- * The langsmith `RunTree` `metadata` setter merges into `extra.metadata`
- * (`{ ...existing, ...new }`), so this matches Python's `run_tree.add_metadata`.
+ * The merge is performed on THIS side of the boundary — we read the existing
+ * `extra.metadata`, spread the new keys over it, then assign — rather than
+ * relying on the langsmith `RunTree.metadata` setter to merge. In `langsmith@0.7`
+ * the setter does merge (`extra.metadata = { ...existing, ...new }`), but that is
+ * an implementation detail of `run_trees.js`, not a documented contract: a future
+ * release that flips it to plain assignment would silently drop the static
+ * `nvm.*` keys attached on the pre-verify pass once the post-verify pass runs.
+ * Reading+merging here keeps the double-pass accumulation correct regardless, and
+ * mirrors how {@link redactMetadataKeys} already reaches into `extra.metadata`.
  */
 export function addMetadata(runTree: RunTree | undefined, metadata: SpanMetadata): void {
   if (!runTree || !metadata || Object.keys(metadata).length === 0) return
   try {
-    runTree.metadata = metadata
+    const rt = runTree as unknown as { extra?: Record<string, unknown> }
+    const existing = (rt.extra?.metadata as Record<string, unknown> | undefined) ?? {}
+    runTree.metadata = { ...existing, ...metadata }
   } catch (err) {
     // observability hygiene must never disrupt the payment flow
     console.debug('nvm-langsmith: addMetadata failed (ignored)', err)

--- a/src/x402/langsmith/spans.ts
+++ b/src/x402/langsmith/spans.ts
@@ -1,0 +1,325 @@
+/**
+ * LangSmith span helpers for Nevermined payment events (TypeScript).
+ *
+ * TS parity port of `payments_py/langsmith/spans.py`. Emits the cross-SDK
+ * `nvm:verify` / `nvm:settlement` spans defined by the
+ * **observability-spans-v1** contract
+ * (`docs/specs/observability-spans-v1.md` in nvm-monorepo), so a single
+ * LangSmith trace can be correlated across the TypeScript and Python SDKs
+ * (e.g. filtered on `nvm.tx_hash`).
+ *
+ * All helpers in this module silently no-op when:
+ *   - the optional `langsmith` JS SDK is not installed; or
+ *   - no LangSmith run tree is active in the current context (e.g.
+ *     `LANGSMITH_TRACING` is unset, or the call is not inside a traced run).
+ *
+ * Failures inside this module never propagate out — observability is
+ * best-effort and must not interfere with the payment flow.
+ *
+ * `langsmith` is imported **lazily** (dynamic `import()`), so users who only
+ * use the `requiresPayment` wrapper without tracing are not forced to install
+ * it. Install it yourself (`pnpm add langsmith`) and set `LANGSMITH_TRACING=true`
+ * to surface these spans.
+ */
+
+import type { RunTree } from 'langsmith'
+import type { VerifyPermissionsResult, SettlePermissionsResult } from '../facilitator-api.js'
+
+/** Plain JSON-ish metadata bag attached to a span / run tree. */
+export type SpanMetadata = Record<string, unknown>
+
+/** Span names — must match observability-spans-v1 exactly (case-sensitive). */
+export const NVM_VERIFY_SPAN = 'nvm:verify'
+export const NVM_SETTLEMENT_SPAN = 'nvm:settlement'
+
+/**
+ * Marker appended to a redacted short token. The joining character is the
+ * single Unicode ellipsis `…` (U+2026), matching the Python implementation
+ * and the spec, NOT three ASCII dots.
+ */
+const SHORT_TOKEN_MARKER = '…(short)'
+
+/**
+ * Cached result of the lazy `langsmith` import.
+ *
+ * `undefined` = not yet attempted; `null` = attempted and unavailable (so we
+ * never retry the dynamic import on every call); otherwise the resolved module
+ * surface we use (`getCurrentRunTree`).
+ */
+type LangsmithModule = {
+  getCurrentRunTree: (permitAbsentRunTree: boolean) => RunTree | undefined
+}
+let cachedLangsmith: LangsmithModule | null | undefined
+
+async function loadLangsmith(): Promise<LangsmithModule | null> {
+  if (cachedLangsmith !== undefined) return cachedLangsmith
+  try {
+    const mod = (await import('langsmith')) as unknown as LangsmithModule
+    cachedLangsmith = typeof mod?.getCurrentRunTree === 'function' ? mod : null
+  } catch {
+    cachedLangsmith = null
+  }
+  return cachedLangsmith
+}
+
+/**
+ * Return the current LangSmith `RunTree`, or `undefined` if none is active or
+ * `langsmith` is not installed. Safe to call unconditionally.
+ */
+export async function activeRunTree(): Promise<RunTree | undefined> {
+  const ls = await loadLangsmith()
+  if (ls === null) return undefined
+  try {
+    // `permitAbsentRunTree: true` returns undefined instead of throwing when
+    // there is no active run, mirroring Python's `get_current_run_tree()` used
+    // behind a try/except.
+    return ls.getCurrentRunTree(true)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Merge `metadata` into `runTree`, swallowing any error. No-op if `runTree` is
+ * absent or `metadata` is empty.
+ *
+ * The langsmith `RunTree` `metadata` setter merges into `extra.metadata`
+ * (`{ ...existing, ...new }`), so this matches Python's `run_tree.add_metadata`.
+ */
+export function addMetadata(runTree: RunTree | undefined, metadata: SpanMetadata): void {
+  if (!runTree || !metadata || Object.keys(metadata).length === 0) return
+  try {
+    runTree.metadata = metadata
+  } catch {
+    // observability hygiene must never disrupt the payment flow
+  }
+}
+
+/**
+ * Remove `keys` from `runTree`'s metadata in place.
+ *
+ * LangSmith inherits a parent run's metadata into child runs created via
+ * `createChild`, so call this on the PARENT run BEFORE opening any child span
+ * whose metadata should not carry the keys. The most common use is stripping
+ * the full `payment_token` from the parent tool span's metadata, since the raw
+ * access token grants access to the protected tool until it expires.
+ *
+ * No-op when `runTree` is absent or no keys are provided. All errors are
+ * swallowed.
+ */
+export function redactMetadataKeys(runTree: RunTree | undefined, ...keys: string[]): void {
+  if (!runTree || keys.length === 0) return
+  try {
+    const extra = (runTree as unknown as { extra?: Record<string, unknown> }).extra
+    const metadata = extra?.metadata as Record<string, unknown> | undefined
+    if (metadata && typeof metadata === 'object') {
+      for (const key of keys) delete metadata[key]
+    }
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Return a short, non-functional reference to a payment token for span
+ * metadata. Mirrors `payments_py/langsmith/spans.py::abbreviate_token` incl.
+ * the redact-and-warn behavior finalized in nvm-monorepo#1747
+ * (payments-py PR #217).
+ *
+ * - `undefined`/empty input → `undefined` (and silent — no token at all is not
+ *   a "wrong token" mistake).
+ * - Already-redacted input (ends with the `…(short)` marker) → returned
+ *   unchanged and silent, so the helper stays idempotent (the decorator path
+ *   abbreviates the same token more than once).
+ * - A token of length ≤ 20 is almost always a misconfiguration (a plan id, an
+ *   opaque handle, etc. passed where the JWT was expected). Because this helper
+ *   exists to keep credentials out of a durable trace store, such tokens are
+ *   **redacted, not exported**: only `<first 4>…(short)` is returned and a
+ *   warning is emitted. The full short value never leaves this function.
+ * - Otherwise (a normal JWT, more than 20 chars) → `<first 16>…<last 4>`.
+ */
+export function abbreviateToken(token: string | undefined | null): string | undefined {
+  if (!token) return undefined
+  if (token.endsWith(SHORT_TOKEN_MARKER)) {
+    // Already redacted (re-applied on the decorator path); re-slicing would let
+    // the marker drift, so return unchanged and stay silent — the original
+    // short value already triggered the warning.
+    return token
+  }
+  if (token.length <= 20) {
+    console.warn(
+      'abbreviateToken: token is 20 characters or fewer — was the right x402 ' +
+        'access token passed? Short/non-JWT tokens are almost always a ' +
+        'misconfiguration and are redacted (not exported).',
+    )
+    return `${token.slice(0, 4)}${SHORT_TOKEN_MARKER}`
+  }
+  return `${token.slice(0, 16)}…${token.slice(-4)}`
+}
+
+/** Inputs accepted by {@link buildVerifyMetadata}. */
+export interface VerifyMetadataInput {
+  planIds: string[]
+  scheme?: string
+  network?: string
+  agentId?: string
+  verification?: VerifyPermissionsResult
+  durationMs?: number
+  token?: string
+}
+
+/**
+ * Build the `nvm.*` metadata for a verify span. Drops absent values (a key is
+ * omitted, never set to null/undefined). Matches observability-spans-v1 §2.
+ *
+ * `token` is abbreviated/redacted via {@link abbreviateToken} before being
+ * surfaced as `nvm.payment_token` so the full credential never lands in
+ * metadata we control.
+ */
+export function buildVerifyMetadata(input: VerifyMetadataInput): SpanMetadata {
+  const { planIds, scheme, network, agentId, verification, durationMs, token } = input
+  const md: SpanMetadata = { 'nvm.plan_ids': [...planIds] }
+  if (scheme) md['nvm.scheme'] = scheme
+  if (network) md['nvm.network'] = network
+  if (agentId) md['nvm.agent_id'] = agentId
+  if (durationMs !== undefined) md['nvm.verify.duration_ms'] = round2(durationMs)
+  const abbreviated = abbreviateToken(token)
+  if (abbreviated) md['nvm.payment_token'] = abbreviated
+  if (verification) {
+    if (verification.payer) md['nvm.payer'] = verification.payer
+    if (verification.network && !('nvm.network' in md)) md['nvm.network'] = verification.network
+    if (verification.agentRequestId) md['nvm.agent_request_id'] = verification.agentRequestId
+  }
+  return md
+}
+
+/** Inputs accepted by {@link buildSettleMetadata}. */
+export interface SettleMetadataInput {
+  settlement: SettlePermissionsResult
+  planIds: string[]
+  agentId?: string
+  durationMs?: number
+  token?: string
+}
+
+/**
+ * Build the `nvm.*` metadata for a settlement span. Drops absent values.
+ * Matches observability-spans-v1 §3.
+ *
+ * Note the types preserved exactly per the spec: `nvm.credits_redeemed`
+ * (←`creditsRedeemed`) and `nvm.balance.after` (←`remainingBalance`) are
+ * STRINGS — they are not coerced to numbers. `nvm.tx_hash` ← `transaction`.
+ */
+export function buildSettleMetadata(input: SettleMetadataInput): SpanMetadata {
+  const { settlement, planIds, agentId, durationMs, token } = input
+  const md: SpanMetadata = { 'nvm.plan_ids': [...planIds] }
+  if (agentId) md['nvm.agent_id'] = agentId
+  if (durationMs !== undefined) md['nvm.settle.duration_ms'] = round2(durationMs)
+  const abbreviated = abbreviateToken(token)
+  if (abbreviated) md['nvm.payment_token'] = abbreviated
+  if (settlement.creditsRedeemed != null) md['nvm.credits_redeemed'] = settlement.creditsRedeemed
+  if (settlement.remainingBalance != null) md['nvm.balance.after'] = settlement.remainingBalance
+  if (settlement.transaction) md['nvm.tx_hash'] = settlement.transaction
+  if (settlement.network) md['nvm.network'] = settlement.network
+  if (settlement.payer) md['nvm.payer'] = settlement.payer
+  return md
+}
+
+/** Round to 2 decimals, matching Python's `round(value, 2)`. */
+function round2(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+/**
+ * An opened Nevermined span. `end()` records `outputs`/`error` and flushes the
+ * child run to LangSmith. Always safe to call (no-op when `runTree` is absent).
+ */
+export interface NvmSpan {
+  /** The underlying child `RunTree`, or `undefined` when tracing is inactive. */
+  readonly runTree: RunTree | undefined
+  /** Attach `nvm.*` metadata to this span. */
+  addMetadata(metadata: SpanMetadata): void
+  /** Close the span, flushing it to LangSmith. Optionally record an error. */
+  end(error?: unknown): Promise<void>
+}
+
+async function openNvmSpan(name: string, inputs: SpanMetadata): Promise<NvmSpan> {
+  const parent = await activeRunTree()
+  if (!parent) return inactiveSpan()
+  let child: RunTree
+  try {
+    child = parent.createChild({ name, run_type: 'tool', inputs })
+  } catch {
+    // span setup is pure observability — never let it disrupt the payment flow
+    return inactiveSpan()
+  }
+  return {
+    runTree: child,
+    addMetadata(metadata: SpanMetadata) {
+      addMetadata(child, metadata)
+    },
+    async end(error?: unknown) {
+      try {
+        await child.end(
+          undefined,
+          error === undefined ? undefined : error instanceof Error ? error.message : String(error),
+        )
+        await child.postRun()
+      } catch {
+        // best-effort flush
+      }
+    },
+  }
+}
+
+function inactiveSpan(): NvmSpan {
+  return {
+    runTree: undefined,
+    addMetadata() {
+      /* no-op */
+    },
+    async end() {
+      /* no-op */
+    },
+  }
+}
+
+/** Inputs accepted by {@link verifySpan}. */
+export interface VerifySpanInput {
+  planIds: string[]
+  scheme?: string
+  network?: string
+  agentId?: string
+}
+
+/**
+ * Open an `nvm:verify` child span around a verify call. Returns an
+ * {@link NvmSpan} whose `end()` must be called once the verify completes (or
+ * throws). Always safe — a no-op span is returned when tracing is inactive or
+ * `langsmith` is not installed.
+ */
+export async function verifySpan(input: VerifySpanInput): Promise<NvmSpan> {
+  const { planIds, scheme, network, agentId } = input
+  const inputs: SpanMetadata = { plan_ids: [...planIds] }
+  if (scheme) inputs.scheme = scheme
+  if (network) inputs.network = network
+  if (agentId) inputs.agent_id = agentId
+  return openNvmSpan(NVM_VERIFY_SPAN, inputs)
+}
+
+/** Inputs accepted by {@link settlementSpan}. */
+export interface SettlementSpanInput {
+  planIds: string[]
+  agentId?: string
+}
+
+/**
+ * Open an `nvm:settlement` child span around a settle call. Same semantics as
+ * {@link verifySpan}.
+ */
+export async function settlementSpan(input: SettlementSpanInput): Promise<NvmSpan> {
+  const { planIds, agentId } = input
+  const inputs: SpanMetadata = { plan_ids: [...planIds] }
+  if (agentId) inputs.agent_id = agentId
+  return openNvmSpan(NVM_SETTLEMENT_SPAN, inputs)
+}

--- a/tests/unit/x402/langsmith-decorator.test.ts
+++ b/tests/unit/x402/langsmith-decorator.test.ts
@@ -18,6 +18,11 @@ class FakeRunTree {
   extra: { metadata?: Record<string, unknown> } & Record<string, unknown>
   children: FakeRunTree[] = []
   ended = false
+  // Captures the error string passed to `end(outputs, error)` so the wiring
+  // tests can assert the span was closed WITH the verify/settle failure reason
+  // (the production `openNvmSpan.end()` calls `child.end(undefined, message)`).
+  // Mirrors the `FakeRunTree` in `langsmith-spans.test.ts`.
+  endError: string | undefined
 
   constructor(config: {
     name?: string
@@ -51,13 +56,17 @@ class FakeRunTree {
     return child
   }
 
-  async end(): Promise<void> {
+  async end(_outputs?: unknown, error?: string): Promise<void> {
     this.ended = true
+    this.endError = error
   }
   async postRun(): Promise<void> {}
 }
 
-jest.mock('langsmith', () => {
+// Mock the `langsmith/singletons/traceable` SUB-PATH — that is the specifier
+// `loadLangsmith()` imports and where `getCurrentRunTree` lives. Mocking the
+// `langsmith` root would no-op the wiring under test.
+jest.mock('langsmith/singletons/traceable', () => {
   const state: { current: unknown } = { current: undefined }
   return {
     __esModule: true,
@@ -69,8 +78,8 @@ jest.mock('langsmith', () => {
   }
 })
 
-import * as langsmithMock from 'langsmith'
-import { requiresPayment } from '../../../src/x402/langchain/decorator.js'
+import * as langsmithMock from 'langsmith/singletons/traceable'
+import { requiresPayment, lastSettlement } from '../../../src/x402/langchain/decorator.js'
 import type {
   VerifyPermissionsResult,
   SettlePermissionsResult,
@@ -210,5 +219,64 @@ describe('requiresPayment LangSmith wiring', () => {
     // And the redacted form (never the raw value) reached the spans.
     expect(parent.children[0].metadata['nvm.payment_token']).toBe('shor…(short)')
     expect(JSON.stringify(parent.children[1].metadata)).not.toContain('short-token')
+  })
+
+  it('ends the verify span with invalidReason and skips settlement on isValid=false', async () => {
+    const parent = new FakeRunTree({ name: 'tool' })
+    setActiveRun(parent)
+    const mockPayments = makeMockPayments()
+    mockPayments.facilitator.verifyPermissions.mockResolvedValue({
+      isValid: false,
+      invalidReason: 'Insufficient credits',
+    })
+    const fn = protectedFn(mockPayments)
+
+    await expect(
+      fn({ topic: 'x' }, { configurable: { payment_token: LONG_TOKEN } }),
+    ).rejects.toThrow(/Insufficient credits/)
+
+    // Only the verify span opened; it closed WITH the invalid reason; no settle.
+    expect(parent.children.map((c) => c.name)).toEqual(['nvm:verify'])
+    expect(parent.children[0].ended).toBe(true)
+    expect(parent.children[0].endError).toBe('Insufficient credits')
+    expect(mockPayments.facilitator.settlePermissions).not.toHaveBeenCalled()
+  })
+
+  it('ends the verify span and skips settlement when verifyPermissions throws', async () => {
+    const parent = new FakeRunTree({ name: 'tool' })
+    setActiveRun(parent)
+    const mockPayments = makeMockPayments()
+    mockPayments.facilitator.verifyPermissions.mockRejectedValue(new Error('network timeout'))
+    const fn = protectedFn(mockPayments)
+
+    await expect(
+      fn({ topic: 'x' }, { configurable: { payment_token: LONG_TOKEN } }),
+    ).rejects.toThrow(/network timeout/)
+
+    expect(parent.children.map((c) => c.name)).toEqual(['nvm:verify'])
+    expect(parent.children[0].ended).toBe(true)
+    expect(parent.children[0].endError).toBe('network timeout')
+    expect(mockPayments.facilitator.settlePermissions).not.toHaveBeenCalled()
+  })
+
+  it('ends the settlement span WITH the error (and still returns) when settle throws', async () => {
+    const parent = new FakeRunTree({ name: 'tool' })
+    setActiveRun(parent)
+    const mockPayments = makeMockPayments()
+    mockPayments.facilitator.settlePermissions.mockRejectedValue(new Error('settle boom'))
+    // settlement failure is swallowed — the tool result still comes back.
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const fn = protectedFn(mockPayments)
+
+    const result = await fn({ topic: 'evs' }, { configurable: { payment_token: LONG_TOKEN } })
+
+    expect(result).toBe('insight evs')
+    // Both spans opened; the settlement span closed WITH the settle error.
+    expect(parent.children.map((c) => c.name)).toEqual(['nvm:verify', 'nvm:settlement'])
+    expect(parent.children[1].ended).toBe(true)
+    expect(parent.children[1].endError).toBe('settle boom')
+    // And the stale-receipt guard holds: a failed settle leaves no receipt.
+    expect(lastSettlement()).toBeUndefined()
+    errSpy.mockRestore()
   })
 })

--- a/tests/unit/x402/langsmith-decorator.test.ts
+++ b/tests/unit/x402/langsmith-decorator.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for the LangSmith span wiring inside the `requiresPayment`
+ * decorator (`src/x402/langchain/decorator.ts`). Proves the decorator opens
+ * `nvm:verify` / `nvm:settlement` child spans around the verify/settle calls,
+ * redacts the full `payment_token` from the parent run tree, and no-ops cleanly
+ * when no LangSmith run is active.
+ *
+ * Same caveat as `langsmith-spans.test.ts` (and the TS-0 langgraph tests,
+ * #1717): `langsmith` is replaced with a faithful `RunTree` double via
+ * `jest.mock`; the real SDK is not exercised. We assert OUR wiring, not
+ * langsmith's transport.
+ */
+
+class FakeRunTree {
+  name: string
+  run_type: string
+  inputs: Record<string, unknown>
+  extra: { metadata?: Record<string, unknown> } & Record<string, unknown>
+  children: FakeRunTree[] = []
+  ended = false
+
+  constructor(config: {
+    name?: string
+    run_type?: string
+    inputs?: Record<string, unknown>
+    extra?: Record<string, unknown>
+  }) {
+    this.name = config.name ?? ''
+    this.run_type = config.run_type ?? 'chain'
+    this.inputs = config.inputs ?? {}
+    this.extra = (config.extra as FakeRunTree['extra']) ?? {}
+  }
+
+  set metadata(metadata: Record<string, unknown>) {
+    this.extra = {
+      ...this.extra,
+      metadata: { ...this.extra?.metadata, ...metadata },
+    }
+  }
+  get metadata(): Record<string, unknown> {
+    return this.extra?.metadata ?? {}
+  }
+
+  createChild(config: {
+    name: string
+    run_type?: string
+    inputs?: Record<string, unknown>
+  }): FakeRunTree {
+    const child = new FakeRunTree(config)
+    this.children.push(child)
+    return child
+  }
+
+  async end(): Promise<void> {
+    this.ended = true
+  }
+  async postRun(): Promise<void> {}
+}
+
+jest.mock('langsmith', () => {
+  const state: { current: unknown } = { current: undefined }
+  return {
+    __esModule: true,
+    RunTree: FakeRunTree,
+    getCurrentRunTree: (_permitAbsent: boolean) => state.current,
+    __setCurrentRunTree: (rt: unknown) => {
+      state.current = rt
+    },
+  }
+})
+
+import * as langsmithMock from 'langsmith'
+import { requiresPayment } from '../../../src/x402/langchain/decorator.js'
+import type {
+  VerifyPermissionsResult,
+  SettlePermissionsResult,
+} from '../../../src/x402/facilitator-api.js'
+
+function setActiveRun(rt: FakeRunTree | undefined): void {
+  ;(langsmithMock as unknown as { __setCurrentRunTree: (rt: unknown) => void }).__setCurrentRunTree(
+    rt,
+  )
+}
+
+const VERIFY_OK: VerifyPermissionsResult = {
+  isValid: true,
+  payer: '0x1234567890abcdef',
+  network: 'eip155:84532',
+  agentRequestId: 'req-123',
+}
+const SETTLE_OK: SettlePermissionsResult = {
+  success: true,
+  payer: '0x1234567890abcdef',
+  transaction: '0xabc123',
+  network: 'eip155:84532',
+  creditsRedeemed: '1',
+  remainingBalance: '99',
+}
+
+function makeMockPayments() {
+  return {
+    facilitator: {
+      verifyPermissions: jest.fn().mockResolvedValue({ ...VERIFY_OK }),
+      settlePermissions: jest.fn().mockResolvedValue({ ...SETTLE_OK }),
+    },
+  }
+}
+
+function protectedFn(mockPayments: ReturnType<typeof makeMockPayments>) {
+  return requiresPayment((args: { topic: string }) => `insight ${args.topic}`, {
+    payments: mockPayments as never,
+    planId: 'plan-123',
+    credits: 1,
+    agentId: 'agent-x',
+  })
+}
+
+const LONG_TOKEN = 'j'.repeat(40)
+
+beforeEach(() => {
+  setActiveRun(undefined)
+  jest.restoreAllMocks()
+})
+
+describe('requiresPayment LangSmith wiring', () => {
+  it('emits nvm:verify and nvm:settlement child spans under an active run', async () => {
+    const parent = new FakeRunTree({ name: 'tool' })
+    setActiveRun(parent)
+    const fn = protectedFn(makeMockPayments())
+
+    await fn({ topic: 'evs' }, { configurable: { payment_token: LONG_TOKEN } })
+
+    const names = parent.children.map((c) => c.name)
+    expect(names).toEqual(['nvm:verify', 'nvm:settlement'])
+    for (const child of parent.children) {
+      expect(child.run_type).toBe('tool')
+      expect(child.ended).toBe(true)
+    }
+
+    const verify = parent.children[0]
+    expect(verify.metadata['nvm.plan_ids']).toEqual(['plan-123'])
+    expect(verify.metadata['nvm.payer']).toBe('0x1234567890abcdef')
+    expect(verify.metadata['nvm.agent_request_id']).toBe('req-123')
+    // Abbreviated token only — never the raw credential.
+    expect(verify.metadata['nvm.payment_token']).toBe(`${'j'.repeat(16)}…jjjj`)
+    expect(JSON.stringify(verify.metadata)).not.toContain(LONG_TOKEN)
+
+    const settle = parent.children[1]
+    expect(settle.metadata['nvm.tx_hash']).toBe('0xabc123')
+    expect(settle.metadata['nvm.credits_redeemed']).toBe('1')
+    expect(settle.metadata['nvm.balance.after']).toBe('99')
+  })
+
+  it('strips the full payment_token from the parent run tree before verifying', async () => {
+    const parent = new FakeRunTree({ name: 'tool' })
+    // LangChain would have copied configurable.payment_token onto the parent.
+    parent.metadata = { payment_token: LONG_TOKEN }
+    setActiveRun(parent)
+    const fn = protectedFn(makeMockPayments())
+
+    await fn({ topic: 'x' }, { configurable: { payment_token: LONG_TOKEN } })
+
+    expect('payment_token' in parent.metadata).toBe(false)
+    // The parent still gets the abbreviated nvm.payment_token for correlation.
+    expect(parent.metadata['nvm.payment_token']).toBe(`${'j'.repeat(16)}…jjjj`)
+    expect(JSON.stringify(parent.metadata)).not.toContain(LONG_TOKEN)
+  })
+
+  it('opens a verify span even for an unpaid probe (no token)', async () => {
+    const parent = new FakeRunTree({ name: 'tool' })
+    setActiveRun(parent)
+    const mockPayments = makeMockPayments()
+    const fn = protectedFn(mockPayments)
+
+    await expect(fn({ topic: 'x' }, { configurable: {} })).rejects.toThrow(/Payment required/)
+
+    expect(parent.children.map((c) => c.name)).toEqual(['nvm:verify'])
+    expect(parent.children[0].metadata['nvm.plan_ids']).toEqual(['plan-123'])
+    expect(parent.children[0].ended).toBe(true)
+    expect(mockPayments.facilitator.verifyPermissions).not.toHaveBeenCalled()
+  })
+
+  it('no-ops (and still settles) when no LangSmith run is active', async () => {
+    setActiveRun(undefined)
+    const mockPayments = makeMockPayments()
+    const fn = protectedFn(mockPayments)
+
+    const result = await fn({ topic: 'evs' }, { configurable: { payment_token: LONG_TOKEN } })
+
+    expect(result).toBe('insight evs')
+    expect(mockPayments.facilitator.verifyPermissions).toHaveBeenCalledTimes(1)
+    expect(mockPayments.facilitator.settlePermissions).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/x402/langsmith-decorator.test.ts
+++ b/tests/unit/x402/langsmith-decorator.test.ts
@@ -259,6 +259,27 @@ describe('requiresPayment LangSmith wiring', () => {
     expect(mockPayments.facilitator.settlePermissions).not.toHaveBeenCalled()
   })
 
+  it('persists only the ABBREVIATED token in config.configurable.payment_context (never the raw credential)', async () => {
+    const parent = new FakeRunTree({ name: 'tool' })
+    setActiveRun(parent)
+    // Hold a reference to the same configurable bag the decorator mutates, so we
+    // can read payment_context back after invocation.
+    const config: { configurable: Record<string, unknown> } = {
+      configurable: { payment_token: LONG_TOKEN },
+    }
+    const fn = protectedFn(makeMockPayments())
+
+    await fn({ topic: 'evs' }, config)
+
+    const ctx = config.configurable.payment_context as { token: string }
+    expect(ctx).toBeDefined()
+    // The stored token is the abbreviated reference, not the raw credential —
+    // so LangChain capturing config.configurable into a nested span can't leak
+    // the full token (the gap aaitor flagged on the nested payment_context.token).
+    expect(ctx.token).toBe(`${'j'.repeat(16)}…jjjj`)
+    expect(JSON.stringify(config.configurable.payment_context)).not.toContain(LONG_TOKEN)
+  })
+
   it('ends the settlement span WITH the error (and still returns) when settle throws', async () => {
     const parent = new FakeRunTree({ name: 'tool' })
     setActiveRun(parent)

--- a/tests/unit/x402/langsmith-decorator.test.ts
+++ b/tests/unit/x402/langsmith-decorator.test.ts
@@ -191,4 +191,24 @@ describe('requiresPayment LangSmith wiring', () => {
     expect(mockPayments.facilitator.verifyPermissions).toHaveBeenCalledTimes(1)
     expect(mockPayments.facilitator.settlePermissions).toHaveBeenCalledTimes(1)
   })
+
+  it('warns once (not per build) for a misconfigured short token', async () => {
+    // The decorator pre-abbreviates the token ONCE (mirrors Python's
+    // attach_metadata_safely), so a short token warns a single time even though
+    // the verify + settle builders both surface nvm.payment_token.
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const parent = new FakeRunTree({ name: 'tool' })
+    setActiveRun(parent)
+    const fn = protectedFn(makeMockPayments())
+
+    await fn({ topic: 'x' }, { configurable: { payment_token: 'short-token' } })
+
+    const shortWarns = warn.mock.calls.filter((c) =>
+      String(c[0]).includes('20 characters or fewer'),
+    )
+    expect(shortWarns).toHaveLength(1)
+    // And the redacted form (never the raw value) reached the spans.
+    expect(parent.children[0].metadata['nvm.payment_token']).toBe('shor…(short)')
+    expect(JSON.stringify(parent.children[1].metadata)).not.toContain('short-token')
+  })
 })

--- a/tests/unit/x402/langsmith-real-sdk.test.ts
+++ b/tests/unit/x402/langsmith-real-sdk.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Real-SDK smoke test (NO jest.mock) guarding the langsmith import path that
+ * `loadLangsmith()` (src/x402/langsmith/spans.ts) depends on.
+ *
+ * Why this exists: `getCurrentRunTree` is NOT exported from the `langsmith`
+ * root — it lives exclusively at the `langsmith/singletons/traceable` sub-path.
+ * The wiring tests in `langsmith-spans.test.ts` / `langsmith-decorator.test.ts`
+ * MOCK that sub-path, so they would stay green even if the real package moved
+ * or renamed the export. That is the exact regression that once shipped the
+ * whole observability feature dead with a green CI (the import resolved, the
+ * `typeof getCurrentRunTree === 'function'` check silently failed, every span
+ * no-op'd). This test asserts the real contract so a future langsmith
+ * re-arrangement fails HERE instead of at a customer.
+ *
+ * It imports the REAL module in a child `node` process rather than directly in
+ * jest: the project's jest config does not transform `node_modules` (langsmith
+ * pulls in ESM-only deps such as `uuid`), so a direct `import('langsmith/...')`
+ * inside a jest test fails to load for reasons unrelated to the export shape.
+ * Node imports the real ESM module natively, exactly as production does at
+ * runtime, so this faithfully exercises the path `loadLangsmith()` takes.
+ */
+import { execFileSync } from 'node:child_process'
+
+describe('langsmith real-SDK import path (no mock)', () => {
+  it('exports getCurrentRunTree as a function from langsmith/singletons/traceable', () => {
+    // Mirrors the runtime import in `loadLangsmith()`. On success prints
+    // `function`; on a missing export prints `<typeof>`; on a failed import
+    // prints `import-error:<code>` and exits non-zero (surfaced by execFileSync).
+    const script =
+      "import('langsmith/singletons/traceable')" +
+      '.then((m) => process.stdout.write(typeof m.getCurrentRunTree))' +
+      ".catch((e) => { process.stdout.write('import-error:' + (e && e.code)); process.exitCode = 1 })"
+
+    const out = execFileSync(process.execPath, ['--input-type=module', '-e', script], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    })
+
+    expect(out).toBe('function')
+  })
+})

--- a/tests/unit/x402/langsmith-spans.test.ts
+++ b/tests/unit/x402/langsmith-spans.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Unit tests for the LangSmith span helpers (`src/x402/langsmith/spans.ts`),
+ * the TS parity port of `payments_py/langsmith/spans.py`.
+ *
+ * These tests assert OUR wiring: the `nvm.*` attribute set + types per the
+ * observability-spans-v1 contract, the redact-and-warn token defense (#1747),
+ * the parent-metadata redaction, and that `nvm:verify` / `nvm:settlement` child
+ * spans are opened with `run_type: "tool"`.
+ *
+ * Caveat (mirrors the TS-0 langgraph approach, see #1717): the real `langsmith`
+ * JS SDK is replaced with a faithful `RunTree` double via `jest.mock` (the
+ * repo's ts-jest config transpiles to CommonJS, so `jest.mock(...)` with a
+ * factory + regular `import` is the working pattern — the same one TS-0's
+ * `langchain-decorator.test.ts` uses). The project's Jest setup does not
+ * transform `node_modules` (langsmith pulls in ESM-only deps such as `uuid@14`)
+ * and `tsc` excludes `tests/`, so these unit tests do NOT validate against the
+ * real langsmith runtime. The double's shape was taken from `langsmith@0.7.4`'s
+ * `RunTree` (`createChild`/`end`/`postRun`, the merging `metadata` setter that
+ * writes `extra.metadata`, and `getCurrentRunTree`). A real-SDK integration test
+ * is deferred to the follow-up tutorial work (out of scope here).
+ */
+
+/** Minimal stand-in mirroring the langsmith@0.7.4 RunTree surface we use. */
+class FakeRunTree {
+  name: string
+  run_type: string
+  inputs: Record<string, unknown>
+  extra: { metadata?: Record<string, unknown> } & Record<string, unknown>
+  children: FakeRunTree[] = []
+  ended = false
+  endError: string | undefined
+  posted = false
+
+  constructor(config: {
+    name?: string
+    run_type?: string
+    inputs?: Record<string, unknown>
+    extra?: Record<string, unknown>
+  }) {
+    this.name = config.name ?? ''
+    this.run_type = config.run_type ?? 'chain'
+    this.inputs = config.inputs ?? {}
+    this.extra = (config.extra as FakeRunTree['extra']) ?? {}
+  }
+
+  // The real setter merges into extra.metadata ({ ...existing, ...new }).
+  set metadata(metadata: Record<string, unknown>) {
+    this.extra = {
+      ...this.extra,
+      metadata: { ...this.extra?.metadata, ...metadata },
+    }
+  }
+  get metadata(): Record<string, unknown> {
+    return this.extra?.metadata ?? {}
+  }
+
+  createChild(config: {
+    name: string
+    run_type?: string
+    inputs?: Record<string, unknown>
+  }): FakeRunTree {
+    const child = new FakeRunTree(config)
+    this.children.push(child)
+    return child
+  }
+
+  async end(_outputs?: unknown, error?: string): Promise<void> {
+    this.ended = true
+    this.endError = error
+  }
+
+  async postRun(): Promise<void> {
+    this.posted = true
+  }
+}
+
+// `jest.mock` factories are hoisted above imports and may not close over
+// outer `let`/`const`, so the mutable "active run" handle lives on the mock
+// module itself and is read back via the imported mock in each test.
+jest.mock('langsmith', () => {
+  const state: { current: unknown } = { current: undefined }
+  return {
+    __esModule: true,
+    RunTree: FakeRunTree,
+    getCurrentRunTree: (_permitAbsent: boolean) => state.current,
+    // test-only handle to set the active run tree
+    __setCurrentRunTree: (rt: unknown) => {
+      state.current = rt
+    },
+  }
+})
+
+import * as langsmithMock from 'langsmith'
+import {
+  abbreviateToken,
+  activeRunTree,
+  addMetadata,
+  buildSettleMetadata,
+  buildVerifyMetadata,
+  redactMetadataKeys,
+  settlementSpan,
+  verifySpan,
+} from '../../../src/x402/langsmith/spans.js'
+import type {
+  VerifyPermissionsResult,
+  SettlePermissionsResult,
+} from '../../../src/x402/facilitator-api.js'
+
+function setActiveRun(rt: FakeRunTree | undefined): void {
+  ;(langsmithMock as unknown as { __setCurrentRunTree: (rt: unknown) => void }).__setCurrentRunTree(
+    rt,
+  )
+}
+
+beforeEach(() => {
+  setActiveRun(undefined)
+  jest.restoreAllMocks()
+})
+
+// ---- abbreviateToken (redact + warn, #1747 / payments-py#217) -------------
+
+describe('abbreviateToken', () => {
+  it('abbreviates a long JWT-like token to <first16>…<last4>', () => {
+    const token = 'a'.repeat(40)
+    expect(abbreviateToken(token)).toBe(`${token.slice(0, 16)}…${token.slice(-4)}`)
+  })
+
+  it('returns undefined (silently) for empty/undefined input', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(abbreviateToken(undefined)).toBeUndefined()
+    expect(abbreviateToken(null)).toBeUndefined()
+    expect(abbreviateToken('')).toBeUndefined()
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('redacts a <=20-char token to <first4>…(short) AND warns', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const short = 'not-a-real-jwt' // 14 chars
+    const result = abbreviateToken(short)
+    expect(result).toBe('not-…(short)')
+    // Full short value never leaves the helper.
+    expect(result).not.toContain(short)
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats exactly 20 chars as short (inclusive upper bound)', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(abbreviateToken('a'.repeat(20))).toBe('aaaa…(short)')
+  })
+
+  it('is idempotent on an already-redacted value and stays silent', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const redacted = 'aaaa…(short)'
+    expect(abbreviateToken(redacted)).toBe(redacted)
+    expect(warn).not.toHaveBeenCalled()
+  })
+})
+
+// ---- buildVerifyMetadata --------------------------------------------------
+
+describe('buildVerifyMetadata', () => {
+  it('always includes nvm.plan_ids and drops absent optionals', () => {
+    const md = buildVerifyMetadata({ planIds: ['plan-1'] })
+    expect(md).toEqual({ 'nvm.plan_ids': ['plan-1'] })
+  })
+
+  it('includes static fields, rounds duration, abbreviates token', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const md = buildVerifyMetadata({
+      planIds: ['plan-1', 'plan-2'],
+      scheme: 'nvm:erc4337',
+      network: 'eip155:84532',
+      agentId: 'agent-x',
+      durationMs: 12.3456,
+      token: 'j'.repeat(40),
+    })
+    expect(md['nvm.scheme']).toBe('nvm:erc4337')
+    expect(md['nvm.network']).toBe('eip155:84532')
+    expect(md['nvm.agent_id']).toBe('agent-x')
+    expect(md['nvm.verify.duration_ms']).toBe(12.35)
+    expect(md['nvm.payment_token']).toBe(`${'j'.repeat(16)}…jjjj`)
+  })
+
+  it('extracts payer/agent_request_id and network-fallback from verification', () => {
+    const verification: VerifyPermissionsResult = {
+      isValid: true,
+      payer: '0xabc',
+      network: 'eip155:84532',
+      agentRequestId: 'req-9',
+    }
+    const md = buildVerifyMetadata({ planIds: ['p'], verification })
+    expect(md['nvm.payer']).toBe('0xabc')
+    expect(md['nvm.agent_request_id']).toBe('req-9')
+    expect(md['nvm.network']).toBe('eip155:84532')
+  })
+
+  it('lets an explicit network win over the verification network', () => {
+    const verification: VerifyPermissionsResult = {
+      isValid: true,
+      network: 'eip155:1',
+    }
+    const md = buildVerifyMetadata({
+      planIds: ['p'],
+      network: 'eip155:84532',
+      verification,
+    })
+    expect(md['nvm.network']).toBe('eip155:84532')
+  })
+
+  it('omits nvm.payment_token when no token supplied', () => {
+    const md = buildVerifyMetadata({ planIds: ['p'] })
+    expect('nvm.payment_token' in md).toBe(false)
+  })
+})
+
+// ---- buildSettleMetadata --------------------------------------------------
+
+describe('buildSettleMetadata', () => {
+  const SETTLE_OK: SettlePermissionsResult = {
+    success: true,
+    payer: '0xabc',
+    transaction: '0xdeadbeef',
+    network: 'eip155:84532',
+    creditsRedeemed: '5',
+    remainingBalance: '95',
+  }
+
+  it('maps fields per spec and keeps credit/balance as STRINGS', () => {
+    const md = buildSettleMetadata({
+      settlement: SETTLE_OK,
+      planIds: ['plan-1'],
+      agentId: 'agent-x',
+      durationMs: 8.0,
+    })
+    expect(md['nvm.plan_ids']).toEqual(['plan-1'])
+    expect(md['nvm.agent_id']).toBe('agent-x')
+    expect(md['nvm.settle.duration_ms']).toBe(8)
+    expect(md['nvm.tx_hash']).toBe('0xdeadbeef')
+    expect(md['nvm.network']).toBe('eip155:84532')
+    expect(md['nvm.payer']).toBe('0xabc')
+    // Types preserved exactly — strings, not numbers.
+    expect(md['nvm.credits_redeemed']).toBe('5')
+    expect(typeof md['nvm.credits_redeemed']).toBe('string')
+    expect(md['nvm.balance.after']).toBe('95')
+    expect(typeof md['nvm.balance.after']).toBe('string')
+  })
+
+  it('omits empty transaction and network', () => {
+    const md = buildSettleMetadata({
+      settlement: { success: false, transaction: '', network: '' },
+      planIds: ['p'],
+    })
+    expect('nvm.tx_hash' in md).toBe(false)
+    expect('nvm.network' in md).toBe(false)
+  })
+
+  it('omits credits/balance when undefined', () => {
+    const md = buildSettleMetadata({
+      settlement: { success: true, transaction: '0x1', network: 'eip155:1' },
+      planIds: ['p'],
+    })
+    expect('nvm.credits_redeemed' in md).toBe(false)
+    expect('nvm.balance.after' in md).toBe(false)
+  })
+})
+
+// ---- activeRunTree / addMetadata / redactMetadataKeys ---------------------
+
+describe('activeRunTree', () => {
+  it('returns the current run tree when one is active', async () => {
+    const rt = new FakeRunTree({ name: 'parent' })
+    setActiveRun(rt)
+    expect(await activeRunTree()).toBe(rt as never)
+  })
+
+  it('returns undefined when no run is active', async () => {
+    setActiveRun(undefined)
+    expect(await activeRunTree()).toBeUndefined()
+  })
+})
+
+describe('addMetadata', () => {
+  it('merges metadata into the run tree', () => {
+    const rt = new FakeRunTree({ name: 'p' })
+    addMetadata(rt as never, { 'nvm.plan_ids': ['a'] })
+    addMetadata(rt as never, { 'nvm.payer': '0x1' })
+    expect(rt.metadata).toEqual({ 'nvm.plan_ids': ['a'], 'nvm.payer': '0x1' })
+  })
+
+  it('is a no-op for an undefined run tree or empty metadata', () => {
+    expect(() => addMetadata(undefined, { a: 1 })).not.toThrow()
+    const rt = new FakeRunTree({ name: 'p' })
+    addMetadata(rt as never, {})
+    expect(rt.metadata).toEqual({})
+  })
+})
+
+describe('redactMetadataKeys', () => {
+  it('removes the given keys from the run tree metadata in place', () => {
+    const rt = new FakeRunTree({ name: 'p' })
+    rt.metadata = { payment_token: 'SECRET', keep: 'me' }
+    redactMetadataKeys(rt as never, 'payment_token')
+    expect('payment_token' in rt.metadata).toBe(false)
+    expect(rt.metadata.keep).toBe('me')
+  })
+
+  it('is a no-op when run tree is undefined or no keys given', () => {
+    expect(() => redactMetadataKeys(undefined, 'x')).not.toThrow()
+    const rt = new FakeRunTree({ name: 'p' })
+    rt.metadata = { a: 1 }
+    redactMetadataKeys(rt as never)
+    expect(rt.metadata).toEqual({ a: 1 })
+  })
+})
+
+// ---- verifySpan / settlementSpan ------------------------------------------
+
+describe('verifySpan / settlementSpan', () => {
+  it('opens an nvm:verify child span with run_type tool when traced', async () => {
+    const parent = new FakeRunTree({ name: 'tool' })
+    setActiveRun(parent)
+    const span = await verifySpan({
+      planIds: ['plan-1'],
+      scheme: 'nvm:erc4337',
+      network: 'eip155:84532',
+      agentId: 'agent-x',
+    })
+    expect(span.runTree).toBeDefined()
+    const child = parent.children[0]
+    expect(child.name).toBe('nvm:verify')
+    expect(child.run_type).toBe('tool')
+    expect(child.inputs).toEqual({
+      plan_ids: ['plan-1'],
+      scheme: 'nvm:erc4337',
+      network: 'eip155:84532',
+      agent_id: 'agent-x',
+    })
+    span.addMetadata({ 'nvm.plan_ids': ['plan-1'] })
+    expect(child.metadata['nvm.plan_ids']).toEqual(['plan-1'])
+    await span.end()
+    expect(child.ended).toBe(true)
+    expect(child.posted).toBe(true)
+  })
+
+  it('opens an nvm:settlement child span (plan_ids + agent_id only)', async () => {
+    const parent = new FakeRunTree({ name: 'tool' })
+    setActiveRun(parent)
+    const span = await settlementSpan({ planIds: ['p'], agentId: 'a' })
+    const child = parent.children[0]
+    expect(child.name).toBe('nvm:settlement')
+    expect(child.run_type).toBe('tool')
+    expect(child.inputs).toEqual({ plan_ids: ['p'], agent_id: 'a' })
+    await span.end(new Error('boom'))
+    expect(child.endError).toBe('boom')
+  })
+
+  it('returns an inactive no-op span when no run is active', async () => {
+    setActiveRun(undefined)
+    const span = await verifySpan({ planIds: ['p'] })
+    expect(span.runTree).toBeUndefined()
+    // No-op methods must not throw.
+    span.addMetadata({ x: 1 })
+    await expect(span.end()).resolves.toBeUndefined()
+  })
+})

--- a/tests/unit/x402/langsmith-spans.test.ts
+++ b/tests/unit/x402/langsmith-spans.test.ts
@@ -77,7 +77,12 @@ class FakeRunTree {
 // `jest.mock` factories are hoisted above imports and may not close over
 // outer `let`/`const`, so the mutable "active run" handle lives on the mock
 // module itself and is read back via the imported mock in each test.
-jest.mock('langsmith', () => {
+//
+// Mock the `langsmith/singletons/traceable` SUB-PATH, not the `langsmith` root:
+// that is where `getCurrentRunTree` actually lives and what `loadLangsmith()`
+// imports. Mocking the root here would leave the real sub-path import in place
+// and the wiring untested (see `langsmith-real-sdk.test.ts`).
+jest.mock('langsmith/singletons/traceable', () => {
   const state: { current: unknown } = { current: undefined }
   return {
     __esModule: true,
@@ -90,7 +95,7 @@ jest.mock('langsmith', () => {
   }
 })
 
-import * as langsmithMock from 'langsmith'
+import * as langsmithMock from 'langsmith/singletons/traceable'
 import {
   abbreviateToken,
   activeRunTree,

--- a/tests/unit/x402/langsmith-spans.test.ts
+++ b/tests/unit/x402/langsmith-spans.test.ts
@@ -148,10 +148,41 @@ describe('abbreviateToken', () => {
     expect(abbreviateToken('a'.repeat(20))).toBe('aaaa…(short)')
   })
 
-  it('is idempotent on an already-redacted value and stays silent', () => {
+  it('collapses a <=4-char token to just the marker (reveals nothing)', () => {
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
-    const redacted = 'aaaa…(short)'
-    expect(abbreviateToken(redacted)).toBe(redacted)
+    // A 1–4 char token: revealing the first 4 would reveal the WHOLE value, so
+    // nothing is revealed — it collapses to just the marker. (Regression guard
+    // for the pre-#217 behavior where `abbreviateToken('abcd')` leaked 'abcd'.)
+    expect(abbreviateToken('abcd')).toBe('…(short)')
+    expect(abbreviateToken('a')).toBe('…(short)')
+    expect(abbreviateToken('xy')).toBe('…(short)')
+    expect(warn).toHaveBeenCalledTimes(3)
+  })
+
+  it('is idempotent on a genuine redacted marker and stays silent', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    // Both valid marker lengths: 8 (collapsed) and 12 (<first4> + marker).
+    expect(abbreviateToken('…(short)')).toBe('…(short)') // length 8
+    expect(abbreviateToken('aaaa…(short)')).toBe('aaaa…(short)') // length 12
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('redacts a raw value that merely ENDS in the marker (wrong length)', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    // A raw secret that happens to end in the marker but is NOT length 8/12 must
+    // be redacted, not returned verbatim (classifier-bypass guard, #217).
+    const sneaky = 'secret-x…(short)' // length 16, ends in marker
+    const result = abbreviateToken(sneaky)
+    expect(result).toBe('secr…(short)')
+    expect(result).not.toBe(sneaky)
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('is idempotent on an already-abbreviated long token', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const tok = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.sig-XYZ'
+    const once = abbreviateToken(tok)
+    expect(abbreviateToken(once)).toBe(once)
     expect(warn).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Description

TS parity for Sprint 1 observability: the TypeScript SDK now emits the cross-SDK
`nvm:verify` / `nvm:settlement` LangSmith spans around the x402 verify→work→settle
lifecycle, matching the Python SDK **attribute-for-attribute** per the
[observability-spans-v1 contract](https://github.com/nevermined-io/nvm-monorepo/blob/main/docs/specs/observability-spans-v1.md)
(nvm-monorepo#1746, spec PR nevermined-io/nvm-monorepo#1882). Identical spans let a single
LangSmith trace be correlated across a TypeScript buyer and a Python seller — e.g. filter on `nvm.tx_hash`.

> **Stacked on TS-0 (#370).** Base is `feat/ts0-langchain-helpers`, not `main` — this PR
> and TS-0 both edit `src/x402/langchain/decorator.ts`. Merges **after** #370; retarget base→main
> once TS-0 lands (GitHub usually auto-retargets). Review only the delta on top of TS-0.

### Design — Option B (Python-parity), user-confirmed

The original issue framing assumed a `NeverminedTracer extends BaseCallbackHandler`. **That class does
not exist in payments-py** (verified). Sprint 1's Python model is *imperative* spans opened by the
`@requires_payment` decorator (`verify_span` / `settlement_span` in `payments_py/langsmith/spans.py`),
not a passive callback handler. Per the user decision (2026-06-04), this PR ports that model: span
helpers wired into the existing TS `requiresPayment` decorator around `verifyPermissions` /
`settlePermissions`, mirroring Python's decorator.

### What's here

- **`src/x402/langsmith/spans.ts`** — `verifySpan` / `settlementSpan` (langsmith JS `RunTree.createChild`,
  `run_type: "tool"`, names exactly `nvm:verify` / `nvm:settlement`), `buildVerifyMetadata` /
  `buildSettleMetadata` (exact `nvm.*` set per spec; `nvm.credits_redeemed` & `nvm.balance.after` stay
  **strings**; `nvm.payment_token` joiner is **U+2026** `…`; `nvm.tx_hash`←`transaction`,
  `nvm.balance.after`←`remainingBalance`), `abbreviateToken` (redact+warn per #1747 / payments-py#217:
  ≤20-char tokens redacted to `<first4>…(short)` + warn, idempotent; empty stays silent),
  `redactMetadataKeys`, `activeRunTree`, `addMetadata`.
- **`src/x402/langsmith/index.ts`** + a `./langsmith` subpath export.
- **`decorator.ts` wiring** — redacts the full `payment_token` from the parent run tree **before**
  opening the verify span; two-pass verify metadata (static pre-verify so unpaid discovery probes are
  still labeled, then results + timing); settlement span around the settle call. No-op when tracing is
  off or `langsmith` is absent.
- **Packaging** — `langsmith` declared as an **optional peer dependency** (consistent with
  `@langchain/core`), imported **lazily** so non-observability users aren't forced to install it.

### Tests

26 new unit tests (`tests/unit/x402/langsmith-spans.test.ts`, `langsmith-decorator.test.ts`): span
names + attributes per spec, types preserved as strings, redact+warn token defense, full token never
shipped, parent-token redaction, no-op when tracing disabled. Full unit suite green: **201 passed**.

Caveat (honest, mirrors TS-0's langgraph tests in #1717): the real `langsmith` JS SDK is replaced with
a faithful `RunTree` double via `jest.mock` — the repo's Jest setup doesn't transform `node_modules`
(langsmith pulls in ESM-only `uuid@14`) and `tsc` excludes `tests/`, so these unit tests assert OUR
wiring, not langsmith's transport. The double's shape was taken from `langsmith@0.7.4`. A real-SDK
integration test is deferred to the tutorial follow-up.

### Out of scope (human closeout — NOT in this PR)

The TS variant tutorial (sibling of `langchain-paid-agent-py-with-langsmith`) and the demo video — an
agent can't record a video. Ships the SDK module + tests + docs; the tutorial/video remain for a human.

### Docs

Separate docs PR updates `docs/integrate/add-to-your-agent/langchain.mdx` "Trace payments in LangSmith"
section to cover TypeScript alongside Python (the api-reference tree is generated on release via
update-docs.yml). Link: _added in a follow-up comment._

## Is this PR related with an open issue?

Part of epic nevermined-io/nvm-monorepo#1703
Closes nevermined-io/nvm-monorepo#1709
Spec: nevermined-io/nvm-monorepo#1882 · Stacked on TS-0: #370

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Follows the code style of this project. (`pnpm lint` + prettier clean)
- [x] Tests Cover Changes (26 new unit tests; full unit suite 201 passed)
- [x] Documentation (separate docs PR; `./langsmith` subpath + JSDoc)

#### Funny gif

![tracing](https://media.giphy.com/media/3o7TKsQ8UQ0Mcsq4ze/giphy.gif)

🤖 Generated with [Claude Code](https://claude.com/claude-code)