### PR TITLE
fix(langchain): remove raw payment_token from config.configurable

### DIFF
--- a/src/x402/langchain/decorator.ts
+++ b/src/x402/langchain/decorator.ts
@@ -211,6 +211,17 @@ function storeInConfigurable(config: unknown, key: string, value: unknown): void
 }
 
 /**
+ * Remove a key from config.configurable if present (no-op otherwise).
+ */
+function removeFromConfigurable(config: unknown, key: string): void {
+  if (config == null || typeof config !== 'object') return
+
+  const configurable = (config as Record<string, unknown>).configurable
+  if (configurable == null || typeof configurable !== 'object') return
+  delete (configurable as Record<string, unknown>)[key]
+}
+
+/**
  * Wraps a LangChain.js tool implementation with x402 payment verification and settlement.
  *
  * This is a higher-order function that takes the tool's implementation function and
@@ -319,6 +330,22 @@ export function requiresPayment<TArgs extends Record<string, unknown>, TResult>(
       )
     }
 
+    // Drop the raw token from configurable now that we hold it in `token`.
+    // LangChain's `ensureConfig` re-promotes every configurable scalar into a
+    // runnable's `metadata` on EACH invocation, so any traced runnable the tool
+    // body spawns (an LLM call, a sub-chain) sharing this config would otherwise
+    // re-leak the full credential into its own span metadata — and a child run
+    // opened *during* `fn()` would capture it before the settle-side
+    // `redactMetadataKeys` below could run. Removing the key here is the
+    // proactive complement to that reactive redaction. This MUST run after
+    // extraction (deleting earlier would make `extractPaymentToken` return null)
+    // and before `fn()` — guaranteed, since `fn()` is called further down.
+    // Settlement uses the local `token`, never configurable, so removal is
+    // non-functional. On the `tool()`/LangGraph path LangChain hands the wrapper
+    // a per-invocation config copy, so this does not mutate a config the caller
+    // reuses across sibling tools.
+    removeFromConfigurable(config, 'payment_token')
+
     // Abbreviate/redact the token ONCE here (mirrors Python's
     // attach_metadata_safely pre-abbreviation) and pass the result into the
     // metadata builders. abbreviateToken is idempotent, so the builders leave
@@ -402,13 +429,15 @@ export function requiresPayment<TArgs extends Record<string, unknown>, TResult>(
     // Settle credits, wrapped in an nvm:settlement span (mirrors Python's
     // settlement_span around settle_permissions).
     //
-    // Re-fetch the active run tree: the verify-side redaction at the top of this
-    // function stripped `payment_token` from the run tree active BEFORE `fn()`,
-    // but `fn()` may have opened nested traced runs, so `activeRunTree()` can now
-    // return a different RunTree that LangChain auto-populated with the raw
-    // `payment_token` from `config.configurable`. Redact it again here, BEFORE
-    // opening the settlement span, so the credential never rides into the settle
-    // child span or the (possibly new) parent tree.
+    // Re-fetch the active run tree: `fn()` may have opened nested traced runs, so
+    // `activeRunTree()` can now return a different RunTree than the verify-side
+    // redaction at the top of this function scrubbed. We already removed
+    // `payment_token` from `config.configurable` before `fn()` ran, so newly
+    // opened child runs can no longer re-promote the raw credential — this
+    // re-redaction is now defense-in-depth, covering any RunTree whose metadata
+    // was populated before that removal took effect. Redact BEFORE opening the
+    // settlement span so the credential never rides into the settle child span or
+    // the (possibly new) parent tree.
     const settleParentRunTree = await activeRunTree()
     redactMetadataKeys(settleParentRunTree, 'payment_token')
     const settleStarted = Date.now()

--- a/tests/unit/x402/langsmith-decorator.test.ts
+++ b/tests/unit/x402/langsmith-decorator.test.ts
@@ -280,6 +280,30 @@ describe('requiresPayment LangSmith wiring', () => {
     expect(JSON.stringify(config.configurable.payment_context)).not.toContain(LONG_TOKEN)
   })
 
+  it('removes the raw payment_token from config.configurable after extraction (nvm-monorepo#1901)', async () => {
+    const parent = new FakeRunTree({ name: 'tool' })
+    setActiveRun(parent)
+    // Hold the same configurable bag the decorator mutates.
+    const config: { configurable: Record<string, unknown> } = {
+      configurable: { payment_token: LONG_TOKEN },
+    }
+    const mockPayments = makeMockPayments()
+    const fn = protectedFn(mockPayments)
+
+    await fn({ topic: 'evs' }, config)
+
+    // The raw key is gone, so LangChain's ensureConfig can't re-promote it into
+    // a child runnable the tool body spawns. No raw token survives in the bag.
+    expect('payment_token' in config.configurable).toBe(false)
+    expect(JSON.stringify(config.configurable)).not.toContain(LONG_TOKEN)
+    // Settlement still ran with the RAW token (the wrapper reads its local
+    // `token`, not configurable), so removal is non-functional.
+    expect(mockPayments.facilitator.settlePermissions).toHaveBeenCalledTimes(1)
+    expect(mockPayments.facilitator.settlePermissions.mock.calls[0][0].x402AccessToken).toBe(
+      LONG_TOKEN,
+    )
+  })
+
   it('ends the settlement span WITH the error (and still returns) when settle throws', async () => {
     const parent = new FakeRunTree({ name: 'tool' })
     setActiveRun(parent)


### PR DESCRIPTION
## What

Reverse-parity with **nevermined-io/payments-py#219** — the Python port closed this leak, the two SDKs had diverged. Closes the residual raw-credential leak via child runnables that @aaitor flagged on that PR. Tracked as nevermined-io/nvm-monorepo#1901 (epic #1703).

## Problem

`requiresPayment` left the raw `payment_token` in `config.configurable` after extraction. LangChain's `ensureConfig` re-promotes every configurable scalar into a runnable's `metadata` on **each** invocation, so any traced runnable the tool body spawns (an LLM call, a sub-chain) sharing the config re-leaks the full token into its own span metadata — and a child run opened *during* `fn()` captures it before the settle-side `redactMetadataKeys` can run.

`#371` already abbreviates `payment_context.token` and scrubs the parent/settle run-tree metadata, but those redactions are **reactive** (they strip a run tree's metadata at one moment); none of them removed the key from `configurable` itself, so newly-opened child runs kept re-promoting it.

## Fix

A `removeFromConfigurable` helper (symmetric with `storeInConfigurable`) pops `payment_token` from `config.configurable` right after extraction — the **proactive** complement to the reactive redaction. After this, `ensureConfig` has nothing to re-promote into child runs.

Ordering is load-bearing: the pop runs **after** `extractPaymentToken` (deleting earlier would make it return `null`) and **before** `fn()` (guaranteed — `fn()` is called further down). Settlement reads the local `token`, never `configurable`, so removal is non-functional. On the `tool()`/LangGraph path LangChain hands the wrapper a per-invocation config copy, so sibling tools are unaffected. The settle-side redact comment is updated — it is now defense-in-depth, since `configurable` no longer carries the raw token.

## Tests

+1 regression (`removes the raw payment_token from config.configurable after extraction`): asserts the key is gone from `config.configurable` after invocation, no raw token survives in the bag, and settle still ran with the **raw** token (proving removal is non-functional).

`tsc` build + full unit suite green (213 passed, 1 skipped); `eslint ./src` 0 errors; `prettier --check` clean.

> ℹ️ The linked issue lives in `nvm-monorepo`, so GitHub's auto-close won't fire cross-repo on merge — it'll be closed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)