### PR TITLE
docs: fix getFiatPriceConfig amount units (6-decimal, not cents)

### DIFF
--- a/markdown/payment-plans.md
+++ b/markdown/payment-plans.md
@@ -101,7 +101,7 @@ const testnetEurcConfig = payments.plans.getEURCPriceConfig(
 ```typescript
 // Fiat pricing in USD (default)
 const priceConfig = payments.plans.getFiatPriceConfig(
-  1000n,          // Amount in cents ($10.00)
+  10_000_000n,    // Amount in 6-decimal units ($10.00) — NOT cents
   builderAddress
 )
 
@@ -109,11 +109,13 @@ const priceConfig = payments.plans.getFiatPriceConfig(
 import { Currency } from '@nevermined-io/payments'
 
 const eurPriceConfig = payments.plans.getFiatPriceConfig(
-  2900n,          // Amount in euro cents (€29.00)
+  29_000_000n,    // Amount in 6-decimal units (€29.00) — NOT cents
   builderAddress,
   Currency.EUR
 )
 ```
+
+> Fiat amounts are in **6-decimal units** (the USDC convention used across the Nevermined protocol), **not** cents — `10_000_000n` = $10.00. The server-side minimum is **$1.00** (`1_000_000n`); smaller amounts are rejected with `BCK.PROTOCOL.0047`.
 
 ### Free Plans
 


### PR DESCRIPTION
## What

`markdown/payment-plans.md` documented `getFiatPriceConfig` amounts in **cents** (`1000n` = $10.00, `2900n` = €29.00), but the function takes **6-decimal units** (the USDC convention) — as `src/plans.ts` already documents:

> `amount` is in **6-decimal units** … NOT cents. To charge $2.00, pass `2_000_000n`. Minimum charge is **$1.00** (`1_000_000n`) … below the minimum surfaces as `BCK.PROTOCOL.0047`.

So the documented `2900n` is actually **€0.0029** — below the €1.00 minimum, and rejected by the backend.

## Change

- USD example: `1000n` "cents" → `10_000_000n` (6-decimal, $10.00)
- EUR example: `2900n` "euro cents" → `29_000_000n` (6-decimal, €29.00)
- Added a one-line note on the convention + the $1.00 minimum / `BCK.PROTOCOL.0047`

Docs-only; no code, tests, or public interfaces change. The `spendingLimitCents` delegation examples are genuinely cents and were left as-is.

## Why it matters

`markdown/` is published to the Mintlify docs (`api-reference/typescript/payment-plans.md`), so this same error is live in the public docs. Surfaced in review of [nevermined-io/docs#218](https://github.com/nevermined-io/docs/pull/218), which fixed the convention in the agent skill and the development guide; this PR fixes the SDK-repo source the docs mirror.
