### PR TITLE
feat(x402): delegation planId + required currency + deprecate inline create-on-the-fly

### DIFF
--- a/markdown/querying-an-agent.md
+++ b/markdown/querying-an-agent.md
@@ -127,6 +127,8 @@ const { accessToken } = await subscriberPayments.x402.getX402AccessToken(
 
 #### CLI
 
+> ⚠️ Inline create-on-the-fly is deprecated (nevermined-io/nvm-monorepo#1674) — the `--payment-type fiat` / `--payment-method-id` / `--spending-limit-cents` / `--delegation-duration-secs` flags create a delegation on the fly. Prefer creating a delegation first, then requesting the token by its `delegationId`.
+
 ```bash
 # Crypto (default)
 nvm x402token get-x402-access-token <planId>

--- a/markdown/querying-an-agent.md
+++ b/markdown/querying-an-agent.md
@@ -41,21 +41,26 @@ console.log('Access token generated')
 
 ### Token Parameters
 
-The `getX402AccessToken` method accepts several optional parameters:
+The `getX402AccessToken` method takes the plan id plus two optional arguments:
 
 ```typescript
 const { accessToken } = await subscriberPayments.x402.getX402AccessToken(
   planId,
-  agentId,              // Optional: Restrict to specific agent
-  redemptionLimit,      // Optional: Max credits this token can burn (BigInt)
-  orderLimit,           // Optional: Order limit (string)
-  expiration            // Optional: Token expiration date (ISO string)
+  agentId,       // Optional: restrict the token to a specific agent
+  tokenOptions,  // Optional: X402TokenOptions (scheme, network, delegationConfig)
 )
 ```
 
+Both schemes require `tokenOptions.delegationConfig` — pass
+`{ delegationId }` for a delegation created via
+[`createDelegation`](#card-delegation-tokens-fiat).
+
 ### Card-Delegation Tokens (Fiat)
 
-For plans that accept fiat payments, generate tokens using the `nvm:card-delegation` scheme. Pass `X402TokenOptions` with a `CardDelegationConfig` to specify the payment method and spending limits:
+For plans that accept fiat payments, use the `nvm:card-delegation` scheme.
+Create the delegation once with `createDelegation` (passing the enrolled card's
+`providerPaymentMethodId` and the required `currency`), then request tokens by
+its `delegationId`:
 
 ```typescript
 import { Payments, EnvironmentName, X402TokenOptions } from '@nevermined-io/payments'
@@ -65,27 +70,27 @@ const subscriberPayments = Payments.getInstance({
   environment: 'sandbox' as EnvironmentName,
 })
 
-// List enrolled payment methods
+// 1. List enrolled payment methods and create a delegation once.
 const methods = await subscriberPayments.delegation.listPaymentMethods()
 console.log(`Found ${methods.length} enrolled card(s)`)
 
-// Build token options for card-delegation
+const { delegationId } = await subscriberPayments.delegation.createDelegation({
+  provider: methods[0].provider ?? 'stripe',
+  providerPaymentMethodId: methods[0].id, // or a specific 'pm_...' ID
+  spendingLimitCents: 1000, // max $10.00
+  durationSecs: 3600, // 1 hour delegation
+  currency: 'usd',
+})
+
+// 2. Request a token by delegationId (reuse it for subsequent requests).
 const tokenOptions: X402TokenOptions = {
   scheme: 'nvm:card-delegation',
-  delegationConfig: {
-    providerPaymentMethodId: methods[0].id,  // or a specific 'pm_...' ID
-    spendingLimitCents: 1000,                // max $10.00
-    durationSecs: 3600,                      // 1 hour delegation
-  },
+  delegationConfig: { delegationId },
 }
 
-// Generate fiat access token
 const { accessToken } = await subscriberPayments.x402.getX402AccessToken(
   planId,
   agentId,
-  undefined,  // redemptionLimit
-  undefined,  // orderLimit
-  undefined,  // expiration
   tokenOptions,
 )
 ```
@@ -102,18 +107,21 @@ const scheme = await resolveScheme(subscriberPayments, planId)
 let tokenOptions: X402TokenOptions | undefined
 if (scheme === 'nvm:card-delegation') {
   const methods = await subscriberPayments.delegation.listPaymentMethods()
+  const { delegationId } = await subscriberPayments.delegation.createDelegation({
+    provider: methods[0].provider ?? 'stripe',
+    providerPaymentMethodId: methods[0].id,
+    spendingLimitCents: 1000,
+    durationSecs: 3600,
+    currency: 'usd',
+  })
   tokenOptions = {
     scheme: 'nvm:card-delegation',
-    delegationConfig: {
-      providerPaymentMethodId: methods[0].id,
-      spendingLimitCents: 1000,
-      durationSecs: 3600,
-    },
+    delegationConfig: { delegationId },
   }
 }
 
 const { accessToken } = await subscriberPayments.x402.getX402AccessToken(
-  planId, agentId, undefined, undefined, undefined, tokenOptions,
+  planId, agentId, tokenOptions,
 )
 ```
 

--- a/markdown/x402.md
+++ b/markdown/x402.md
@@ -49,12 +49,13 @@ The Nevermined Payments Library implements X402 v2, which uses:
 
 ## Generate X402 Access Tokens
 
-Subscribers generate access tokens to query agents. **Both schemes
-(`nvm:erc4337` and `nvm:card-delegation`) require a `delegationConfig`** —
-the older "just pass planId + agentId" shape no longer mints a token and
-will surface `BCK.X402.0030` ("Required token-generation input is missing
-or incomplete"; the `details` field names the missing input, e.g.
-"delegationConfig is required …") at the backend.
+The supported flow is **create-first**: create a delegation once with
+`payments.delegation.createDelegation(...)`, then request access tokens by
+passing only its `delegationId`. **Both schemes (`nvm:erc4337` and
+`nvm:card-delegation`) require a `delegationConfig`** — the older
+"just pass planId + agentId" shape no longer mints a token and surfaces
+`BCK.X402.0030` ("Required token-generation input is missing or incomplete";
+the `details` field names the missing input) at the backend.
 
 ```typescript
 import { Payments, EnvironmentName, X402TokenOptions } from '@nevermined-io/payments'
@@ -64,13 +65,20 @@ const subscriberPayments = Payments.getInstance({
   environment: 'sandbox' as EnvironmentName,
 })
 
-// Crypto (nvm:erc4337) example — auto-creates a delegation on first call
+// 1. Create a delegation once. `currency` is required: 'usdc' for the
+//    crypto (erc4337) scheme, 'usd'/'eur'/… for card providers.
+const { delegationId } = await subscriberPayments.delegation.createDelegation({
+  provider: 'erc4337',
+  spendingLimitCents: 1000, // $10 cap
+  durationSecs: 86_400, // 1 day
+  currency: 'usdc',
+})
+
+// 2. Request a token by delegationId. Reuse this delegation for every
+//    subsequent token request until it expires or is exhausted.
 const tokenOptions: X402TokenOptions = {
   scheme: 'nvm:erc4337',
-  delegationConfig: {
-    spendingLimitCents: 1000, // $10 cap
-    durationSecs: 86_400, // 1 day
-  },
+  delegationConfig: { delegationId },
 }
 
 const { accessToken } = await subscriberPayments.x402.getX402AccessToken(
@@ -82,9 +90,12 @@ const { accessToken } = await subscriberPayments.x402.getX402AccessToken(
 console.log('X402 access token generated')
 ```
 
-To reuse a previously-minted delegation rather than auto-creating one,
-pass `delegationConfig: { delegationId: '<uuid>' }` — the backend
-verifies the delegation is still active and returns its bound token.
+> ⚠️ **Inline create-on-the-fly is deprecated.** Passing creation fields
+> (`spendingLimitCents`, `durationSecs`, `providerPaymentMethodId`, `cardId`,
+> `currency`, `merchantAccountId`, `maxTransactions`) directly in
+> `delegationConfig` instead of a `delegationId` still works, but
+> `getX402AccessToken` now emits a runtime deprecation warning. Create the
+> delegation first (above) and pass only `{ delegationId }`.
 
 ### Generate Tokens via Nevermined App
 
@@ -100,53 +111,47 @@ This provides a user-friendly interface for non-technical users to generate toke
 
 ### Generate Card-Delegation Tokens
 
-For fiat plans using `nvm:card-delegation`, pass `X402TokenOptions` with a `CardDelegationConfig`:
+For fiat plans using `nvm:card-delegation`, create the delegation first with
+`createDelegation` (passing the card's `providerPaymentMethodId`), then request
+tokens by its `delegationId`. `currency` is required on creation:
 
 ```typescript
-import { X402TokenOptions, CardDelegationConfig } from '@nevermined-io/payments'
+import { X402TokenOptions } from '@nevermined-io/payments'
 
-// USD card delegation
+// 1. Create a USD card delegation once.
+const { delegationId: usdDelegationId } =
+  await subscriberPayments.delegation.createDelegation({
+    provider: 'stripe',
+    providerPaymentMethodId: 'pm_1AbCdEfGhIjKlM',
+    spendingLimitCents: 10000, // $100.00
+    durationSecs: 2592000, // 30 days
+    currency: 'usd',
+    maxTransactions: 100,
+  })
+
+// 2. Request a token by delegationId (reuse for every subsequent request).
 const tokenOptions: X402TokenOptions = {
   scheme: 'nvm:card-delegation',
-  delegationConfig: {
-    providerPaymentMethodId: 'pm_1AbCdEfGhIjKlM',
-    spendingLimitCents: 10000,  // $100.00
-    durationSecs: 2592000,       // 30 days
-    currency: 'usd',
-    maxTransactions: 100
-  }
+  delegationConfig: { delegationId: usdDelegationId },
 }
 
-// EUR card delegation
-const eurTokenOptions: X402TokenOptions = {
-  scheme: 'nvm:card-delegation',
-  delegationConfig: {
-    providerPaymentMethodId: 'pm_1AbCdEfGhIjKlM',
-    spendingLimitCents: 10000,  // €100.00 (in euro cents)
-    durationSecs: 2592000,       // 30 days
-    currency: 'eur',
-    maxTransactions: 100
-  }
-}
-
-// USD card delegation token
 const { accessToken } = await subscriberPayments.x402.getX402AccessToken(
   planId,
   agentId,
   tokenOptions,
 )
-
-// EUR card delegation token
-const { accessToken: eurAccessToken } = await subscriberPayments.x402.getX402AccessToken(
-  planId,
-  agentId,
-  eurTokenOptions,
-)
 ```
+
+A EUR delegation is the same call with `currency: 'eur'`. The delegation's
+currency is fixed at creation, so you create one delegation per currency and
+reuse each by its `delegationId`.
 
 ### Reusing Existing Delegations
 
-Instead of creating a new delegation on every token request, you can reuse an existing delegation by passing its `delegationId`. This is useful when running multiple agents that should share a single spending budget, and is the **only** supported pattern for Visa delegations (which cannot be created from the SDK):
+Passing `delegationConfig: { delegationId }` is the supported pattern for every
+provider, and the **only** supported pattern for Visa delegations (which cannot
+be created from the SDK). Reuse one delegation across multiple agents that share
+a single spending budget:
 
 ```typescript
 const tokenOptions: X402TokenOptions = {
@@ -165,49 +170,41 @@ const { accessToken } = await subscriberPayments.x402.getX402AccessToken(
 
 When `delegationId` is provided, the backend verifies that the delegation is active and that the requesting API key has access, then returns its existing token without creating a new delegation. The provider (`stripe`, `braintree`, or `visa`) is inferred from the delegation record on the server.
 
-### Specifying a Card
-
-You can target a specific enrolled card using `cardId`. The backend will look for an active delegation on that card or create a new one:
-
-```typescript
-const tokenOptions: X402TokenOptions = {
-  scheme: 'nvm:card-delegation',
-  delegationConfig: {
-    cardId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
-    spendingLimitCents: 5000,  // Only used if a new delegation is created
-    durationSecs: 604800,
-  }
-}
-```
-
-### Auto-Selection
-
-When neither `cardId` nor `delegationId` is specified (and `providerPaymentMethodId` is omitted), the backend automatically selects the best card and delegation for the requesting API key. It finds cards accessible to the API key, looks for active delegations with remaining budget, and reuses one if available — otherwise creates a new delegation:
+To scope a token request to a specific NVM API key, add `apiKeyId` alongside
+`delegationId` — both fields stay active (non-deprecated):
 
 ```typescript
-const tokenOptions: X402TokenOptions = {
-  scheme: 'nvm:card-delegation',
-  delegationConfig: {
-    spendingLimitCents: 10000,
-    durationSecs: 2592000,
-  }
-}
+delegationConfig: { delegationId: '…', apiKeyId: 'key-uuid' }
 ```
+
+### Deprecated: inline create-on-the-fly
+
+> ⚠️ **Deprecated.** Supplying creation fields directly in `delegationConfig`
+> instead of a `delegationId` (e.g. `providerPaymentMethodId` +
+> `spendingLimitCents`, a bare `cardId`, or an identifier-less "auto-select"
+> shape) still creates a delegation on the fly, but `getX402AccessToken` now
+> emits a runtime deprecation warning. Use the create-first pattern above
+> (`createDelegation` → `{ delegationId }`); inline creation will be removed in
+> a future major release.
 
 ### CardDelegationConfig Reference
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `delegationId` | `string` | No | Existing delegation UUID to reuse |
-| `cardId` | `string` | No | Payment method UUID to target |
-| `providerPaymentMethodId` | `string` | No | Stripe payment method ID (e.g., `pm_...`) |
-| `spendingLimitCents` | `number` | No* | Max spending in cents (for new delegations) |
-| `durationSecs` | `number` | No* | Duration in seconds (for new delegations) |
-| `currency` | `string` | No | Currency code, defaults to `usd` |
-| `merchantAccountId` | `string` | No | Stripe Connect account ID |
-| `maxTransactions` | `number` | No | Max transactions allowed |
+| Field | Type | Status | Description |
+|-------|------|--------|-------------|
+| `delegationId` | `string` | Active | Existing delegation UUID to reuse — the supported path |
+| `apiKeyId` | `string` | Active | NVM API Key ID to scope the token request to |
+| `cardId` | `string` | Deprecated | Payment method UUID to target (inline create) |
+| `providerPaymentMethodId` | `string` | Deprecated | Stripe payment method ID (e.g., `pm_...`) (inline create) |
+| `spendingLimitCents` | `number` | Deprecated | Max spending in cents (inline create) |
+| `durationSecs` | `number` | Deprecated | Duration in seconds (inline create) |
+| `currency` | `string` | Deprecated | Currency code (inline create) |
+| `planId` | `string` | Deprecated | Plan ID to scope a new delegation to (inline create) |
+| `merchantAccountId` | `string` | Deprecated | Stripe Connect account ID (inline create) |
+| `maxTransactions` | `number` | Deprecated | Max transactions allowed (inline create) |
 
-\* Required when creating a new delegation. Ignored when reusing an existing one via `delegationId`.
+The deprecated fields apply only to inline create-on-the-fly. Create the
+delegation with [`createDelegation`](#createdelegation) and pass only
+`delegationId` (optionally `apiKeyId`) here.
 
 ### Auto Scheme Resolution
 
@@ -287,6 +284,50 @@ for (const d of delegations) {
   }
 }
 ```
+
+#### createDelegation
+
+Create a delegation once, then reuse it across token requests by its
+`delegationId` (the create-first pattern). This is the supported way to
+provision spending authority for `nvm:erc4337` and `nvm:card-delegation` —
+prefer it over inline create-on-the-fly in `getX402AccessToken`.
+
+```typescript
+// Crypto (erc4337): currency must be 'usdc'.
+const { delegationId } = await delegationApi.createDelegation({
+  provider: 'erc4337',
+  spendingLimitCents: 100000, // $1000 cap
+  durationSecs: 604800, // 1 week
+  currency: 'usdc',
+})
+
+// Card (stripe / braintree): pass the enrolled card's providerPaymentMethodId.
+const { delegationId: cardDelegationId } = await delegationApi.createDelegation({
+  provider: 'stripe',
+  providerPaymentMethodId: 'pm_1AbCdEfGhIjKlM',
+  spendingLimitCents: 10000,
+  durationSecs: 2592000,
+  currency: 'usd',
+})
+```
+
+`CreateDelegationPayload` fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `provider` | `'stripe' \| 'braintree' \| 'visa' \| 'erc4337'` | Yes | Delegation provider |
+| `spendingLimitCents` | `number` | Yes | Maximum spending limit in cents |
+| `durationSecs` | `number` | Yes | Delegation lifetime in seconds |
+| `currency` | `string` | Yes | Currency code — `'usdc'` for erc4337, `'usd'`/`'eur'`/… for card providers. No silent default; the backend requires it. |
+| `providerPaymentMethodId` | `string` | Card only | Payment method ID (Stripe `pm_...`, Braintree vault token, Visa Agentic token id) |
+| `planId` | `string` | No | Optional and additive — delegations are plan-agnostic by default; supply `planId` to bind the delegation to a single plan. (Visa is always plan-specific and requires it.) |
+| `merchantAccountId` | `string` | No | Stripe Connect account ID or Braintree merchantId |
+| `maxTransactions` | `number` | No | Maximum number of transactions allowed |
+| `apiKeyId` | `string` | No | NVM API Key ID to scope the delegation to |
+
+> Visa delegations require a browser-side device-binding ceremony and cannot be
+> created from the SDK — see [Visa support](#visa-support). Create them in the
+> Nevermined webapp, then consume them here by `delegationId`.
 
 #### DelegationListResponse Fields
 
@@ -606,10 +647,17 @@ const subscriberPayments = Payments.getInstance({
   environment: 'sandbox' as EnvironmentName,
 })
 
-// 1. Generate access token (delegationConfig is required for both schemes)
+// 1. Create a delegation once (currency required; 'usdc' for erc4337),
+//    then generate an access token by its delegationId.
+const { delegationId } = await subscriberPayments.delegation.createDelegation({
+  provider: 'erc4337',
+  spendingLimitCents: 1000,
+  durationSecs: 86_400,
+  currency: 'usdc',
+})
 const { accessToken } = await subscriberPayments.x402.getX402AccessToken(planId, agentId, {
   scheme: 'nvm:erc4337',
-  delegationConfig: { spendingLimitCents: 1000, durationSecs: 86_400 },
+  delegationConfig: { delegationId },
 })
 
 // 2. Make request with payment-signature header

--- a/markdown/x402.md
+++ b/markdown/x402.md
@@ -318,7 +318,7 @@ const { delegationId: cardDelegationId } = await delegationApi.createDelegation(
 | `provider` | `'stripe' \| 'braintree' \| 'visa' \| 'erc4337'` | Yes | Delegation provider |
 | `spendingLimitCents` | `number` | Yes | Maximum spending limit in cents |
 | `durationSecs` | `number` | Yes | Delegation lifetime in seconds |
-| `currency` | `string` | Yes | Currency code — `'usdc'` for erc4337, `'usd'`/`'eur'`/… for card providers. No silent default; the backend requires it. |
+| `currency` | `DelegationCurrency` (`'usd' \| 'eur' \| 'usdc' \| 'eurc'`) | Yes | Currency code — `'usdc'`/`'eurc'` for erc4337, `'usd'`/`'eur'` for card providers. No silent default; the backend requires it. |
 | `providerPaymentMethodId` | `string` | Card only | Payment method ID (Stripe `pm_...`, Braintree vault token, Visa Agentic token id) |
 | `planId` | `string` | No | Optional and additive — delegations are plan-agnostic by default; supply `planId` to bind the delegation to a single plan. (Visa is always plan-specific and requires it.) |
 | `merchantAccountId` | `string` | No | Stripe Connect account ID or Braintree merchantId |

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -539,29 +539,64 @@ export function isValidScheme(s: unknown): s is X402SchemeType {
 /**
  * Configuration for delegation-based payments (both crypto and card schemes).
  *
- * To reuse an existing delegation supply `delegationId`.
- * To reuse an existing card (PaymentMethod entity) supply `cardId`.
- * When creating a brand-new delegation provide `providerPaymentMethodId`,
- * `spendingLimitCents`, and `durationSecs`.
+ * The supported flow is **create-first**: create a delegation with
+ * {@link DelegationAPI.createDelegation}, then request the access token with
+ * `delegationConfig: { delegationId }`.
+ *
+ * @deprecated The inline create-on-the-fly fields (`providerPaymentMethodId`,
+ * `spendingLimitCents`, `durationSecs`, `currency`, `merchantAccountId`,
+ * `maxTransactions`, `cardId`) are deprecated. Calling
+ * {@link X402TokenAPI.getX402AccessToken} with a `delegationConfig` that lacks
+ * `delegationId` emits a runtime deprecation warning; create the delegation
+ * first and pass only `delegationId` (optionally `apiKeyId`) here.
  */
 export interface DelegationConfig {
-  /** PaymentMethod entity UUID — preferred way to reference an enrolled card */
+  /**
+   * PaymentMethod entity UUID — references an enrolled card.
+   * @deprecated Inline create-on-the-fly. Create the delegation first and pass `delegationId`.
+   */
   cardId?: string
-  /** Existing delegation UUID to reuse instead of creating a new one */
+  /** Existing delegation UUID to reuse instead of creating a new one. The supported (non-deprecated) path. */
   delegationId?: string
-  /** Stripe payment method ID (e.g., 'pm_...'). Required only for new delegations. */
+  /**
+   * Stripe payment method ID (e.g., 'pm_...'). Required only for new delegations.
+   * @deprecated Inline create-on-the-fly. Create the delegation first and pass `delegationId`.
+   */
   providerPaymentMethodId?: string
-  /** Maximum spending limit in cents. Required only for new delegations. */
+  /**
+   * Maximum spending limit in cents. Required only for new delegations.
+   * @deprecated Inline create-on-the-fly. Create the delegation first and pass `delegationId`.
+   */
   spendingLimitCents?: number
-  /** Duration of the delegation in seconds. Required only for new delegations. */
+  /**
+   * Duration of the delegation in seconds. Required only for new delegations.
+   * @deprecated Inline create-on-the-fly. Create the delegation first and pass `delegationId`.
+   */
   durationSecs?: number
-  /** Currency code (default: 'usd') */
+  /**
+   * Currency code (e.g., 'usd', 'usdc').
+   * @deprecated Inline create-on-the-fly. Create the delegation first and pass `delegationId`.
+   */
   currency?: string
-  /** Merchant account ID (Stripe Connect acct_xxx or Braintree merchantId) */
+  /**
+   * Merchant account ID (Stripe Connect acct_xxx or Braintree merchantId).
+   * @deprecated Inline create-on-the-fly. Create the delegation first and pass `delegationId`.
+   */
   merchantAccountId?: string
-  /** Maximum number of transactions allowed */
+  /**
+   * Maximum number of transactions allowed.
+   * @deprecated Inline create-on-the-fly. Create the delegation first and pass `delegationId`.
+   */
   maxTransactions?: number
-  /** NVM API Key ID to scope the delegation to */
+  /**
+   * Plan ID to scope a newly-created delegation to. Optional and additive:
+   * delegations are plan-agnostic by default; supplying `planId` opts into a
+   * plan-bound delegation. (Visa delegations are always plan-specific and
+   * require it server-side.)
+   * @deprecated Inline create-on-the-fly. Create the delegation first and pass `delegationId`.
+   */
+  planId?: string
+  /** NVM API Key ID to scope the delegation to. Active (non-deprecated). */
   apiKeyId?: string
 }
 
@@ -577,9 +612,13 @@ export interface CreateDelegationPayload {
   spendingLimitCents: number
   /** Duration of the delegation in seconds */
   durationSecs: number
-  /** Currency code (default: 'usd') */
-  currency?: string
-  /** Plan ID to scope the delegation to */
+  /** Currency code (e.g., 'usd' for card providers, 'usdc' for erc4337). Required by the backend — no silent default. */
+  currency: string
+  /**
+   * Plan ID to scope the delegation to. Optional and additive: delegations are
+   * plan-agnostic by default; supplying `planId` opts into a plan-bound
+   * delegation. (Visa delegations are always plan-specific and require it.)
+   */
   planId?: string
   /** Merchant account ID (Stripe Connect acct_xxx or Braintree merchantId) */
   merchantAccountId?: string

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -537,18 +537,29 @@ export function isValidScheme(s: unknown): s is X402SchemeType {
 }
 
 /**
+ * Currency codes accepted for a delegation. Lowercase, mirroring the
+ * backend's `@IsIn(['usd','eur','usdc','eurc'])` constraint on
+ * `POST /api/v1/delegation/create` and the Python SDK's `DelegationCurrency`.
+ * Card providers use `'usd'`/`'eur'`; erc4337 uses `'usdc'`/`'eurc'`.
+ */
+export type DelegationCurrency = 'usd' | 'eur' | 'usdc' | 'eurc'
+
+/**
  * Configuration for delegation-based payments (both crypto and card schemes).
  *
  * The supported flow is **create-first**: create a delegation with
  * {@link DelegationAPI.createDelegation}, then request the access token with
  * `delegationConfig: { delegationId }`.
  *
- * @deprecated The inline create-on-the-fly fields (`providerPaymentMethodId`,
+ * @remarks
+ * The inline create-on-the-fly fields (`providerPaymentMethodId`,
  * `spendingLimitCents`, `durationSecs`, `currency`, `merchantAccountId`,
- * `maxTransactions`, `cardId`) are deprecated. Calling
+ * `maxTransactions`, `cardId`) are individually deprecated. Calling
  * {@link X402TokenAPI.getX402AccessToken} with a `delegationConfig` that lacks
- * `delegationId` emits a runtime deprecation warning; create the delegation
- * first and pass only `delegationId` (optionally `apiKeyId`) here.
+ * `delegationId` but carries one of those fields emits a runtime deprecation
+ * warning; create the delegation first and pass only `delegationId` (optionally
+ * `apiKeyId`) here. The interface itself is NOT deprecated — the
+ * `{ delegationId }` reuse path is the supported way to configure a token request.
  */
 export interface DelegationConfig {
   /**
@@ -574,10 +585,10 @@ export interface DelegationConfig {
    */
   durationSecs?: number
   /**
-   * Currency code (e.g., 'usd', 'usdc').
+   * Currency code (e.g., 'usd' for card providers, 'usdc' for erc4337).
    * @deprecated Inline create-on-the-fly. Create the delegation first and pass `delegationId`.
    */
-  currency?: string
+  currency?: DelegationCurrency
   /**
    * Merchant account ID (Stripe Connect acct_xxx or Braintree merchantId).
    * @deprecated Inline create-on-the-fly. Create the delegation first and pass `delegationId`.
@@ -613,7 +624,7 @@ export interface CreateDelegationPayload {
   /** Duration of the delegation in seconds */
   durationSecs: number
   /** Currency code (e.g., 'usd' for card providers, 'usdc' for erc4337). Required by the backend — no silent default. */
-  currency: string
+  currency: DelegationCurrency
   /**
    * Plan ID to scope the delegation to. Optional and additive: delegations are
    * plan-agnostic by default; supplying `planId` opts into a plan-bound

--- a/src/x402/index.ts
+++ b/src/x402/index.ts
@@ -40,6 +40,7 @@ export type {
 export type {
   X402SchemeType,
   DelegationConfig,
+  DelegationCurrency,
   CreateDelegationPayload,
   CreateDelegationResponse,
   X402TokenOptions,

--- a/src/x402/token.ts
+++ b/src/x402/token.ts
@@ -28,14 +28,16 @@ export class X402TokenAPI extends BasePaymentsAPI {
   }
 
   /**
-   * Create a delegation and get an X402 access token for the given plan.
+   * Get an X402 access token for the given plan, backed by a delegation.
    *
    * This token allows the agent to verify and settle delegations on behalf
    * of the subscriber.
    *
-   * For erc4337 scheme, you must pass `tokenOptions.delegationConfig` with either:
-   * - `delegationId` to reuse an existing delegation, or
-   * - `spendingLimitCents` + `durationSecs` to auto-create a new one.
+   * The supported flow is **create-first**: create the delegation once with
+   * {@link DelegationAPI.createDelegation}, then pass its `delegationId` in
+   * `tokenOptions.delegationConfig`. Passing inline create-on-the-fly fields
+   * (spending limits / `providerPaymentMethodId` / `cardId`, i.e. no
+   * `delegationId`) is **deprecated** and emits a runtime warning.
    *
    * @param planId - The unique identifier of the payment plan
    * @param agentId - The unique identifier of the AI agent (optional)
@@ -47,14 +49,15 @@ export class X402TokenAPI extends BasePaymentsAPI {
    *
    * @example
    * ```typescript
-   * // Pattern A — auto-create delegation
-   * const result = await payments.x402.getX402AccessToken(planId, agentId, {
-   *   delegationConfig: { spendingLimitCents: 10000, durationSecs: 604800 }
+   * // Supported: create the delegation first, then request the token by id.
+   * const { delegationId } = await payments.delegation.createDelegation({
+   *   provider: 'erc4337',
+   *   spendingLimitCents: 10000,
+   *   durationSecs: 604800,
+   *   currency: 'usdc',
    * })
-   *
-   * // Pattern B — reuse existing delegation
    * const result = await payments.x402.getX402AccessToken(planId, agentId, {
-   *   delegationConfig: { delegationId: 'existing-delegation-uuid' }
+   *   delegationConfig: { delegationId },
    * })
    * ```
    */
@@ -73,8 +76,22 @@ export class X402TokenAPI extends BasePaymentsAPI {
     if (!tokenOptions?.delegationConfig) {
       throw PaymentsError.validation(
         `delegationConfig is required for ${scheme} token generation. ` +
-          'Provide delegationConfig.delegationId to reuse an existing delegation, ' +
-          'or delegationConfig.spendingLimitCents + durationSecs to auto-create one.',
+          'Create a delegation first with payments.delegation.createDelegation(), ' +
+          'then request the token with delegationConfig.delegationId.',
+      )
+    }
+
+    // Deprecation: the supported flow is create-first — create the delegation
+    // with createDelegation(), then request the token with { delegationId }.
+    // A delegationConfig without delegationId triggers inline create-on-the-fly,
+    // which the backend has deprecated (auto-select and providerPaymentMethodId/
+    // cardId creation). Warn once per call; the { delegationId } path is silent.
+    if (!tokenOptions.delegationConfig.delegationId) {
+      console.warn(
+        '[DEPRECATED] getX402AccessToken: inline create-on-the-fly delegationConfig ' +
+          '(no delegationId) is deprecated and will be removed in a future release. ' +
+          'Create the delegation first with payments.delegation.createDelegation(), ' +
+          'then request the token with delegationConfig: { delegationId }.',
       )
     }
 

--- a/src/x402/token.ts
+++ b/src/x402/token.ts
@@ -83,10 +83,22 @@ export class X402TokenAPI extends BasePaymentsAPI {
 
     // Deprecation: the supported flow is create-first — create the delegation
     // with createDelegation(), then request the token with { delegationId }.
-    // A delegationConfig without delegationId triggers inline create-on-the-fly,
-    // which the backend has deprecated (auto-select and providerPaymentMethodId/
-    // cardId creation). Warn once per call; the { delegationId } path is silent.
-    if (!tokenOptions.delegationConfig.delegationId) {
+    // A delegationConfig that carries an inline-create signal instead of a
+    // delegationId triggers inline create-on-the-fly, which the backend has
+    // deprecated (auto-select and providerPaymentMethodId/cardId creation).
+    // Warn once per call; the { delegationId } (± apiKeyId) path is silent.
+    // Predicate mirrors the Python SDK (payments-py#224): no delegationId AND
+    // at least one creation field present — a bare/invalid config is left to
+    // fail downstream rather than warned.
+    const { delegationId, cardId, providerPaymentMethodId, spendingLimitCents, durationSecs } =
+      tokenOptions.delegationConfig
+    const isInlineCreate =
+      !delegationId &&
+      (cardId !== undefined ||
+        providerPaymentMethodId !== undefined ||
+        spendingLimitCents !== undefined ||
+        durationSecs !== undefined)
+    if (isInlineCreate) {
       console.warn(
         '[DEPRECATED] getX402AccessToken: inline create-on-the-fly delegationConfig ' +
           '(no delegationId) is deprecated and will be removed in a future release. ' +

--- a/src/x402/token.ts
+++ b/src/x402/token.ts
@@ -92,6 +92,15 @@ export class X402TokenAPI extends BasePaymentsAPI {
     // fail downstream rather than warned.
     const { delegationId, cardId, providerPaymentMethodId, spendingLimitCents, durationSecs } =
       tokenOptions.delegationConfig
+    // Reject an explicit empty/blank delegationId early — it is neither a valid
+    // reuse id nor an inline-create signal, and forwarding `delegationId: ''`
+    // would 4xx at the backend. (Symmetric with the Python SDK, payments-py#225.)
+    if (delegationId !== undefined && delegationId.trim() === '') {
+      throw PaymentsError.validation(
+        'delegationConfig.delegationId must not be an empty string. ' +
+          'Pass a valid delegation UUID or omit the field.',
+      )
+    }
     const isInlineCreate =
       !delegationId &&
       (cardId !== undefined ||
@@ -119,10 +128,9 @@ export class X402TokenAPI extends BasePaymentsAPI {
       },
     }
 
-    // Add delegation config for both erc4337 and card-delegation schemes
-    if (tokenOptions?.delegationConfig) {
-      body.delegationConfig = tokenOptions.delegationConfig
-    }
+    // Add delegation config for both erc4337 and card-delegation schemes.
+    // delegationConfig is guaranteed present here (the absence check above throws).
+    body.delegationConfig = tokenOptions.delegationConfig
 
     const options = this.getBackendHTTPOptions('POST', body)
 

--- a/tests/e2e/test_a2a_client_e2e.test.ts
+++ b/tests/e2e/test_a2a_client_e2e.test.ts
@@ -282,6 +282,7 @@ describe('A2A Client E2E Tests', () => {
       provider: 'erc4337',
       spendingLimitCents: 100000,
       durationSecs: 604800,
+      currency: 'usdc',
     })
 
     // Get client with delegation config

--- a/tests/e2e/test_a2a_e2e.test.ts
+++ b/tests/e2e/test_a2a_e2e.test.ts
@@ -306,6 +306,7 @@ describe('A2A E2E Flow', () => {
         provider: 'erc4337',
         spendingLimitCents: 100000,
         durationSecs: 604800,
+        currency: 'usdc',
       })
       delegationId = delegation.delegationId
 

--- a/tests/e2e/test_express_middleware_e2e.test.ts
+++ b/tests/e2e/test_express_middleware_e2e.test.ts
@@ -213,6 +213,7 @@ describe('Express Payment Middleware E2E', () => {
           provider: 'erc4337',
           spendingLimitCents: 100000,
           durationSecs: 604800,
+          currency: 'usdc',
         }),
       {
         label: 'Delegation Creation',

--- a/tests/e2e/test_mcp_oauth_e2e.test.ts
+++ b/tests/e2e/test_mcp_oauth_e2e.test.ts
@@ -513,6 +513,7 @@ describe('MCP OAuth E2E Tests', () => {
         provider: 'erc4337',
         spendingLimitCents: 100000,
         durationSecs: 604800,
+        currency: 'usdc',
       })
       const accessParams = await retryWithBackoff(
         () =>

--- a/tests/e2e/test_payments_e2e.test.ts
+++ b/tests/e2e/test_payments_e2e.test.ts
@@ -581,6 +581,7 @@ describe('Payments E2E Tests', () => {
           provider: 'erc4337',
           spendingLimitCents: 100000,
           durationSecs: 604800,
+          currency: 'usdc',
         })
         agentAccessParams = await paymentsSubscriber.x402.getX402AccessToken(
           creditsPlanId!,

--- a/tests/e2e/test_x402_card_delegation_braintree_e2e.test.ts
+++ b/tests/e2e/test_x402_card_delegation_braintree_e2e.test.ts
@@ -79,6 +79,7 @@ describe('X402 Card Delegation Flow (Braintree)', () => {
           providerPaymentMethodId: pm!.id,
           spendingLimitCents: 10000,
           durationSecs: 604800,
+          currency: 'usd',
         }),
       { label: 'Braintree Delegation Creation', attempts: 3 },
     )

--- a/tests/e2e/test_x402_card_delegation_stripe_e2e.test.ts
+++ b/tests/e2e/test_x402_card_delegation_stripe_e2e.test.ts
@@ -70,6 +70,7 @@ describe('X402 Card Delegation Flow (Stripe)', () => {
           providerPaymentMethodId: card!.id,
           spendingLimitCents: 10000,
           durationSecs: 604800,
+          currency: 'usd',
         }),
       { label: 'Stripe Delegation Creation', attempts: 3 },
     )

--- a/tests/e2e/test_x402_e2e.test.ts
+++ b/tests/e2e/test_x402_e2e.test.ts
@@ -269,6 +269,7 @@ describe('X402 Delegation Flow', () => {
           delegationConfig: {
             spendingLimitCents: 50000,
             durationSecs: 3600,
+            currency: 'usdc',
           },
         }),
       {

--- a/tests/e2e/test_x402_e2e.test.ts
+++ b/tests/e2e/test_x402_e2e.test.ts
@@ -123,6 +123,7 @@ describe('X402 Delegation Flow', () => {
           provider: 'erc4337',
           spendingLimitCents: 100000, // $1000 USDC
           durationSecs: 604800, // 1 week
+          currency: 'usdc',
         }),
       {
         label: 'Crypto Delegation Creation',

--- a/tests/unit/x402-token-deprecation.test.ts
+++ b/tests/unit/x402-token-deprecation.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for the create-first / inline-create deprecation surface of
+ * getX402AccessToken, plus the additive planId and required currency on
+ * createDelegation.
+ *
+ * Mirrors the backend contract from nevermined-io/nvm-monorepo#1549
+ * (#1534 plan-agnostic + additive planId, #1677 currency-required, #1674
+ * deprecate inline create-on-the-fly): the supported flow is create-first
+ * (createDelegation -> { delegationId }); a delegationConfig without a
+ * delegationId is inline create-on-the-fly and must emit a runtime
+ * deprecation warning, while the { delegationId } path stays silent.
+ */
+import { Payments } from '../../src/payments.js'
+
+const TEST_API_KEY =
+  process.env.TEST_PROXY_BEARER_TOKEN ||
+  'sandbox-staging:eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweDU4MzhCNTUxMmNGOWYxMkZFOWYyYmVjY0IyMGViNDcyMTFGOUIwYmMiLCJzdWIiOiIweDIxRjc5ZjlkM2I2ZDUyZUY4Y2M4QjFhN0YyNjFCY2Y1ZjJFRjM1NGEiLCJqdGkiOiIweGUxMjIwMmRkMzZlZmQ4N2FkMjE1MmRlMjlkM2MwNmE5ZDU5N2M4NWJhOGMxOTQ1YjQ5MjlkYTYyYTRiZjQ1NGYiLCJleHAiOjE3OTEwNDc0OTcsIm8xMXkiOiJzay1oZWxpY29uZS13amUzYXdpLW5ud2V5M2EtdzdndnY3YS1oYmh3bm1pIn0.JI14qfSWHCWRvHOK9TAg3HEXWX7oKEI6fU6gaaWlyDl5btBWLh8FQo1ZnuzixPmgsUR3gc4oRlenLPUuTy-mORw'
+
+interface CapturedCall {
+  url: string
+  init?: RequestInit
+}
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+describe('getX402AccessToken — create-first deprecation', () => {
+  let originalFetch: typeof fetch
+  let calls: CapturedCall[]
+  let payments: Payments
+  let warnSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+    calls = []
+    payments = Payments.getInstance({
+      nvmApiKey: TEST_API_KEY,
+      environment: 'staging_sandbox',
+    })
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    warnSpy.mockRestore()
+  })
+
+  const installFetch = (handler: (call: CapturedCall) => Response | Promise<Response>): void => {
+    global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const call: CapturedCall = { url, init }
+      calls.push(call)
+      return handler(call)
+    }) as unknown as typeof fetch
+  }
+
+  const deprecationWarn = (): string | undefined =>
+    warnSpy.mock.calls.map((args) => String(args[0])).find((msg) => msg.includes('[DEPRECATED]'))
+
+  test('reuse-by-delegationId does NOT emit a deprecation warning', async () => {
+    installFetch(() => jsonResponse({ accessToken: 'tok.reuse' }))
+
+    await payments.x402.getX402AccessToken('plan-1', 'agent-1', {
+      scheme: 'nvm:card-delegation',
+      delegationConfig: { delegationId: 'del-uuid-1' },
+    })
+
+    expect(deprecationWarn()).toBeUndefined()
+  })
+
+  test('delegationId + apiKeyId is still silent (apiKeyId stays active)', async () => {
+    installFetch(() => jsonResponse({ accessToken: 'tok.reuse' }))
+
+    await payments.x402.getX402AccessToken('plan-1', 'agent-1', {
+      scheme: 'nvm:card-delegation',
+      delegationConfig: { delegationId: 'del-uuid-1', apiKeyId: 'key-1' },
+    })
+
+    expect(deprecationWarn()).toBeUndefined()
+  })
+
+  test('inline create with spending limits (no delegationId) warns', async () => {
+    installFetch(() => jsonResponse({ accessToken: 'tok.inline' }))
+
+    await payments.x402.getX402AccessToken('plan-1', 'agent-1', {
+      scheme: 'nvm:erc4337',
+      delegationConfig: { spendingLimitCents: 1000, durationSecs: 3600 },
+    })
+
+    const warn = deprecationWarn()
+    expect(warn).toBeDefined()
+    expect(warn).toContain('createDelegation')
+    expect(warn).toContain('delegationId')
+  })
+
+  test('inline create with providerPaymentMethodId (no delegationId) warns', async () => {
+    installFetch(() => jsonResponse({ accessToken: 'tok.inline' }))
+
+    await payments.x402.getX402AccessToken('plan-1', 'agent-1', {
+      scheme: 'nvm:card-delegation',
+      delegationConfig: { providerPaymentMethodId: 'pm_123', spendingLimitCents: 5000, durationSecs: 3600 },
+    })
+
+    expect(deprecationWarn()).toBeDefined()
+  })
+
+  test('cardId without delegationId warns (cardId is a deprecated inline-create field)', async () => {
+    installFetch(() => jsonResponse({ accessToken: 'tok.inline' }))
+
+    await payments.x402.getX402AccessToken('plan-1', 'agent-1', {
+      scheme: 'nvm:card-delegation',
+      delegationConfig: { cardId: 'card-uuid', spendingLimitCents: 5000, durationSecs: 3600 },
+    })
+
+    expect(deprecationWarn()).toBeDefined()
+  })
+
+  test('identifier-less auto-select shape (no delegationId) warns', async () => {
+    installFetch(() => jsonResponse({ accessToken: 'tok.inline' }))
+
+    await payments.x402.getX402AccessToken('plan-1', 'agent-1', {
+      scheme: 'nvm:card-delegation',
+      delegationConfig: { spendingLimitCents: 10000, durationSecs: 2592000 },
+    })
+
+    expect(deprecationWarn()).toBeDefined()
+  })
+
+  test('missing delegationConfig throws (does not warn)', async () => {
+    installFetch(() => jsonResponse({ accessToken: 'unused' }))
+
+    await expect(
+      payments.x402.getX402AccessToken('plan-1', 'agent-1', { scheme: 'nvm:erc4337' }),
+    ).rejects.toThrow(/delegationConfig is required/)
+
+    expect(deprecationWarn()).toBeUndefined()
+  })
+})
+
+describe('createDelegation — required currency + additive planId on the wire', () => {
+  let originalFetch: typeof fetch
+  let calls: CapturedCall[]
+  let payments: Payments
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+    calls = []
+    payments = Payments.getInstance({
+      nvmApiKey: TEST_API_KEY,
+      environment: 'staging_sandbox',
+    })
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  const installFetch = (handler: (call: CapturedCall) => Response | Promise<Response>): void => {
+    global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      calls.push({ url, init })
+      return handler({ url, init })
+    }) as unknown as typeof fetch
+  }
+
+  test('posts currency and the optional planId verbatim', async () => {
+    installFetch(() => jsonResponse({ delegationId: 'del-1' }))
+
+    await payments.delegation.createDelegation({
+      provider: 'stripe',
+      providerPaymentMethodId: 'pm_123',
+      spendingLimitCents: 10000,
+      durationSecs: 604800,
+      currency: 'usd',
+      planId: 'plan-bound-1',
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toContain('/api/v1/delegation/create')
+    const body = JSON.parse(calls[0].init!.body as string)
+    expect(body.currency).toBe('usd')
+    expect(body.planId).toBe('plan-bound-1')
+  })
+
+  test('plan-agnostic by default — planId is omitted when not supplied', async () => {
+    installFetch(() => jsonResponse({ delegationId: 'del-1' }))
+
+    await payments.delegation.createDelegation({
+      provider: 'erc4337',
+      spendingLimitCents: 100000,
+      durationSecs: 604800,
+      currency: 'usdc',
+    })
+
+    const body = JSON.parse(calls[0].init!.body as string)
+    expect(body.currency).toBe('usdc')
+    expect(body.planId).toBeUndefined()
+  })
+})

--- a/tests/unit/x402-token-deprecation.test.ts
+++ b/tests/unit/x402-token-deprecation.test.ts
@@ -156,6 +156,34 @@ describe('getX402AccessToken — create-first deprecation', () => {
     expect(deprecationWarn()).toBeDefined()
   })
 
+  test('durationSecs alone (no delegationId) warns — each creation field triggers', async () => {
+    // Standalone single-field trigger: guards against a predicate that drops one
+    // of the inline-create fields from the OR chain.
+    installFetch(() => jsonResponse({ accessToken: 'tok.inline' }))
+
+    await payments.x402.getX402AccessToken('plan-1', 'agent-1', {
+      scheme: 'nvm:erc4337',
+      delegationConfig: { durationSecs: 3600 },
+    })
+
+    expect(deprecationWarn()).toBeDefined()
+  })
+
+  test('emits the deprecation warning exactly once per call', async () => {
+    // Guards against a double-warn regression (e.g. warning in two places).
+    installFetch(() => jsonResponse({ accessToken: 'tok.inline' }))
+
+    await payments.x402.getX402AccessToken('plan-1', 'agent-1', {
+      scheme: 'nvm:erc4337',
+      delegationConfig: { spendingLimitCents: 1000, durationSecs: 3600 },
+    })
+
+    const deprecationCalls = warnSpy.mock.calls.filter((args) =>
+      String(args[0]).includes('[DEPRECATED]'),
+    )
+    expect(deprecationCalls).toHaveLength(1)
+  })
+
   test('bare delegationConfig (no delegationId, no creation fields) does NOT warn', async () => {
     // Mirrors the Python SDK predicate: warn only when an inline-create signal
     // is present. A bare/invalid config is left to fail downstream, not warned.
@@ -188,6 +216,21 @@ describe('getX402AccessToken — create-first deprecation', () => {
     ).rejects.toThrow(/delegationConfig is required/)
 
     expect(deprecationWarn()).toBeUndefined()
+  })
+
+  test('empty-string delegationId throws early (not treated as inline-create)', async () => {
+    installFetch(() => jsonResponse({ accessToken: 'unused' }))
+
+    await expect(
+      payments.x402.getX402AccessToken('plan-1', 'agent-1', {
+        scheme: 'nvm:card-delegation',
+        delegationConfig: { delegationId: '   ' },
+      }),
+    ).rejects.toThrow(/delegationId must not be an empty string/)
+
+    // It fails the request entirely — no warning, no fetch.
+    expect(deprecationWarn()).toBeUndefined()
+    expect(calls).toHaveLength(0)
   })
 })
 

--- a/tests/unit/x402-token-deprecation.test.ts
+++ b/tests/unit/x402-token-deprecation.test.ts
@@ -85,10 +85,29 @@ describe('getX402AccessToken — create-first deprecation', () => {
     expect(deprecationWarn()).toBeUndefined()
   })
 
-  test('inline create with spending limits (no delegationId) warns', async () => {
-    installFetch(() => jsonResponse({ accessToken: 'tok.inline' }))
+  test('delegationId present + leftover inline fields is silent (migration footgun)', async () => {
+    // A caller migrating to create-first may leave the old inline fields in
+    // place alongside the new delegationId. delegationId wins — reuse path,
+    // no warning — so the migration is not punished mid-flight.
+    installFetch(() => jsonResponse({ accessToken: 'tok.reuse' }))
 
     await payments.x402.getX402AccessToken('plan-1', 'agent-1', {
+      scheme: 'nvm:card-delegation',
+      delegationConfig: {
+        delegationId: 'del-1',
+        spendingLimitCents: 1000,
+        durationSecs: 3600,
+        currency: 'usd',
+      },
+    })
+
+    expect(deprecationWarn()).toBeUndefined()
+  })
+
+  test('inline create with spending limits (no delegationId) warns but is NON-FATAL', async () => {
+    installFetch(() => jsonResponse({ accessToken: 'tok.inline' }))
+
+    const res = await payments.x402.getX402AccessToken('plan-1', 'agent-1', {
       scheme: 'nvm:erc4337',
       delegationConfig: { spendingLimitCents: 1000, durationSecs: 3600 },
     })
@@ -97,6 +116,11 @@ describe('getX402AccessToken — create-first deprecation', () => {
     expect(warn).toBeDefined()
     expect(warn).toContain('createDelegation')
     expect(warn).toContain('delegationId')
+    // The warning must NOT short-circuit the request: the token request still
+    // fires and returns. Guards against a regression turning warn -> throw.
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toContain('/api/v1/x402/permissions')
+    expect(res.accessToken).toBe('tok.inline')
   })
 
   test('inline create with providerPaymentMethodId (no delegationId) warns', async () => {

--- a/tests/unit/x402-token-deprecation.test.ts
+++ b/tests/unit/x402-token-deprecation.test.ts
@@ -6,9 +6,12 @@
  * Mirrors the backend contract from nevermined-io/nvm-monorepo#1549
  * (#1534 plan-agnostic + additive planId, #1677 currency-required, #1674
  * deprecate inline create-on-the-fly): the supported flow is create-first
- * (createDelegation -> { delegationId }); a delegationConfig without a
- * delegationId is inline create-on-the-fly and must emit a runtime
- * deprecation warning, while the { delegationId } path stays silent.
+ * (createDelegation -> { delegationId }); a delegationConfig that carries an
+ * inline-create signal (cardId / providerPaymentMethodId / spendingLimitCents
+ * / durationSecs) but no delegationId is inline create-on-the-fly and must
+ * emit a runtime deprecation warning. The { delegationId } path — and a bare
+ * config with neither a delegationId nor a creation field — stay silent.
+ * Predicate aligned with the Python SDK (payments-py#224).
  */
 import { Payments } from '../../src/payments.js'
 
@@ -118,7 +121,7 @@ describe('getX402AccessToken — create-first deprecation', () => {
     expect(deprecationWarn()).toBeDefined()
   })
 
-  test('identifier-less auto-select shape (no delegationId) warns', async () => {
+  test('identifier-less auto-select shape (spending limits, no delegationId) warns', async () => {
     installFetch(() => jsonResponse({ accessToken: 'tok.inline' }))
 
     await payments.x402.getX402AccessToken('plan-1', 'agent-1', {
@@ -127,6 +130,30 @@ describe('getX402AccessToken — create-first deprecation', () => {
     })
 
     expect(deprecationWarn()).toBeDefined()
+  })
+
+  test('bare delegationConfig (no delegationId, no creation fields) does NOT warn', async () => {
+    // Mirrors the Python SDK predicate: warn only when an inline-create signal
+    // is present. A bare/invalid config is left to fail downstream, not warned.
+    installFetch(() => jsonResponse({ accessToken: 'tok.bare' }))
+
+    await payments.x402.getX402AccessToken('plan-1', 'agent-1', {
+      scheme: 'nvm:card-delegation',
+      delegationConfig: {},
+    })
+
+    expect(deprecationWarn()).toBeUndefined()
+  })
+
+  test('apiKeyId-only delegationConfig (no delegationId, no creation fields) does NOT warn', async () => {
+    installFetch(() => jsonResponse({ accessToken: 'tok.bare' }))
+
+    await payments.x402.getX402AccessToken('plan-1', 'agent-1', {
+      scheme: 'nvm:card-delegation',
+      delegationConfig: { apiKeyId: 'key-1' },
+    })
+
+    expect(deprecationWarn()).toBeUndefined()
   })
 
   test('missing delegationConfig throws (does not warn)', async () => {

--- a/tests/unit/x402-visa.test.ts
+++ b/tests/unit/x402-visa.test.ts
@@ -196,6 +196,7 @@ describe('Visa provider surface', () => {
         providerPaymentMethodId: 'vat_1abc23def45',
         spendingLimitCents: 1_000,
         durationSecs: 3_600,
+        currency: 'usd',
       })
     } catch (err) {
       caught = err as PaymentsError
@@ -219,6 +220,7 @@ describe('Visa provider surface', () => {
         providerPaymentMethodId: 'vat_1abc23def45',
         spendingLimitCents: 1_000,
         durationSecs: 3_600,
+        currency: 'usd',
       })
       .catch(() => undefined)
 


### PR DESCRIPTION
## Description

TypeScript SDK side of the x402 hardening epic (**nevermined-io/nvm-monorepo#1549**), mirroring the now-merged backend contract from `nvm-monorepo#1534` / `#1677` / `#1674`.

**1. `planId` on `DelegationConfig`** — delegations are plan-agnostic by default; `planId` opts into a plan-bound delegation. (`CreateDelegationPayload` already carried `planId`.) Additive as a type change, but **`DelegationConfig.planId` is `@deprecated` on arrival**: it only takes effect on the deprecated inline create-on-the-fly path. The supported way to bind a plan is `createDelegation({ planId })` (on `CreateDelegationPayload`, where `planId` is *not* deprecated), then reuse by `delegationId`.

**2. `currency` is now required on `CreateDelegationPayload`** — the backend no longer silently defaults `usd`/`usdc`, so the SDK surfaces it at compile time. Coordinated breaking release with the backend and `payments-py` (#224). Every `createDelegation` call site that omitted `currency` was updated: `usd` for card providers, `usdc` for erc4337.

**3. Runtime deprecation warning for inline create-on-the-fly** — `getX402AccessToken` now emits a `console.warn` when called with a `delegationConfig` that has **no `delegationId`** (spending-limits / `providerPaymentMethodId` / `cardId` / identifier-less auto-select). The supported create-first path — `createDelegation()` → `{ delegationId }` (optionally `+ apiKeyId`) — stays silent. This mirrors the merged backend, which deprecated the same capability via OpenAPI `deprecated` markers + server-side warnings (delegationId and apiKeyId remain active). The 7 inline-create `DelegationConfig` fields are also marked `@deprecated` in JSDoc.

**4. SDK reference docs (`markdown/`) updated to create-first** — `x402.md` and `querying-an-agent.md`: reframed inline-create / Auto-Selection / "Specifying a Card" examples to `createDelegation` → `{ delegationId }`, added a `createDelegation` reference block (required `currency`, additive `planId`), and fixed a stale 6-arg `getX402AccessToken` signature (the real signature is 3-arg). Validated with `./scripts/generate-docs.sh`. Central narrative docs are tracked separately in `nvm-monorepo#1913`.

### Reviewer note — predicate decision
The deprecation trigger is **"`delegationConfig` present AND no `delegationId`"**, derived from the merged backend behaviour (Mode 1 `{ delegationId }` = blessed; Mode 2 auto-select + Mode 3 inline-create = deprecated; `cardId` got the deprecated marker too). Flagged to the epic lead for confirmation; easy to retune on the same branch if a different line (e.g. `cardId` also silent) is preferred.

## Is this PR related with an open issue?

Part of nevermined-io/nvm-monorepo#1549. Closes #379.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

`currency` becoming required on `CreateDelegationPayload` is the breaking compile-time change (coordinated release). The new `DelegationConfig.planId` field and the deprecation warning are additive/non-breaking — though `DelegationConfig.planId` is itself `@deprecated` (effective only on the inline path; use `createDelegation({ planId })` to plan-bind).

## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

