### PR TITLE
feat: pin backend API version via Nevermined-Version header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,19 @@ The CLI has BigInt-aware JSON parsing (reviver in `cli/src/base-command.ts`) and
 
 The SDK and CLI support four environment values: `sandbox`, `live`, `staging_sandbox`, and `staging_live`. The `staging_*` variants are for **internal development only** and must never appear in public-facing documentation. All docs, examples, and SKILL files must use only `sandbox` and `live`. The CLI defaults to `sandbox` when no environment is set.
 
+### API Version Pinning
+
+Every HTTP call to the Nevermined backend carries a `Nevermined-Version` header pinning the **backend API** version (nvm-monorepo MAJOR.MINOR) this SDK release is built and tested against — this is NOT the SDK package version. Both constants live in `src/common/api-version.ts`:
+
+- `LOCKED_API_VERSION` — the pinned backend contract (currently `1.1`). Resolved as `options.version ?? LOCKED_API_VERSION` in `BasePaymentsAPI.getBackendHTTPOptions()` / `getPublicHTTPOptions()`, so it applies to authenticated and public endpoints alike.
+- `API_VERSION_HEADER` — the header name (`Nevermined-Version`).
+
+**Bump procedure** (deliberate, never automatic): update `LOCKED_API_VERSION` when targeting a newer backend contract, run the e2e suite against a staging backend running that version, then cut a minor SDK release.
+
+**Override path**: per `Payments` instance via the existing `options.version` (e.g. `Payments.getInstance({ ..., version: '1.0' })`). There is intentionally **no per-request override** — `Nevermined-Version` is not in the `ALLOWED_EXTRA_HEADERS` allowlist, so `extraHeaders` cannot clobber it.
+
+See https://docs.nevermined.app/api-reference/versioning and nvm-monorepo#1535/#1938.
+
 ### x402 Protocol and Documentation Standards
 
 When writing examples or documentation:

--- a/markdown/initializing-the-library.md
+++ b/markdown/initializing-the-library.md
@@ -77,7 +77,9 @@ const payments = Payments.getBrowserInstance({
   returnUrl: 'https://myapp.example/callback',
   environment: 'sandbox',
   appId: 'my-app',
-  version: '1.0.0',
+  // Optional: pin the backend API version (MAJOR.MINOR). Defaults to the
+  // version this SDK release targets — omit unless you must pin an older one.
+  version: '1.1',
 })
 ```
 

--- a/src/api/agents-api.ts
+++ b/src/api/agents-api.ts
@@ -168,7 +168,10 @@ export class AgentsAPI extends BasePaymentsAPI {
 
     const response = await fetch(url, options)
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Unable to register agent & plan', await safeParseJson(response))
+      throw PaymentsError.fromBackend(
+        'Unable to register agent & plan',
+        await safeParseJson(response),
+      )
     }
     const result = await response.json()
     return {
@@ -192,7 +195,7 @@ export class AgentsAPI extends BasePaymentsAPI {
    */
   public async getAgent(agentId: string) {
     const url = new URL(API_URL_GET_AGENT.replace(':agentId', agentId), this.environment.backend)
-    const response = await fetch(url)
+    const response = await fetch(url, this.getPublicHTTPOptions('GET'))
     if (!response.ok) {
       throw PaymentsError.fromBackend('Agent not found', await safeParseJson(response))
     }
@@ -257,7 +260,7 @@ export class AgentsAPI extends BasePaymentsAPI {
     const query =
       API_URL_GET_AGENT_PLANS.replace(':agentId', agentId) + '?' + pagination.asQueryParams()
     const url = new URL(query, this.environment.backend)
-    const response = await fetch(url)
+    const response = await fetch(url, this.getPublicHTTPOptions('GET'))
     if (!response.ok) {
       throw PaymentsError.fromBackend('Agent not found', await safeParseJson(response))
     }
@@ -327,7 +330,10 @@ export class AgentsAPI extends BasePaymentsAPI {
     const url = new URL(endpoint, this.environment.backend)
     const response = await fetch(url, options)
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Unable to remove plan from agent', await safeParseJson(response))
+      throw PaymentsError.fromBackend(
+        'Unable to remove plan from agent',
+        await safeParseJson(response),
+      )
     }
 
     return response.json()

--- a/src/api/base-payments.ts
+++ b/src/api/base-payments.ts
@@ -90,6 +90,15 @@ export abstract class BasePaymentsAPI {
     this.environment = Environments[options.environment as EnvironmentName]
     this.environmentName = options.environment
     this.appId = options.appId
+    // `version` is the backend API pin (MAJOR.MINOR) sent verbatim as
+    // Nevermined-Version. Fail fast on a malformed value rather than shipping
+    // an invalid header (e.g. an SDK package version '1.0.0', 'v1.1', or '')
+    // that the backend rejects with 400 on every call.
+    if (options.version !== undefined && !/^\d+\.\d+$/.test(options.version)) {
+      throw new PaymentsError(
+        `Invalid 'version' option '${options.version}': expected a backend API version as MAJOR.MINOR (e.g. '1.1'). Omit it to use the SDK's default pin.`,
+      )
+    }
     this.version = options.version
     this.currentOrganizationId = options.organizationId ?? null
 

--- a/src/api/base-payments.ts
+++ b/src/api/base-payments.ts
@@ -1,4 +1,5 @@
 import { decodeJwt } from 'jose'
+import { API_VERSION_HEADER, LOCKED_API_VERSION } from '../common/api-version.js'
 import { jsonReplacer } from '../common/helper.js'
 import { PaymentsError } from '../common/payments.error.js'
 import { PaymentOptions, PaymentScheme } from '../common/types.js'
@@ -60,6 +61,11 @@ export abstract class BasePaymentsAPI {
   protected environmentName: EnvironmentName
   protected returnUrl: string
   protected appId?: string
+  /**
+   * Backend API version (MAJOR.MINOR) pinned by this instance, set from
+   * `options.version`. When unset, every request defaults to
+   * {@link LOCKED_API_VERSION}.
+   */
   protected version?: string
   protected accountAddress: string
   protected heliconeApiKey: string
@@ -168,6 +174,7 @@ export abstract class BasePaymentsAPI {
       Accept: 'application/json',
       'Content-Type': 'application/json',
       Authorization: `Bearer ${this.nvmApiKey}`,
+      [API_VERSION_HEADER]: this.version ?? LOCKED_API_VERSION,
     }
     if (this.currentOrganizationId) {
       headers[CURRENT_ORG_ID_HEADER] = this.currentOrganizationId
@@ -201,16 +208,14 @@ export abstract class BasePaymentsAPI {
   protected getPublicHTTPOptions(method: string, body?: any) {
     const options: {
       method: string
-      headers: {
-        Accept: string
-        'Content-Type': string
-      }
+      headers: Record<string, string>
       body?: string
     } = {
       method,
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
+        [API_VERSION_HEADER]: this.version ?? LOCKED_API_VERSION,
       },
     }
 

--- a/src/api/contracts-api.ts
+++ b/src/api/contracts-api.ts
@@ -28,7 +28,7 @@ export class ContractsAPI extends BasePaymentsAPI {
     const infoUrl = new URL('/', this.environment.backend)
 
     try {
-      const response = await fetch(infoUrl, { method: 'GET' })
+      const response = await fetch(infoUrl, this.getPublicHTTPOptions('GET'))
       if (!response.ok) {
         throw new PaymentsError(
           `Failed to fetch deployment info: ${response.status} ${response.statusText}`,

--- a/src/api/plans-api.ts
+++ b/src/api/plans-api.ts
@@ -610,15 +610,8 @@ export class PlansAPI extends BasePaymentsAPI {
       holderAddress,
     )
 
-    const options = {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-    }
     const url = new URL(balanceUrl, this.environment.backend)
-    const response = await fetch(url, options)
+    const response = await fetch(url, this.getPublicHTTPOptions('GET'))
     if (!response.ok) {
       throw PaymentsError.fromBackend('Unable to get balance', await safeParseJson(response))
     }

--- a/src/api/plans-api.ts
+++ b/src/api/plans-api.ts
@@ -513,7 +513,7 @@ export class PlansAPI extends BasePaymentsAPI {
   public async getPlan(planId: string) {
     const query = API_URL_GET_PLAN.replace(':planId', planId)
     const url = new URL(query, this.environment.backend)
-    const response = await fetch(url)
+    const response = await fetch(url, this.getPublicHTTPOptions('GET'))
     if (!response.ok) {
       throw PaymentsError.fromBackend('Plan not found', await safeParseJson(response))
     }
@@ -568,7 +568,7 @@ export class PlansAPI extends BasePaymentsAPI {
     const query =
       API_URL_GET_PLAN_AGENTS.replace(':planId', planId) + '?' + pagination.asQueryParams()
     const url = new URL(query, this.environment.backend)
-    const response = await fetch(url)
+    const response = await fetch(url, this.getPublicHTTPOptions('GET'))
     if (!response.ok) {
       throw PaymentsError.fromBackend('Plan not found', await safeParseJson(response))
     }

--- a/src/common/api-version.ts
+++ b/src/common/api-version.ts
@@ -1,0 +1,24 @@
+/**
+ * The Nevermined **backend API** version (nvm-monorepo MAJOR.MINOR) this SDK
+ * release is built and tested against — NOT the version of the SDK package
+ * itself. Every HTTP request the SDK sends to the Nevermined backend carries
+ * this value in the {@link API_VERSION_HEADER} header so the backend keeps
+ * serving the matching API contract even after newer backend deployments.
+ *
+ * Bump this constant deliberately, and only when the SDK targets a newer
+ * backend contract: update the value, run the e2e suite against a staging
+ * backend running that version, then cut a minor SDK release.
+ *
+ * Callers can override the pin per `Payments` instance via
+ * `options.version`.
+ *
+ * @see https://docs.nevermined.app/api-reference/versioning
+ */
+export const LOCKED_API_VERSION = '1.1'
+
+/**
+ * Name of the HTTP request header carrying the backend API version the SDK
+ * is pinned to. Sent on every backend call with the resolved instance
+ * version (defaults to {@link LOCKED_API_VERSION}).
+ */
+export const API_VERSION_HEADER = 'Nevermined-Version'

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -39,7 +39,13 @@ export interface PaymentOptions {
   appId?: string
 
   /**
-   * The version of the API to use.
+   * Pins the Nevermined backend API version (MAJOR.MINOR) sent with every
+   * request via the `Nevermined-Version` header. Defaults to
+   * {@link LOCKED_API_VERSION} — the backend contract this SDK release is
+   * built and tested against. Override only to deliberately target a
+   * different backend contract.
+   *
+   * @see https://docs.nevermined.app/api-reference/versioning
    */
   version?: string
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './environments.js'
 export * from './payments.js'
 export * from './utils.js'
+export * from './common/api-version.js'
 export * from './common/types.js'
 export * from './common/payments.error.js'
 export * from './common/helper.js'

--- a/src/payments.ts
+++ b/src/payments.ts
@@ -93,8 +93,9 @@ export class Payments extends BasePaymentsAPI {
    * Returns the Delegation API for listing enrolled payment methods.
    * The instance is lazily initialized on first access — the current
    * organization pin (set via `setOrganizationId` or the constructor
-   * option) is forwarded so the first call carries the right
-   * `X-Current-Org-Id` header.
+   * option) and the backend API version pin (`options.version`) are
+   * forwarded so the first call carries the right `X-Current-Org-Id`
+   * and `Nevermined-Version` headers.
    */
   public get delegation(): DelegationAPI {
     if (!this._delegation) {
@@ -102,6 +103,7 @@ export class Payments extends BasePaymentsAPI {
         nvmApiKey: this.nvmApiKey,
         environment: this.environmentName,
         organizationId: this.currentOrganizationId ?? undefined,
+        version: this.version,
       })
     }
     return this._delegation

--- a/src/payments.ts
+++ b/src/payments.ts
@@ -149,7 +149,7 @@ export class Payments extends BasePaymentsAPI {
    *   returnUrl: 'https://mysite.example',
    *   environment: 'sandbox',
    *   appId: 'my-app-id',
-   *   version: '1.0.0'
+   *   version: '1.1'
    * })
    * ```
    * @returns An instance of {@link Payments}

--- a/tests/unit/api-version.test.ts
+++ b/tests/unit/api-version.test.ts
@@ -187,10 +187,13 @@ describe('API version pinning — Nevermined-Version header', () => {
 
       await payments.plans.getPlan('plan-123')
       await payments.plans.getAgentsAssociatedToAPlan('plan-123')
+      await payments.plans
+        .getPlanBalance('plan-123', '0x6B16D0b334824581B4a24A49Fd7fcbD6509CE5da')
+        .catch(() => undefined) // stub payload may not satisfy parsing; the wire assertion below is the point
       await payments.agents.getAgent('agent-123')
       await payments.agents.getAgentPlans('agent-123')
 
-      expect(calls).toHaveLength(4)
+      expect(calls).toHaveLength(5)
       for (const call of calls) {
         expect(call.init.headers[API_VERSION_HEADER]).toBe(LOCKED_API_VERSION)
         expect(call.init.headers.Authorization).toBeUndefined()

--- a/tests/unit/api-version.test.ts
+++ b/tests/unit/api-version.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Unit tests for backend API version pinning (nvm-monorepo#1938, epic #1535).
+ *
+ * Every HTTP call the SDK makes to the Nevermined backend must carry a
+ * `Nevermined-Version` header so the backend serves the API contract this SDK
+ * release was built and tested against. The value defaults to
+ * `LOCKED_API_VERSION` and is overridable per instance via `options.version`
+ * — never per request.
+ *
+ * `fetch` is replaced with a recording stub (same pattern as
+ * `organizations-api.test.ts`) so headers can be asserted without hitting the
+ * network. The mock NVM API key is the same fixture used in
+ * `payments.test.ts`.
+ */
+
+import { Payments } from '../../src/payments.js'
+import { BasePaymentsAPI } from '../../src/api/base-payments.js'
+import { API_VERSION_HEADER, LOCKED_API_VERSION } from '../../src/common/api-version.js'
+import { PaymentOptions } from '../../src/common/types.js'
+
+const TEST_API_KEY =
+  'sandbox-staging:eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweDU4MzhCNTUxMmNGOWYxMkZFOWYyYmVjY0IyMGViNDcyMTFGOUIwYmMiLCJzdWIiOiIweDIxRjc5ZjlkM2I2ZDUyZUY4Y2M4QjFhN0YyNjFCY2Y1ZjJFRjM1NGEiLCJqdGkiOiIweGUxMjIwMmRkMzZlZmQ4N2FkMjE1MmRlMjlkM2MwNmE5ZDU5N2M4NWJhOGMxOTQ1YjQ5MjlkYTYyYTRiZjQ1NGYiLCJleHAiOjE3OTEwNDc0OTcsIm8xMXkiOiJzay1oZWxpY29uZS13amUzYXdpLW5ud2V5M2EtdzdndnY3YS1oYmh3bm1pIn0.JI14qfSWHCWRvHOK9TAg3HEXWX7oKEI6fU6gaaWlyDl5btBWLh8FQo1ZnuzixPmgsUR3gc4oRlenLPUuTy-mORw'
+
+/**
+ * Minimal concrete subclass exposing the protected HTTP option builders so
+ * both can be asserted on directly.
+ */
+class TestPaymentsAPI extends BasePaymentsAPI {
+  backendOptions(method: string, body?: any, extraHeaders?: Record<string, string>) {
+    return this.getBackendHTTPOptions(method, body, extraHeaders)
+  }
+
+  publicOptions(method: string, body?: any) {
+    return this.getPublicHTTPOptions(method, body)
+  }
+}
+
+function makeApi(version?: string): TestPaymentsAPI {
+  const options: PaymentOptions = {
+    nvmApiKey: TEST_API_KEY,
+    environment: 'staging_sandbox',
+    ...(version ? { version } : {}),
+  }
+  return new TestPaymentsAPI(options)
+}
+
+type RecordedCall = { url: URL; init: any }
+
+const originalFetch = globalThis.fetch
+
+function installFetchStub(
+  responder: (call: RecordedCall) => { ok: boolean; status?: number; body: any },
+): RecordedCall[] {
+  const calls: RecordedCall[] = []
+  globalThis.fetch = (async (input: any, init?: any) => {
+    const url = input instanceof URL ? input : new URL(String(input))
+    const call: RecordedCall = { url, init: init ?? input }
+    calls.push(call)
+    const { ok, status = ok ? 200 : 500, body } = responder(call)
+    return {
+      ok,
+      status,
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    } as any
+  }) as any
+  return calls
+}
+
+function restoreFetch() {
+  globalThis.fetch = originalFetch
+}
+
+describe('API version pinning — Nevermined-Version header', () => {
+  describe('constants', () => {
+    test('LOCKED_API_VERSION is the backend MAJOR.MINOR contract this SDK targets', () => {
+      expect(LOCKED_API_VERSION).toBe('1.1')
+    })
+
+    test('API_VERSION_HEADER is the Nevermined-Version header name', () => {
+      expect(API_VERSION_HEADER).toBe('Nevermined-Version')
+    })
+
+    test('both constants are re-exported from the package barrel', async () => {
+      const barrel = await import('../../src/index.js')
+      expect(barrel.LOCKED_API_VERSION).toBe(LOCKED_API_VERSION)
+      expect(barrel.API_VERSION_HEADER).toBe(API_VERSION_HEADER)
+    })
+  })
+
+  describe('getBackendHTTPOptions', () => {
+    test('pins LOCKED_API_VERSION by default', () => {
+      const { headers } = makeApi().backendOptions('GET')
+      expect(headers[API_VERSION_HEADER]).toBe('1.1')
+    })
+
+    test('honours the instance-level options.version override', () => {
+      const { headers } = makeApi('1.0').backendOptions('POST', { some: 'body' })
+      expect(headers[API_VERSION_HEADER]).toBe('1.0')
+    })
+
+    test('leaves the other transport headers untouched', () => {
+      const { headers } = makeApi().backendOptions('GET')
+      expect(headers.Authorization).toBe(`Bearer ${TEST_API_KEY}`)
+      expect(headers.Accept).toBe('application/json')
+      expect(headers['Content-Type']).toBe('application/json')
+    })
+
+    test('per-request extraHeaders cannot override the pinned version', () => {
+      const { headers } = makeApi().backendOptions('GET', undefined, {
+        [API_VERSION_HEADER]: '9.9',
+      })
+      expect(headers[API_VERSION_HEADER]).toBe(LOCKED_API_VERSION)
+    })
+  })
+
+  describe('getPublicHTTPOptions', () => {
+    test('pins LOCKED_API_VERSION by default', () => {
+      const { headers } = makeApi().publicOptions('GET')
+      expect(headers[API_VERSION_HEADER]).toBe('1.1')
+    })
+
+    test('honours the instance-level options.version override', () => {
+      const { headers } = makeApi('1.0').publicOptions('POST', { some: 'body' })
+      expect(headers[API_VERSION_HEADER]).toBe('1.0')
+    })
+
+    test('never includes an Authorization header', () => {
+      const { headers } = makeApi().publicOptions('GET')
+      expect((headers as Record<string, string>).Authorization).toBeUndefined()
+      expect(headers.Accept).toBe('application/json')
+      expect(headers['Content-Type']).toBe('application/json')
+    })
+  })
+
+  describe('Payments instance — header reaches the wire', () => {
+    afterEach(() => {
+      restoreFetch()
+    })
+
+    test('authenticated backend calls send the default version', async () => {
+      const payments = Payments.getInstance({
+        nvmApiKey: TEST_API_KEY,
+        environment: 'staging_sandbox',
+      })
+      const calls = installFetchStub(() => ({ ok: true, body: [] }))
+
+      await payments.organizations.getMyMemberships()
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0].init.headers[API_VERSION_HEADER]).toBe(LOCKED_API_VERSION)
+      expect(calls[0].init.headers.Authorization).toMatch(/^Bearer /)
+    })
+
+    test('options.version override propagates to sub-API calls', async () => {
+      const payments = Payments.getInstance({
+        nvmApiKey: TEST_API_KEY,
+        environment: 'staging_sandbox',
+        version: '1.0',
+      })
+      const calls = installFetchStub(() => ({ ok: true, body: [] }))
+
+      await payments.organizations.getMyMemberships()
+
+      expect(calls[0].init.headers[API_VERSION_HEADER]).toBe('1.0')
+    })
+
+    test('the lazily-built delegation API inherits the instance override', async () => {
+      const payments = Payments.getInstance({
+        nvmApiKey: TEST_API_KEY,
+        environment: 'staging_sandbox',
+        version: '1.0',
+      })
+      const calls = installFetchStub(() => ({ ok: true, body: [] }))
+
+      await payments.delegation.listPaymentMethods()
+
+      expect(calls[0].init.headers[API_VERSION_HEADER]).toBe('1.0')
+    })
+
+    test('public (unauthenticated) backend endpoints send the version header', async () => {
+      const payments = Payments.getInstance({
+        nvmApiKey: TEST_API_KEY,
+        environment: 'staging_sandbox',
+      })
+      const calls = installFetchStub(() => ({ ok: true, body: {} }))
+
+      await payments.plans.getPlan('plan-123')
+      await payments.plans.getAgentsAssociatedToAPlan('plan-123')
+      await payments.agents.getAgent('agent-123')
+      await payments.agents.getAgentPlans('agent-123')
+
+      expect(calls).toHaveLength(4)
+      for (const call of calls) {
+        expect(call.init.headers[API_VERSION_HEADER]).toBe(LOCKED_API_VERSION)
+        expect(call.init.headers.Authorization).toBeUndefined()
+      }
+    })
+
+    test('the deployment info bootstrap call sends the version header', async () => {
+      const payments = Payments.getInstance({
+        nvmApiKey: TEST_API_KEY,
+        environment: 'staging_sandbox',
+      })
+      const calls = installFetchStub(() => ({
+        ok: true,
+        body: { deployment: { contracts: { PaymentsVault: '0x1' } } },
+      }))
+
+      await payments.contracts.getDeploymentInfo()
+
+      expect(calls[0].init.headers[API_VERSION_HEADER]).toBe(LOCKED_API_VERSION)
+    })
+  })
+})

--- a/tests/unit/api-version.test.ts
+++ b/tests/unit/api-version.test.ts
@@ -114,6 +114,27 @@ describe('API version pinning — Nevermined-Version header', () => {
     })
   })
 
+  describe('options.version validation', () => {
+    test.each(['1.0', '1.1', '2.10'])('accepts canonical MAJOR.MINOR %p', (version) => {
+      expect(() =>
+        Payments.getInstance({ nvmApiKey: TEST_API_KEY, environment: 'staging_sandbox', version }),
+      ).not.toThrow()
+    })
+
+    test.each(['1.0.0', 'v1.1', '1', '1.x', ''])(
+      'rejects a malformed version %p at construction',
+      (version) => {
+        expect(() =>
+          Payments.getInstance({
+            nvmApiKey: TEST_API_KEY,
+            environment: 'staging_sandbox',
+            version,
+          }),
+        ).toThrow(/MAJOR\.MINOR/)
+      },
+    )
+  })
+
   describe('getPublicHTTPOptions', () => {
     test('pins LOCKED_API_VERSION by default', () => {
       const { headers } = makeApi().publicOptions('GET')
@@ -185,11 +206,12 @@ describe('API version pinning — Nevermined-Version header', () => {
       })
       const calls = installFetchStub(() => ({ ok: true, body: {} }))
 
+      // getPlanBalance does no client-side body parsing, so an ok:true stub
+      // with a valid holder address resolves cleanly — assert it directly so
+      // a future pre-fetch throw surfaces here instead of being swallowed.
       await payments.plans.getPlan('plan-123')
       await payments.plans.getAgentsAssociatedToAPlan('plan-123')
-      await payments.plans
-        .getPlanBalance('plan-123', '0x6B16D0b334824581B4a24A49Fd7fcbD6509CE5da')
-        .catch(() => undefined) // stub payload may not satisfy parsing; the wire assertion below is the point
+      await payments.plans.getPlanBalance('plan-123', '0x6B16D0b334824581B4a24A49Fd7fcbD6509CE5da')
       await payments.agents.getAgent('agent-123')
       await payments.agents.getAgentPlans('agent-123')
 


### PR DESCRIPTION
Implements the SDK half of nevermined-io/nvm-monorepo#1938 (epic nvm-monorepo#1535).

Every HTTP call to the Nevermined backend now carries `Nevermined-Version: <LOCKED_API_VERSION>` (currently **`1.1`** — the backend MAJOR.MINOR this SDK targets, not the package version), overridable per instance.

## ⚠️ Release ordering

**Do NOT publish this SDK until backend v1.1.0 is deployed to production.** The backend rejects pins above its current version with `400 BCK.VERSION.0001`, so a 1.1-pinned SDK against a 1.0 backend fails every call. Merging is safe; publishing waits for the platform rollout.

Integration/e2e suites were deliberately not run (staging is not on 1.1 yet) — run them as the release gate once staging deploys v1.1.0.

## Test plan
- [x] TDD: header tests written first, watched fail
- [x] Full unit suite green
- [x] Lint/format clean
- [ ] e2e against staging at v1.1.0 (pre-publish gate)
