### PR TITLE
docs(openclaw): document automatic API version pinning

### DIFF
--- a/openclaw/skills/nevermined/SKILL.md
+++ b/openclaw/skills/nevermined/SKILL.md
@@ -63,6 +63,12 @@ Authenticate with Nevermined via browser login. Opens a browser window to obtain
 ### `/nvm_logout`
 Log out from Nevermined and remove the stored API key.
 
+## API versioning
+
+Every Nevermined-backend call this plugin makes goes through the `@nevermined-io/payments` SDK, which **pins the backend API version** (the platform `MAJOR.MINOR`) via the `Nevermined-Version` header automatically — so OpenClaw-orchestrated agents keep getting a stable wire shape across platform releases without any per-call work. The pinned version is the one the bundled SDK release was built and tested against; it moves only when the plugin upgrades its SDK dependency.
+
+If an agent makes a **direct** REST call to the Nevermined API (outside these tools), send `Nevermined-Version: <MAJOR.MINOR>`, default it to the `current` from `GET /api/v1/meta/versions`, and never silently change a key's stored pin. See <https://docs.nevermined.app/docs/development-guide/api-versioning>.
+
 ## Subscriber Tools
 
 ### `nevermined_checkBalance`


### PR DESCRIPTION
Completes the **OpenClaw half of nevermined-io/nvm-monorepo#1940** (epic #1535). The skill half shipped in docs#224.

The OpenClaw plugin makes **no direct Nevermined-backend REST calls** — all backend traffic flows through the `@nevermined-io/payments` SDK, which (after #381) pins `Nevermined-Version` automatically. So the plugin inherits version pinning for free; the only direct `fetch` is to the *agent's* URL (carrying the x402 token, not the version header).

This PR documents that in the OpenClaw skill: the automatic pinning behavior + direct-REST guidance (default to `GET /meta/versions` `current`, never silently change a key's pin).

Docs-only; no code or signature changes.

[skip-version-gate]: docs only