### PR TITLE
docs: fix ClawHub skill references → nevermined-io/nevermined

### DIFF
--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -14,7 +14,7 @@ This plugin is published from the [`nevermined-io/payments`](https://github.com/
 | **Security policy** | https://github.com/nevermined-io/payments/security/policy |
 | **Issue tracker** | https://github.com/nevermined-io/payments/issues |
 
-> ✅ **Official ClawHub listing.** The official skill lives at [`clawhub.ai/nevermined/nevermined-payments`](https://clawhub.ai/nevermined/nevermined-payments) under the `@nevermined` org publisher. Treat any other ClawHub publisher as a third-party mirror until further notice. The canonical npm package is [`@nevermined-io/openclaw-plugin`](https://www.npmjs.com/package/@nevermined-io/openclaw-plugin).
+> ✅ **Official ClawHub listing.** The official skill lives at [`clawhub.ai/nevermined-io/nevermined`](https://clawhub.ai/nevermined-io/nevermined) under the `nevermined-io` org publisher. Treat any other ClawHub publisher as a third-party mirror until further notice. The canonical npm package is [`@nevermined-io/openclaw-plugin`](https://www.npmjs.com/package/@nevermined-io/openclaw-plugin).
 >
 > 🔐 **Never log payment tokens.** x402 access tokens (the `payment-signature` header) are bearer credentials. Treat them like API keys: redact them in any debug output, log pipeline, or telemetry exporter (pino, winston, OpenTelemetry, etc.).
 

--- a/openclaw/skills/nevermined/SKILL.md
+++ b/openclaw/skills/nevermined/SKILL.md
@@ -50,7 +50,7 @@ metadata:
 
 This plugin provides gateway tools for interacting with Nevermined AI agent payments. Supports both crypto (on-chain) and fiat (credit card) payment flows.
 
-> **Official source.** This skill is published from [`nevermined-io/payments`](https://github.com/nevermined-io/payments) (subdirectory `openclaw/`) by Nevermined AG, mirrored to ClawHub at [`clawhub.ai/nevermined/nevermined-payments`](https://clawhub.ai/nevermined/nevermined-payments) under the `@nevermined` org publisher. The npm package is [`@nevermined-io/openclaw-plugin`](https://www.npmjs.com/package/@nevermined-io/openclaw-plugin) (Apache-2.0).
+> **Official source.** This skill is published from [`nevermined-io/payments`](https://github.com/nevermined-io/payments) (subdirectory `openclaw/`) by Nevermined AG, mirrored to ClawHub at [`clawhub.ai/nevermined-io/nevermined`](https://clawhub.ai/nevermined-io/nevermined) under the `nevermined-io` org publisher. The npm package is [`@nevermined-io/openclaw-plugin`](https://www.npmjs.com/package/@nevermined-io/openclaw-plugin) (Apache-2.0).
 >
 > **Never log payment tokens.** x402 access tokens (the `payment-signature` header) are bearer credentials. Redact them in any debug or telemetry output.
 


### PR DESCRIPTION
The Nevermined skill is now published under the **`nevermined-io`** ClawHub publisher at **https://clawhub.ai/nevermined-io/nevermined** (slug `nevermined`).

Updates the two stale references that pointed to the old `clawhub.ai/nevermined/nevermined-payments` under `@nevermined`:
- `openclaw/README.md` (mirrors into the docs `api-reference/openclaw-plugin/` — fixes the rendered docs reference)
- `openclaw/skills/nevermined/SKILL.md`

npm package references are unchanged.