### PR TITLE
feat(a2a): align A2A with x402 v2 in-band transport + canonical agent-card discovery

### DIFF
--- a/markdown/a2a-integration.md
+++ b/markdown/a2a-integration.md
@@ -19,12 +19,12 @@ The A2A integration provides:
 
 ## Build Payment Agent Card
 
-The agent card is published at `/.well-known/agent.json` and includes payment metadata. Before sending a paid request, **clients should fetch and validate the target agent's card** to confirm the expected `agentId`, the `capabilities`, and the supported X402 schemes — this protects against routing payment-signature tokens to a typosquatted or unauthorised endpoint:
+The agent card is published at the canonical `/.well-known/agent-card.json` (A2A 0.3+), with the legacy `/.well-known/agent.json` kept as a backward-compat alias. It includes payment metadata. Before sending a paid request, **clients should fetch and validate the target agent's card** to confirm the expected `agentId`, the `capabilities`, and the supported X402 schemes — this protects against routing payment tokens to a typosquatted or unauthorised endpoint:
 
 ```typescript
 const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1'])
 
-const cardUrl = new URL('/.well-known/agent.json', agentUrl)
+const cardUrl = new URL('/.well-known/agent-card.json', agentUrl)
 const card = await fetch(cardUrl, { method: 'GET' }).then((r) => r.json())
 
 if (card.agentId !== expectedAgentId) {
@@ -73,7 +73,7 @@ const agentCard = Payments.a2a.buildPaymentAgentCard(
 
 ## Payment Extension Structure
 
-The agent card includes a Nevermined payment extension in `capabilities.extensions`:
+The agent card declares two extensions in `capabilities.extensions`: the Nevermined payment extension (pricing metadata) and the official a2a-x402 extension (`https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2`), which signals support for the standards-compliant in-band x402 v2 flow (see below). Both are emitted for one release; `urn:nevermined:payment` will be dropped once clients migrate to v0.2 only.
 
 ```json
 {
@@ -90,11 +90,45 @@ The agent card includes a Nevermined payment extension in `capabilities.extensio
           "planId": "plan-456",
           "costDescription": "5 credits per request"
         }
+      },
+      {
+        "uri": "https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2",
+        "required": false
       }
     ]
   }
 }
 ```
+
+## x402 v2 In-Band Payments (Standards Flow)
+
+Payment is signalled **in band** following the [Coinbase x402 v2 A2A transport spec](https://github.com/coinbase/x402/blob/main/specs/transports-v2/a2a.md) and the official [a2a-x402 extension](https://github.com/google-agentic-commerce/a2a-x402). No HTTP 402 is involved — the whole handshake rides on A2A task/message metadata, correlated by `taskId`. This is automatic when you use `payments.a2a.start`; nothing changes in your executor.
+
+Lifecycle:
+
+1. **Payment required** — a payment-gated `message/send` arrives with no payment. The server returns a Task with `status.state = "input-required"` and `status.message.metadata`:
+
+   ```json
+   {
+     "x402.payment.status": "payment-required",
+     "x402.payment.required": { /* X402PaymentRequired (accepts[] of plans) */ }
+   }
+   ```
+
+2. **Payment submitted** — the client sends a follow-up `message/send` whose `message.metadata` carries the payload, correlated via `message.taskId`:
+
+   ```json
+   {
+     "x402.payment.status": "payment-submitted",
+     "x402.payment.payload": { /* PaymentPayload */ }
+   }
+   ```
+
+3. **Completed / failed** — on success the final Task carries `x402.payment.status: "payment-completed"` plus `x402.payment.receipts` (array of settle receipts). On failure it is `failed` / `x402.payment.status: "payment-failed"` with the error under `x402.payment.error`, and paid content is suppressed.
+
+Metadata keys: `x402.payment.status`, `x402.payment.required`, `x402.payment.payload`, `x402.payment.receipts`, `x402.payment.error`.
+
+> ⚠️ **Header flow deprecated.** The legacy `payment-signature` HTTP header still works but is now a **deprecated fallback, kept for one release**. New integrations should rely on the in-band metadata flow above.
 
 ## Implement Executor
 
@@ -293,7 +327,7 @@ const { server, close } = await payments.a2a.start({
   executor,
   port: 6000,
   basePath: '/a2a/',
-  exposeAgentCard: true,        // Expose /.well-known/agent.json
+  exposeAgentCard: true,        // Expose /.well-known/agent-card.json (+ legacy /.well-known/agent.json alias)
   exposeDefaultRoutes: true,    // Expose health and info routes
 })
 
@@ -307,7 +341,7 @@ process.on('SIGINT', async () => {
 })
 ```
 
-> 🔐 **Run behind a reverse proxy with HTTPS in production.** A2A peers exchange paid `payment-signature` tokens over HTTP headers — never expose the raw server on a public hostname without TLS. Bind the dev server to `127.0.0.1` (e.g. by running it inside a container with no published port, or behind a localhost-bound proxy).
+> 🔐 **Run behind a reverse proxy with HTTPS in production.** A2A peers exchange paid tokens — in band via `x402.payment.payload`, or over the deprecated `payment-signature` header — so never expose the raw server on a public hostname without TLS. Bind the dev server to `127.0.0.1` (e.g. by running it inside a container with no published port, or behind a localhost-bound proxy).
 
 ## Credit Reporting
 
@@ -532,7 +566,7 @@ const { server, close } = await payments.a2a.start({
 })
 
 console.log('Weather A2A Agent running on http://localhost:6000/a2a/')
-console.log('Agent card: http://localhost:6000/a2a/.well-known/agent.json')
+console.log('Agent card: http://localhost:6000/a2a/.well-known/agent-card.json')
 
 // Graceful shutdown
 process.on('SIGINT', async () => {
@@ -573,7 +607,7 @@ const { server, close } = await payments.a2a.start({
   executor,                       // Task executor (required)
   port: 6000,                     // Server port (required)
   basePath: '/a2a/',              // Base path (optional, default: '/')
-  exposeAgentCard: true,          // Expose /.well-known/agent.json (optional)
+  exposeAgentCard: true,          // Expose /.well-known/agent-card.json + legacy alias (optional)
   exposeDefaultRoutes: true,      // Expose /health, /info (optional)
   paymentsService: payments,      // Custom payments instance (optional)
   handlerOptions: {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     }
   },
   "dependencies": {
-    "@a2a-js/sdk": "^0.3.4",
+    "@a2a-js/sdk": "^0.3.13",
     "@helicone/helpers": "^1.6.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
   .:
     dependencies:
       '@a2a-js/sdk':
-        specifier: ^0.3.4
+        specifier: ^0.3.13
         version: 0.3.13(@grpc/grpc-js@1.14.3)(express@4.21.2)
       '@helicone/helpers':
         specifier: ^1.6.0
@@ -5026,10 +5026,6 @@ packages:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
-
   uuid@11.1.1:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
@@ -5044,6 +5040,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -5176,7 +5173,7 @@ snapshots:
 
   '@a2a-js/sdk@0.3.13(@grpc/grpc-js@1.14.3)(express@4.21.2)':
     dependencies:
-      uuid: 11.1.0
+      uuid: 11.1.1
     optionalDependencies:
       '@grpc/grpc-js': 1.14.3
       express: 4.21.2
@@ -11770,8 +11767,6 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@10.0.0: {}
-
-  uuid@11.1.0: {}
 
   uuid@11.1.1: {}
 

--- a/src/a2a/agent-card.ts
+++ b/src/a2a/agent-card.ts
@@ -13,7 +13,7 @@
 import type { AgentCard } from './types.js'
 
 /**
- * Canonical A2A agent-card discovery path (A2A >= 0.3 and `@a2a-js/sdk`'s own
+ * Canonical A2A agent-card discovery path (A2A 0.3+ and `@a2a-js/sdk`'s own
  * default, per RFC 8615). Served by Nevermined A2A agents and used as the
  * default when fetching a remote agent's card.
  */
@@ -26,6 +26,22 @@ export const AGENT_CARD_WELL_KNOWN_PATH = '.well-known/agent-card.json'
  * ponytail: drop the alias + fallback one release after agents are updated.
  */
 export const LEGACY_AGENT_CARD_WELL_KNOWN_PATH = '.well-known/agent.json'
+
+/**
+ * Nevermined's own payment extension URI. Carries the agent/plan params the
+ * Nevermined paywall reads (agentId, planId, redemptionConfig, …). Kept for one
+ * release alongside the official a2a-x402 extension below for backward compat.
+ */
+export const NVM_PAYMENT_EXTENSION_URI = 'urn:nevermined:payment'
+
+/**
+ * Official a2a-x402 extension URI (x402 v2 A2A transport). Declaring it tells
+ * generic A2A clients this agent speaks the standards-compliant in-band x402
+ * flow (payment signalled through Task / Message `x402.payment.*` metadata).
+ * @see https://github.com/google-agentic-commerce/a2a-x402
+ */
+export const A2A_X402_EXTENSION_URI =
+  'https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2'
 
 /**
  * Payment/pricing information to be included in the AgentCard extensions.
@@ -136,11 +152,21 @@ export function buildPaymentAgentCard(
       extensions: [
         ...(baseCard.capabilities?.extensions || []),
         {
-          uri: 'urn:nevermined:payment',
+          uri: NVM_PAYMENT_EXTENSION_URI,
           description: paymentMetadata.costDescription,
           required: false,
           // explicit type assertion to satisfy {[key: string]: unknown}
           params: paymentMetadata as { [key: string]: unknown },
+        },
+        // Official a2a-x402 extension: signals to generic A2A clients that this
+        // agent supports the standards-compliant in-band x402 v2 payment flow.
+        // Kept additive alongside the Nevermined extension for one release.
+        {
+          uri: A2A_X402_EXTENSION_URI,
+          description:
+            paymentMetadata.costDescription ||
+            'Supports payments using the x402 protocol for on-chain settlement.',
+          required: false,
         },
       ],
     },

--- a/src/a2a/agent-card.ts
+++ b/src/a2a/agent-card.ts
@@ -13,6 +13,21 @@
 import type { AgentCard } from './types.js'
 
 /**
+ * Canonical A2A agent-card discovery path (A2A >= 0.3 and `@a2a-js/sdk`'s own
+ * default, per RFC 8615). Served by Nevermined A2A agents and used as the
+ * default when fetching a remote agent's card.
+ */
+export const AGENT_CARD_WELL_KNOWN_PATH = '.well-known/agent-card.json'
+
+/**
+ * Legacy pre-0.3 discovery path. Still served as a backward-compat alias and
+ * tried as a fetch fallback, so newly-updated clients keep working against
+ * Nevermined agents that have not adopted the canonical path yet.
+ * ponytail: drop the alias + fallback one release after agents are updated.
+ */
+export const LEGACY_AGENT_CARD_WELL_KNOWN_PATH = '.well-known/agent.json'
+
+/**
  * Payment/pricing information to be included in the AgentCard extensions.
  *
  * This interface defines the structure for payment metadata that will be

--- a/src/a2a/agent-card.ts
+++ b/src/a2a/agent-card.ts
@@ -23,7 +23,7 @@ export const AGENT_CARD_WELL_KNOWN_PATH = '.well-known/agent-card.json'
  * Legacy pre-0.3 discovery path. Still served as a backward-compat alias and
  * tried as a fetch fallback, so newly-updated clients keep working against
  * Nevermined agents that have not adopted the canonical path yet.
- * ponytail: drop the alias + fallback one release after agents are updated.
+ * TODO(a2a): drop the alias + fallback one release after agents are updated.
  */
 export const LEGACY_AGENT_CARD_WELL_KNOWN_PATH = '.well-known/agent.json'
 

--- a/src/a2a/paymentsClient.ts
+++ b/src/a2a/paymentsClient.ts
@@ -17,10 +17,9 @@ import {
 import { A2AClient } from '@a2a-js/sdk/client'
 import { v4 as uuidv4 } from 'uuid'
 import type { AgentCard } from './types.js'
-import {
-  AGENT_CARD_WELL_KNOWN_PATH,
-  LEGACY_AGENT_CARD_WELL_KNOWN_PATH,
-} from './agent-card.js'
+import { AGENT_CARD_WELL_KNOWN_PATH, LEGACY_AGENT_CARD_WELL_KNOWN_PATH } from './agent-card.js'
+import { decodeAccessToken } from '../utils.js'
+import { PaymentStatus, x402A2AUtils, X402A2AMetadata } from './x402-a2a.js'
 
 /**
  * PaymentsClient is a high-level client for A2A agents with payments integration.
@@ -133,6 +132,74 @@ export class PaymentsClient extends A2AClient {
   }
 
   /**
+   * Build the in-band x402 message metadata (x402 v2 A2A transport).
+   *
+   * The server consumes the same base64 access token whether it arrives in the
+   * deprecated `payment-signature` header or in band, so the in-band
+   * `x402.payment.payload` is just the decoded PaymentPayload object. Falls back
+   * to wrapping the raw token if it is not decodable (never expected for real
+   * Nevermined tokens, which are base64 JSON).
+   *
+   * @param accessToken - The x402 access token string
+   * @returns The message-metadata fragment carrying status + payload
+   */
+  private _buildInBandPaymentMetadata(accessToken: string): Record<string, unknown> {
+    const payload = decodeAccessToken(accessToken) ?? { token: accessToken }
+    return {
+      [X402A2AMetadata.STATUS_KEY]: PaymentStatus.PAYMENT_SUBMITTED,
+      [X402A2AMetadata.PAYLOAD_KEY]: payload,
+    }
+  }
+
+  /**
+   * Return a copy of the message params with the in-band x402 payment metadata
+   * merged into `message.metadata`, optionally correlating to a taskId returned
+   * by a prior `input-required` (payment-required) response. Immutable: the
+   * caller's params object is never mutated.
+   *
+   * @param params - The original message send params
+   * @param accessToken - The x402 access token to embed in band
+   * @param taskId - Optional taskId to correlate a payment-required follow-up
+   */
+  private _withInBandPayment(
+    params: MessageSendParams,
+    accessToken: string,
+    taskId?: string,
+  ): MessageSendParams {
+    return {
+      ...params,
+      message: {
+        ...params.message,
+        ...(taskId ? { taskId } : {}),
+        metadata: {
+          ...(params.message.metadata || {}),
+          ...this._buildInBandPaymentMetadata(accessToken),
+        },
+      },
+    }
+  }
+
+  /**
+   * Detect a payment-required response (x402 v2 A2A transport): an
+   * `input-required` task whose status message carries
+   * `x402.payment.status: payment-required`. Returns the task id to correlate a
+   * follow-up payment, or `undefined` when the response is not payment-required.
+   *
+   * @param response - The JSON-RPC send-message response
+   */
+  private _paymentRequiredTaskId(response: SendMessageResponse): string | undefined {
+    if (this.isErrorResponse(response as JSONRPCResponse)) {
+      return undefined
+    }
+    const result = (response as { result?: any }).result
+    if (!result || result.kind !== 'task' || result.status?.state !== 'input-required') {
+      return undefined
+    }
+    const status = x402A2AUtils.getPaymentStatus(result)
+    return status === PaymentStatus.PAYMENT_REQUIRED ? (result.id as string) : undefined
+  }
+
+  /**
    * Type guard to check if a JSON-RPC response is an error response.
    * @param response - The JSON-RPC response to check
    * @returns true if the response contains an error, false otherwise
@@ -148,12 +215,30 @@ export class PaymentsClient extends A2AClient {
    */
   public async sendA2AMessage(params: MessageSendParams): Promise<SendMessageResponse> {
     const accessToken = await this._getX402AccessToken()
+    // Primary path (x402 v2 A2A transport): carry the payment in band. Keep the
+    // deprecated `payment-signature` header for one release so servers that have
+    // not adopted the in-band transport still authorize the request.
     const headers = { 'payment-signature': accessToken }
-    return this._postRpcRequestWithHeaders<MessageSendParams, SendMessageResponse>(
+    const inBandParams = this._withInBandPayment(params, accessToken)
+    const response = await this._postRpcRequestWithHeaders<MessageSendParams, SendMessageResponse>(
       'message/send',
-      params,
+      inBandParams,
       headers,
     )
+
+    // Reactive flow: if the server replied with an `input-required`
+    // payment-required task (it did not accept the in-band payload, e.g. it sent
+    // requirements first), resubmit the payment correlated to that task id.
+    const taskId = this._paymentRequiredTaskId(response)
+    if (taskId) {
+      const followUp = this._withInBandPayment(params, accessToken, taskId)
+      return this._postRpcRequestWithHeaders<MessageSendParams, SendMessageResponse>(
+        'message/send',
+        followUp,
+        headers,
+      )
+    }
+    return response
   }
 
   /**
@@ -176,13 +261,16 @@ export class PaymentsClient extends A2AClient {
     }
     const endpoint = await (this as any)._getServiceEndpoint()
     const clientRequestId = uuidv4()
+    const accessToken = await this._getX402AccessToken()
+    // Carry the payment in band (x402 v2 A2A transport); keep the deprecated
+    // header for one release as a fallback.
+    const inBandParams = this._withInBandPayment(params, accessToken)
     const rpcRequest = {
       jsonrpc: '2.0',
       method: 'message/stream',
-      params: params as { [key: string]: any },
+      params: inBandParams as { [key: string]: any },
       id: clientRequestId,
     }
-    const accessToken = await this._getX402AccessToken()
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: {

--- a/src/a2a/paymentsClient.ts
+++ b/src/a2a/paymentsClient.ts
@@ -75,7 +75,7 @@ export class PaymentsClient extends A2AClient {
    * Fetches a remote agent card, trying the requested (canonical) path first and
    * falling back to the legacy '.well-known/agent.json' so updated clients keep
    * working against agents that have not adopted the canonical path yet.
-   * ponytail: drop the fallback one release after agents are updated.
+   * TODO(a2a): drop the fallback one release after agents are updated.
    */
   private static async _fetchAgentCard(
     agentBaseUrl: string,

--- a/src/a2a/paymentsClient.ts
+++ b/src/a2a/paymentsClient.ts
@@ -17,6 +17,10 @@ import {
 import { A2AClient } from '@a2a-js/sdk/client'
 import { v4 as uuidv4 } from 'uuid'
 import type { AgentCard } from './types.js'
+import {
+  AGENT_CARD_WELL_KNOWN_PATH,
+  LEGACY_AGENT_CARD_WELL_KNOWN_PATH,
+} from './agent-card.js'
 
 /**
  * PaymentsClient is a high-level client for A2A agents with payments integration.
@@ -35,7 +39,7 @@ export class PaymentsClient extends A2AClient {
    * @param payments - The Payments object.
    * @param agentId - The ID of the agent.
    * @param planId - The ID of the plan.
-   * @param agentCardPath - Optional path to the agent card relative to base URL (defaults to '.well-known/agent.json').
+   * @param agentCardPath - Optional path to the agent card relative to base URL (defaults to '.well-known/agent-card.json').
    */
   private constructor(
     agentCard: AgentCard,
@@ -61,13 +65,35 @@ export class PaymentsClient extends A2AClient {
     payments: Payments,
     agentId: string,
     planId: string,
-    agentCardPath = '.well-known/agent.json',
+    agentCardPath = AGENT_CARD_WELL_KNOWN_PATH,
     delegationConfig?: DelegationConfig,
   ): Promise<PaymentsClient> {
-    const agentCardUrl = new URL(agentCardPath, agentBaseUrl).toString()
-    const a2a = await A2AClient.fromCardUrl(agentCardUrl)
-    const agentCard = await (a2a as any).getAgentCard()
-    return new PaymentsClient(agentCard as AgentCard, payments, agentId, planId, delegationConfig)
+    const agentCard = await PaymentsClient._fetchAgentCard(agentBaseUrl, agentCardPath)
+    return new PaymentsClient(agentCard, payments, agentId, planId, delegationConfig)
+  }
+
+  /**
+   * Fetches a remote agent card, trying the requested (canonical) path first and
+   * falling back to the legacy '.well-known/agent.json' so updated clients keep
+   * working against agents that have not adopted the canonical path yet.
+   * ponytail: drop the fallback one release after agents are updated.
+   */
+  private static async _fetchAgentCard(
+    agentBaseUrl: string,
+    agentCardPath: string,
+  ): Promise<AgentCard> {
+    const load = async (path: string): Promise<AgentCard> => {
+      const a2a = await A2AClient.fromCardUrl(new URL(path, agentBaseUrl).toString())
+      return (await (a2a as any).getAgentCard()) as AgentCard
+    }
+    try {
+      return await load(agentCardPath)
+    } catch (err) {
+      if (agentCardPath !== LEGACY_AGENT_CARD_WELL_KNOWN_PATH) {
+        return await load(LEGACY_AGENT_CARD_WELL_KNOWN_PATH)
+      }
+      throw err
+    }
   }
 
   /**

--- a/src/a2a/paymentsRequestHandler.ts
+++ b/src/a2a/paymentsRequestHandler.ts
@@ -525,10 +525,10 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
             const redemptionConfig = await this.getRedemptionConfig()
 
             if (!redemptionConfig.useBatch) {
-              // Prefer the per-request context (in-band flag); fall back to a
-              // per-taskId lookup for executors that mint their own task id.
+              // Prefer the per-request context (authoritative in-band flag); fall
+              // back to a per-taskId lookup for executors that mint their own task id.
               const httpContext =
-                this.getHttpRequestContextForTask(event.taskId) ?? requestHttpContext
+                requestHttpContext ?? this.getHttpRequestContextForTask(event.taskId)
               // Execute redemption with server configuration for non-batch requests
               const response = await this.executeRedemption(
                 bearerToken,
@@ -562,7 +562,32 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
               }
             }
           } catch (err) {
-            // Do nothing
+            // x402 v2 A2A: settlement failed AFTER the paid event was already
+            // streamed to the client (a stream cannot retract it). Do NOT swallow
+            // it — log, and stamp payment-failed on the persisted task so
+            // tasks/get + resubscribe reflect the failure (mirrors non-streaming).
+            console.error('[PaymentsA2A] streaming settlement failed after execution:', err)
+            const httpContext =
+              requestHttpContext ?? this.getHttpRequestContextForTask(event.taskId)
+            if (httpContext?.inBand) {
+              try {
+                const task = resultManager.getCurrentTask()
+                if (task) {
+                  const errorReason = err instanceof Error ? err.message : String(err)
+                  if (task.status) task.status.state = 'failed'
+                  task.artifacts = undefined
+                  this.recordInBandSettlement(task, httpContext, {
+                    success: false,
+                    errorReason,
+                    transaction: '',
+                    network: '',
+                  })
+                  await resultManager.processEvent(task)
+                }
+              } catch (stampErr) {
+                console.error('[PaymentsA2A] failed to stamp streaming payment-failed:', stampErr)
+              }
+            }
           }
         }
 
@@ -627,7 +652,7 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
           // carries the in-band flag). Fall back to a per-taskId lookup for
           // executors that mint their own task id (the event's taskId may then
           // differ from the request's generated one).
-          const httpContext = this.getHttpRequestContextForTask(event.taskId) ?? requestHttpContext
+          const httpContext = requestHttpContext ?? this.getHttpRequestContextForTask(event.taskId)
           await this.handleTaskFinalization(resultManager, event, bearerToken, httpContext)
         }
 
@@ -817,9 +842,11 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
           }
         }
       } catch (err) {
-        // Settlement failed AFTER the agent executed. For the in-band x402 v2
-        // A2A path this is surfaced below (payment-failed + suppressed content);
-        // for the legacy header path the prior behavior (swallow) is preserved.
+        // Settlement failed AFTER the agent executed. Always log it (the legacy
+        // header path has no other surface for it). For the in-band x402 v2 A2A
+        // path it is additionally surfaced below as payment-failed + suppressed
+        // content; the legacy header path still delivers the result (no retract).
+        console.error('[PaymentsA2A] settlement failed after execution:', err)
         settlementError = err
       }
 
@@ -882,7 +909,9 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
           this.deleteHttpRequestContextForTask(event.taskId)
         }
       } catch (err) {
-        // Do nothing
+        // This block persists the payment-failed/suppressed task; if it throws the
+        // suppression itself failed, so log loudly rather than swallow.
+        console.error('[PaymentsA2A] failed to persist finalized task:', err)
       }
     }
     try {

--- a/src/a2a/paymentsRequestHandler.ts
+++ b/src/a2a/paymentsRequestHandler.ts
@@ -23,7 +23,12 @@ import { PaymentsError } from '../common/payments.error.js'
 import { StartAgentRequest, isValidScheme } from '../common/types.js'
 import { Payments } from '../payments.js'
 import { decodeAccessToken } from '../utils.js'
-import { buildPaymentRequired, type X402PaymentRequired } from '../x402/facilitator-api.js'
+import {
+  buildPaymentRequired,
+  type SettlePermissionsResult,
+  type X402PaymentRequired,
+} from '../x402/facilitator-api.js'
+import { x402A2AUtils } from './x402-a2a.js'
 import type {
   A2AAuthResult,
   A2AStreamEvent,
@@ -184,7 +189,9 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
     }
 
     const agentId = paymentExtension?.params?.agentId as string | undefined
-    const scheme = isValidScheme(decodedAccessToken.accepted?.scheme) ? decodedAccessToken.accepted.scheme : 'nvm:erc4337'
+    const scheme = isValidScheme(decodedAccessToken.accepted?.scheme)
+      ? decodedAccessToken.accepted.scheme
+      : 'nvm:erc4337'
 
     const paymentRequired: X402PaymentRequired = buildPaymentRequired(planId, {
       endpoint: endpoint || '',
@@ -265,7 +272,9 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
       throw PaymentsError.unauthorized('Plan ID not found in agent card.')
     }
 
-    const scheme = isValidScheme(decodedAccessToken.accepted?.scheme) ? decodedAccessToken.accepted.scheme : 'nvm:erc4337'
+    const scheme = isValidScheme(decodedAccessToken.accepted?.scheme)
+      ? decodedAccessToken.accepted.scheme
+      : 'nvm:erc4337'
 
     // Build paymentRequired using the helper
     const paymentRequired = buildPaymentRequired(planId, {
@@ -394,6 +403,92 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
   }
 
   /**
+   * x402 v2 A2A transport: if the request is payment-gated and arrived with no
+   * token (the middleware stored a `paymentRequired` on the HTTP context), build
+   * and return the spec-shaped `input-required` task carrying the
+   * X402PaymentRequired object under `x402.payment.required` — WITHOUT executing
+   * the agent. Returns `undefined` when a token was present (normal flow).
+   *
+   * @param params - The incoming message send parameters
+   * @returns The `input-required` Task to return to the client, or `undefined`
+   */
+  private async buildPaymentRequiredTaskIfNeeded(
+    params: MessageSendParams,
+  ): Promise<Task | undefined> {
+    const message = params.message
+    if (!message) {
+      return undefined
+    }
+    const incomingTaskId = message.taskId
+    const httpContext = incomingTaskId
+      ? this.getHttpRequestContextForTask(incomingTaskId)
+      : this.getHttpRequestContextForMessage(message.messageId)
+
+    if (!httpContext?.paymentRequired) {
+      return undefined
+    }
+
+    // Correlate the input-required task with the incoming taskId when present so
+    // the client's follow-up payment payload (same taskId) maps back to it.
+    const taskId = incomingTaskId || uuidv4()
+    const contextId = message.contextId || uuidv4()
+    const task: Task = {
+      kind: 'task',
+      id: taskId,
+      contextId,
+      status: { state: 'submitted', timestamp: new Date().toISOString() },
+      history: [message],
+    }
+    const paymentRequiredTask = x402A2AUtils.createPaymentRequiredTask(
+      task,
+      httpContext.paymentRequired,
+    )
+
+    // Persist the input-required task so the client's follow-up (same taskId)
+    // can correlate to it (otherwise the SDK's _createRequestContext raises
+    // "Task not found"). The follow-up carries the in-band payload, so the
+    // middleware overwrites this taskId's HTTP context with the authorized one.
+    await this.getTaskStore().save(paymentRequiredTask)
+    if (!incomingTaskId) {
+      this.deleteHttpRequestContextForMessage(message.messageId)
+    }
+    return paymentRequiredTask
+  }
+
+  /**
+   * Stamp x402 settlement state onto the final task's metadata, in band, per the
+   * x402 v2 A2A transport. Only applied when the token arrived in band (so the
+   * legacy `payment-signature` header path is unchanged). On success the task
+   * carries `x402.payment.status: payment-completed` + `x402.payment.receipts`;
+   * on failure `payment-failed` + `x402.payment.error` + receipts.
+   *
+   * @param task - The current task (mutated in place)
+   * @param httpContext - The request's HTTP context
+   * @param settlement - The settlement result, or undefined when none ran
+   */
+  private recordInBandSettlement(
+    task: Task | undefined,
+    httpContext: HttpRequestContext | undefined,
+    settlement?: SettlePermissionsResult,
+  ): void {
+    if (!task || !httpContext?.inBand) {
+      return
+    }
+    if (settlement && settlement.success === false) {
+      x402A2AUtils.recordPaymentFailure(
+        task,
+        settlement.errorReason || 'SETTLEMENT_FAILED',
+        settlement,
+      )
+    } else if (settlement) {
+      x402A2AUtils.recordPaymentSuccess(task, settlement)
+    } else {
+      // Verified but no on-chain settlement (free / no-credit call).
+      x402A2AUtils.recordPaymentVerified(task)
+    }
+  }
+
+  /**
    * Processes streaming events with finalization (credits burning and push notifications).
    * Similar to processEventsWithFinalization but yields events for streaming.
    * @param taskId - The task ID
@@ -408,6 +503,7 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
     resultManager: ResultManager,
     eventQueue: ExecutionEventQueue,
     bearerToken: string,
+    requestHttpContext?: HttpRequestContext,
   ): AsyncGenerator<A2AStreamEvent, void, undefined> {
     try {
       for await (const event of eventQueue.events()) {
@@ -429,8 +525,10 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
             const redemptionConfig = await this.getRedemptionConfig()
 
             if (!redemptionConfig.useBatch) {
-              // Get HTTP context if available
-              const httpContext = this.getHttpRequestContextForTask(event.taskId)
+              // Prefer the per-request context (in-band flag); fall back to a
+              // per-taskId lookup for executors that mint their own task id.
+              const httpContext =
+                this.getHttpRequestContextForTask(event.taskId) ?? requestHttpContext
               // Execute redemption with server configuration for non-batch requests
               const response = await this.executeRedemption(
                 bearerToken,
@@ -440,10 +538,27 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
 
               // Update event metadata with response data
               if (response && event.metadata) {
-                event.metadata.txHash = response.txHash
+                event.metadata.txHash = response.txHash ?? response.transaction
                 event.metadata.creditsCharged = response.amountOfCredits
                   ? Number(response.amountOfCredits)
                   : event.metadata.creditsUsed
+              }
+
+              // x402 v2 A2A transport: stamp the settlement receipt onto the
+              // persisted task in band. NOTE: a stream cannot retract the event
+              // it already yielded above, so an in-band settlement is reflected
+              // on the saved task (visible via tasks/get + resubscribe) — it
+              // cannot withhold content the way a non-streaming result does.
+              if (httpContext?.inBand) {
+                const task = resultManager.getCurrentTask()
+                if (task) {
+                  this.recordInBandSettlement(
+                    task,
+                    httpContext,
+                    response as SettlePermissionsResult,
+                  )
+                  await resultManager.processEvent(task)
+                }
               }
             }
           } catch (err) {
@@ -497,6 +612,7 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
       firstResultResolver?: (event: any) => void
       firstResultRejector?: (err: any) => void
     },
+    requestHttpContext?: HttpRequestContext,
   ) {
     let firstResultSent = false
     try {
@@ -507,8 +623,11 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
           event.final &&
           terminalStates.includes(event.status?.state)
         ) {
-          // Get HTTP context if available
-          const httpContext = this.getHttpRequestContextForTask(event.taskId)
+          // Prefer the per-request HTTP context (authoritative for this request,
+          // carries the in-band flag). Fall back to a per-taskId lookup for
+          // executors that mint their own task id (the event's taskId may then
+          // differ from the request's generated one).
+          const httpContext = this.getHttpRequestContextForTask(event.taskId) ?? requestHttpContext
           await this.handleTaskFinalization(resultManager, event, bearerToken, httpContext)
         }
 
@@ -543,10 +662,18 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
    * @returns The resulting message or task
    */
   async sendMessage(params: MessageSendParams): Promise<Message | Task> {
+    // x402 v2 A2A transport: a payment-gated request with no token returns an
+    // `input-required` task (in band) instead of executing the agent.
+    const paymentRequiredTask = await this.buildPaymentRequiredTaskIfNeeded(params)
+    if (paymentRequiredTask) {
+      return paymentRequiredTask
+    }
+
     // Create PaymentsRequestContext and related data
     const {
       paymentsRequestContext,
       taskId,
+      httpContext,
       bearerToken,
       validation,
       requestContext,
@@ -607,6 +734,8 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
         eventQueue,
         bearerToken,
         validation,
+        undefined,
+        httpContext,
       )
       const finalResult = resultManager.getFinalResult()
       if (!finalResult) {
@@ -632,6 +761,7 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
             firstResultResolver: resolve,
             firstResultRejector: reject,
           },
+          httpContext,
         )
       })
     }
@@ -661,6 +791,8 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
         typeof creditsToBurn === 'number' ||
         typeof creditsToBurn === 'bigint')
     ) {
+      let settlement: SettlePermissionsResult | undefined
+      let settlementError: unknown
       try {
         // Get redemption configuration from server (not from client metadata)
         const redemptionConfig = await this.getRedemptionConfig()
@@ -672,25 +804,77 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
             BigInt(creditsToBurn),
             httpContext,
           )
+          settlement = response as SettlePermissionsResult
 
           // Update event metadata with redemption results
           event.metadata = {
             ...event.metadata,
-            txHash: response.txHash,
+            txHash: response.txHash ?? response.transaction,
             // Store the actual credits charged (especially important for margin-based)
             creditsCharged: response.amountOfCredits
               ? Number(response.amountOfCredits)
               : creditsToBurn,
           }
         }
+      } catch (err) {
+        // Settlement failed AFTER the agent executed. For the in-band x402 v2
+        // A2A path this is surfaced below (payment-failed + suppressed content);
+        // for the legacy header path the prior behavior (swallow) is preserved.
+        settlementError = err
+      }
 
+      // Stamp the in-band x402 state onto the FINAL event so it survives when the
+      // caller processes this event into the task's status (mutating the task
+      // here would be overwritten by the final event). The event carries a Task
+      // shape under `event.status`; the helpers mutate `event.status.message`.
+      if (httpContext?.inBand && settlementError) {
+        // x402 v2 A2A transport: a settlement failure after execution must NOT
+        // deliver paid content — replace the agent's status message with a
+        // failed one carrying payment-failed metadata + an error receipt.
+        const errorReason =
+          settlementError instanceof Error ? settlementError.message : String(settlementError)
+        event.status = {
+          state: 'failed',
+          message: {
+            kind: 'message',
+            messageId: uuidv4(),
+            role: 'agent',
+            parts: [{ kind: 'text', text: `Payment settlement failed: ${errorReason}` }],
+            taskId: event.taskId,
+            contextId: event.contextId,
+            metadata: {},
+          },
+          timestamp: new Date().toISOString(),
+        }
+        this.recordInBandSettlement({ status: event.status } as any, httpContext, {
+          success: false,
+          errorReason,
+          transaction: '',
+          network: settlement?.network || '',
+        })
+      } else if (httpContext?.inBand) {
+        // Stamp in-band settlement state onto the final event's status message.
+        this.recordInBandSettlement({ status: event.status } as any, httpContext, settlement)
+      }
+
+      try {
         // Always update task metadata and process the task
         const task = resultManager.getCurrentTask()
         if (task) {
-          // Update task metadata with current event metadata (from executor or redemption)
+          // Update task metadata with current event metadata (executor / redemption).
           task.metadata = {
             ...task.metadata,
             ...event.metadata,
+          }
+
+          if (httpContext?.inBand && settlementError) {
+            // x402 v2 A2A transport: a settlement failure must never deliver paid
+            // content. The agent's status message was already replaced above; also
+            // drop any artifacts it emitted so the paid result cannot surface there
+            // (mirrors the Python SDK's _apply_inband_settlement). History is rebuilt
+            // by processEvent below from the replaced (failed) status, so it carries
+            // no paid content.
+            task.artifacts = undefined
           }
 
           await resultManager.processEvent(task)
@@ -727,10 +911,19 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
   async *sendMessageStream(
     params: MessageSendParams,
   ): AsyncGenerator<A2AStreamEvent, void, undefined> {
+    // x402 v2 A2A transport: a payment-gated request with no token yields a
+    // single `input-required` task (in band) instead of executing the agent.
+    const paymentRequiredTask = await this.buildPaymentRequiredTaskIfNeeded(params)
+    if (paymentRequiredTask) {
+      yield paymentRequiredTask
+      return
+    }
+
     // Create PaymentsRequestContext and related data
     const {
       paymentsRequestContext,
       taskId,
+      httpContext,
       bearerToken,
       requestContext,
       finalMessageForAgent,
@@ -775,6 +968,7 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
       resultManager,
       eventQueue,
       bearerToken,
+      httpContext,
     )
   }
 

--- a/src/a2a/server.ts
+++ b/src/a2a/server.ts
@@ -15,10 +15,20 @@ import http from 'http'
 import { InMemoryTaskStore, JsonRpcTransportHandler, AgentExecutor } from '@a2a-js/sdk/server'
 import type { AgentCard, HttpRequestContext } from './types.js'
 import { PaymentsRequestHandler } from './paymentsRequestHandler.js'
-import { AGENT_CARD_WELL_KNOWN_PATH, LEGACY_AGENT_CARD_WELL_KNOWN_PATH } from './agent-card.js'
+import {
+  AGENT_CARD_WELL_KNOWN_PATH,
+  LEGACY_AGENT_CARD_WELL_KNOWN_PATH,
+  A2A_X402_EXTENSION_URI,
+} from './agent-card.js'
 import type { Payments } from '../payments.js'
 import { buildPaymentRequired, resolveNetwork, resolveScheme } from '../x402/facilitator-api.js'
 import { X402_HEADERS } from '../x402/express/middleware.js'
+import { encodeAccessToken } from '../utils.js'
+import { x402A2AUtils } from './x402-a2a.js'
+
+// Emit the payment-signature-header deprecation notice at most once per process
+// to avoid log spam on high-traffic servers still using the legacy header path.
+let a2aHeaderDeprecationWarned = false
 
 /**
  * Checks if a value is an AsyncIterable (used to detect streaming responses)
@@ -122,8 +132,15 @@ export interface PaymentsA2AServerResult {
  * This middleware is applied after A2A routes are set up and extracts authentication
  * information for credit validation.
  *
- * Accepts tokens from:
- * - payment-signature header (x402 HTTP transport spec v2)
+ * Accepts tokens from (in priority order):
+ * - in-band `x402.payment.payload` in the JSON-RPC message metadata (x402 v2
+ *   A2A transport — the standards path)
+ * - `payment-signature` HTTP header (Nevermined's home-grown paywall — kept as
+ *   a deprecated fallback for one release)
+ *
+ * When the request is payment-gated and carries NEITHER, the middleware lets it
+ * reach the handler with `paymentRequired` set so the handler returns an
+ * `input-required` task (in band) instead of an HTTP 402.
  *
  * @param req - Express request object
  * @param res - Express response object
@@ -174,10 +191,56 @@ async function bearerTokenMiddleware(
   })
   const paymentRequiredHeader = Buffer.from(JSON.stringify(paymentRequired)).toString('base64')
 
-  // x402 HTTP spec v2: payment-signature header
-  const bearerToken = req.headers['payment-signature'] as string | undefined
+  // x402 v2 A2A transport: prefer the in-band payment payload carried in the
+  // JSON-RPC message metadata, re-encoding it into the access token string the
+  // verify/settle path consumes. Fall back to the deprecated payment-signature
+  // header when no in-band payload is present.
+  const inBandPayload = x402A2AUtils.getPaymentPayloadFromMessage(req.body?.params?.message)
+  let bearerToken: string | undefined
+  let inBand = false
+  if (inBandPayload) {
+    bearerToken = encodeAccessToken(inBandPayload)
+    inBand = true
+  } else {
+    bearerToken = req.headers['payment-signature'] as string | undefined
+    if (bearerToken && !a2aHeaderDeprecationWarned) {
+      a2aHeaderDeprecationWarned = true
+      console.warn(
+        '[x402] No x402.payment.payload on the A2A message; using the ' +
+          'payment-signature header (deprecated under the x402 v2 A2A transport).',
+      )
+    }
+  }
 
+  // Associate context with taskId or messageId
+  const taskId = req.body?.taskId ?? req.body?.params?.message?.taskId
+  const messageId = req.body?.params?.message?.messageId
+  const associate = (context: HttpRequestContext) => {
+    if (taskId) {
+      handler.setHttpRequestContextForTask(taskId, context)
+    } else if (messageId) {
+      handler.setHttpRequestContextForMessage(messageId, context)
+    }
+  }
+
+  // No token at all: don't HTTP-402. Let the request reach the handler so it
+  // returns an `input-required` task carrying the X402PaymentRequired object in
+  // band (x402 v2 A2A transport). The deprecated header path keeps its 402 only
+  // when the agent card does NOT declare the x402 extension (legacy clients).
   if (!bearerToken) {
+    const declaresX402 = agentCard.capabilities?.extensions?.some(
+      (ext) => ext.uri === A2A_X402_EXTENSION_URI,
+    )
+    if (declaresX402) {
+      associate({
+        urlRequested: absoluteUrl,
+        httpMethodRequested: req.method,
+        validation: undefined as any,
+        paymentRequired,
+      })
+      next()
+      return
+    }
     res
       .status(402)
       .set(X402_HEADERS.PAYMENT_REQUIRED, paymentRequiredHeader)
@@ -212,21 +275,13 @@ async function bearerTokenMiddleware(
     return
   }
 
-  const context: HttpRequestContext = {
+  associate({
     bearerToken,
     urlRequested: absoluteUrl,
     httpMethodRequested: req.method,
     validation,
-  }
-  // Try to associate context with taskId or messageId
-  const taskId = req.body?.taskId
-  const messageId = req.body?.params?.message?.messageId
-
-  if (taskId) {
-    handler.setHttpRequestContextForTask(taskId, context)
-  } else if (messageId) {
-    handler.setHttpRequestContextForMessage(messageId, context)
-  }
+    inBand,
+  })
 
   next()
 }

--- a/src/a2a/server.ts
+++ b/src/a2a/server.ts
@@ -4,7 +4,7 @@
  *
  * The server provides a complete A2A protocol implementation with:
  * - JSON-RPC endpoint for A2A messages
- * - Agent Card endpoint (.well-known/agent.json)
+ * - Agent Card endpoint (.well-known/agent-card.json, with .well-known/agent.json legacy alias)
  * - Bearer token extraction and validation
  * - Credit validation and burning
  * - Task execution and streaming
@@ -15,6 +15,7 @@ import http from 'http'
 import { InMemoryTaskStore, JsonRpcTransportHandler, AgentExecutor } from '@a2a-js/sdk/server'
 import type { AgentCard, HttpRequestContext } from './types.js'
 import { PaymentsRequestHandler } from './paymentsRequestHandler.js'
+import { AGENT_CARD_WELL_KNOWN_PATH, LEGACY_AGENT_CARD_WELL_KNOWN_PATH } from './agent-card.js'
 import type { Payments } from '../payments.js'
 import { buildPaymentRequired, resolveNetwork, resolveScheme } from '../x402/facilitator-api.js'
 import { X402_HEADERS } from '../x402/express/middleware.js'
@@ -71,7 +72,7 @@ export interface PaymentsA2AServerOptions {
   taskStore?: any
   /** Base path for all A2A routes (defaults to '/') */
   basePath?: string
-  /** Whether to expose the agent card at .well-known/agent.json */
+  /** Whether to expose the agent card at .well-known/agent-card.json (+ legacy .well-known/agent.json alias) */
   exposeAgentCard?: boolean
   /** Whether to expose default A2A JSON-RPC routes */
   exposeDefaultRoutes?: boolean
@@ -321,11 +322,13 @@ export class PaymentsA2AServer {
     const app = expressApp || express()
 
     if (exposeAgentCard) {
-      const agentCardPath =
-        basePath === '/'
-          ? '/.well-known/agent.json'
-          : `${basePath.replace(/\/$/, '')}/.well-known/agent.json`
-      app.get(agentCardPath, (req, res) => {
+      const prefix = basePath === '/' ? '' : basePath.replace(/\/$/, '')
+      // Serve the canonical path (A2A >= 0.3) and the legacy alias so both
+      // pre-spec and current A2A clients can discover the card.
+      app.get(`${prefix}/${AGENT_CARD_WELL_KNOWN_PATH}`, (req, res) => {
+        res.json(agentCard)
+      })
+      app.get(`${prefix}/${LEGACY_AGENT_CARD_WELL_KNOWN_PATH}`, (req, res) => {
         res.json(agentCard)
       })
     }

--- a/src/a2a/types.ts
+++ b/src/a2a/types.ts
@@ -167,6 +167,22 @@ export type HttpRequestContext = {
   urlRequested?: string
   httpMethodRequested?: string
   validation: StartAgentRequest
+  /**
+   * x402 v2 A2A in-band transport: set by the server middleware when a
+   * payment-gated request arrives with NO token (neither in-band
+   * `x402.payment.payload` nor the deprecated `payment-signature` header). The
+   * handler short-circuits and returns an `input-required` task carrying this
+   * X402PaymentRequired object under `x402.payment.required`, instead of
+   * executing the agent.
+   */
+  paymentRequired?: import('../x402/facilitator-api.js').X402PaymentRequired
+  /**
+   * Whether the bearer token was supplied in band (via `x402.payment.payload`
+   * message metadata) rather than the deprecated `payment-signature` header.
+   * When true, settlement receipts are stamped into the task metadata under the
+   * spec-defined `x402.payment.*` keys.
+   */
+  inBand?: boolean
 }
 
 /**

--- a/src/a2a/x402-a2a.ts
+++ b/src/a2a/x402-a2a.ts
@@ -1,0 +1,249 @@
+/**
+ * x402 + A2A in-band integration utilities (x402 v2 A2A transport).
+ *
+ * Port of the Python SDK's `payments_py/x402/a2a.py` `X402A2AUtils`. These
+ * helpers bridge the x402 payment protocol with the A2A (Agent-to-Agent)
+ * protocol, signalling payment state *in band* through A2A Task / Message
+ * metadata instead of HTTP status codes and headers.
+ *
+ * The A2A transport equivalent of the MCP transport's `_meta["x402/payment"]`
+ * keys is the A2A **task / message metadata** under the spec-defined
+ * `x402.payment.*` keys (see {@link X402A2AMetadata}). The wire shapes are
+ * defined by:
+ *   - Coinbase x402 v2 A2A transport: specs/transports-v2/a2a.md
+ *   - A2A x402 extension: https://github.com/google-agentic-commerce/a2a-x402
+ *
+ * These constants/keys are part of the specification and MUST NOT be changed.
+ */
+
+import type { Message, Task, TaskStatus } from '@a2a-js/sdk'
+import type { SettlePermissionsResult, X402PaymentRequired } from '../x402/facilitator-api.js'
+
+/**
+ * Protocol-defined payment states for the A2A x402 flow.
+ *
+ * Tracked in the `x402.payment.status` metadata field. Values are part of the
+ * A2A x402 specification (Section 6: State Management) and must not be changed.
+ */
+export enum PaymentStatus {
+  /** Payment requirements sent to client (task state `input-required`). */
+  PAYMENT_REQUIRED = 'payment-required',
+  /** Payment payload received by server. */
+  PAYMENT_SUBMITTED = 'payment-submitted',
+  /** Payment payload verified by the facilitator. */
+  PAYMENT_VERIFIED = 'payment-verified',
+  /** Payment requirements rejected by the client. */
+  PAYMENT_REJECTED = 'payment-rejected',
+  /** Payment settled on-chain successfully (task state `completed`). */
+  PAYMENT_COMPLETED = 'payment-completed',
+  /** Payment verification or settlement failed (task state `failed`). */
+  PAYMENT_FAILED = 'payment-failed',
+}
+
+/**
+ * Spec-defined A2A task / message metadata keys for the x402 protocol.
+ *
+ * As defined in the A2A x402 specification (Section 6: State Management). These
+ * keys are part of the specification and must not be changed. Note these are
+ * NOT the MCP `_meta["x402/payment"]` keys — A2A signals payment state through
+ * Task / Message `metadata` instead.
+ */
+export const X402A2AMetadata = {
+  /** Current payment flow stage. */
+  STATUS_KEY: 'x402.payment.status',
+  /** X402PaymentRequired object. */
+  REQUIRED_KEY: 'x402.payment.required',
+  /** PaymentPayload object (client → server). */
+  PAYLOAD_KEY: 'x402.payment.payload',
+  /** Array of SettleResponse receipts (server → client). */
+  RECEIPTS_KEY: 'x402.payment.receipts',
+  /** Error code on failure. */
+  ERROR_KEY: 'x402.payment.error',
+} as const
+
+/**
+ * Upper bound on the serialized size of an in-band payment payload. The payload
+ * is untrusted client input that gets re-encoded into a token, so cap it as
+ * defense-in-depth (parity with the MCP `readPaymentPayload` and the Python
+ * sibling's `len(json.dumps(value))` guard).
+ */
+const MAX_INBAND_PAYMENT_PAYLOAD_LEN = 64 * 1024
+
+/** Type guard: a plain (non-null, non-array) object, mirroring `isinstance(value, dict)`. */
+function isPlainObject(value: unknown): value is Record<string, any> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * Read x402 payment metadata from a Message's `metadata`, ignoring non-object values.
+ */
+function metaOf(message?: Message | null): Record<string, any> | undefined {
+  const metadata = message?.metadata
+  return isPlainObject(metadata) ? metadata : undefined
+}
+
+/**
+ * Ensure a Task has a status with a status message carrying a `metadata` object,
+ * returning that metadata object for mutation by the record* helpers.
+ *
+ * The task is mutated in place (the A2A SDK's ResultManager / event flow operate
+ * on task objects by reference), mirroring the Python `X402A2AUtils` behavior.
+ */
+function ensureStatusMetadata(task: Task, defaultText: string): Record<string, any> {
+  if (!task.status) {
+    task.status = { state: 'working' } as TaskStatus
+  }
+  if (!task.status.message) {
+    task.status.message = {
+      kind: 'message',
+      messageId: `${task.id}-status`,
+      role: 'agent',
+      parts: [{ kind: 'text', text: defaultText }],
+      metadata: {},
+    }
+  }
+  if (!isPlainObject(task.status.message.metadata)) {
+    task.status.message.metadata = {}
+  }
+  return task.status.message.metadata as Record<string, any>
+}
+
+/**
+ * Utilities for managing x402 payment state in A2A messages and tasks.
+ *
+ * Provides methods to extract payment status / requirements / payload from
+ * incoming A2A messages and tasks, and to stamp payment-required, verified,
+ * completed and failed state onto outgoing tasks — all via the spec-defined
+ * `x402.payment.*` metadata keys.
+ */
+export class X402A2AUtils {
+  static readonly STATUS_KEY = X402A2AMetadata.STATUS_KEY
+  static readonly REQUIRED_KEY = X402A2AMetadata.REQUIRED_KEY
+  static readonly PAYLOAD_KEY = X402A2AMetadata.PAYLOAD_KEY
+  static readonly RECEIPTS_KEY = X402A2AMetadata.RECEIPTS_KEY
+  static readonly ERROR_KEY = X402A2AMetadata.ERROR_KEY
+
+  // ---- Extraction (client/server reads) ------------------------------------
+
+  /** Extract the payment status from a Message's metadata, or `undefined`. */
+  getPaymentStatusFromMessage(message?: Message | null): string | undefined {
+    const meta = metaOf(message)
+    const value = meta?.[X402A2AUtils.STATUS_KEY]
+    return typeof value === 'string' ? value : undefined
+  }
+
+  /** Extract the payment status from a Task's status message metadata, or `undefined`. */
+  getPaymentStatus(task?: Task | null): string | undefined {
+    return this.getPaymentStatusFromMessage(task?.status?.message)
+  }
+
+  /**
+   * Extract the X402PaymentRequired object from a Message's metadata.
+   *
+   * Returns the raw object (already spec-shaped JSON). Returns `undefined` when
+   * absent or not a plain object.
+   */
+  getPaymentRequirementsFromMessage(message?: Message | null): X402PaymentRequired | undefined {
+    const meta = metaOf(message)
+    const value = meta?.[X402A2AUtils.REQUIRED_KEY]
+    return isPlainObject(value) ? (value as unknown as X402PaymentRequired) : undefined
+  }
+
+  /** Extract the X402PaymentRequired object from a Task's status message metadata. */
+  getPaymentRequirements(task?: Task | null): X402PaymentRequired | undefined {
+    return this.getPaymentRequirementsFromMessage(task?.status?.message)
+  }
+
+  /**
+   * Extract the in-band PaymentPayload object from a Message's metadata.
+   *
+   * The payload is untrusted client input that the server re-encodes into an
+   * access token, so this rejects null, arrays and oversized payloads
+   * (defense-in-depth, parity with the MCP `readPaymentPayload`).
+   *
+   * @returns The PaymentPayload object, or `undefined` when absent/invalid.
+   */
+  getPaymentPayloadFromMessage(message?: Message | null): Record<string, any> | undefined {
+    const meta = metaOf(message)
+    const value = meta?.[X402A2AUtils.PAYLOAD_KEY]
+    if (!isPlainObject(value)) {
+      return undefined
+    }
+    if (JSON.stringify(value).length > MAX_INBAND_PAYMENT_PAYLOAD_LEN) {
+      return undefined
+    }
+    return value
+  }
+
+  /** Extract the in-band PaymentPayload object from a Task's status message metadata. */
+  getPaymentPayload(task?: Task | null): Record<string, any> | undefined {
+    return this.getPaymentPayloadFromMessage(task?.status?.message)
+  }
+
+  // ---- Stamping (server writes) --------------------------------------------
+
+  /**
+   * Set a Task to the payment-required state (`input-required`) with the
+   * X402PaymentRequired object in `x402.payment.required` metadata.
+   *
+   * Mutates and returns `task` (in place), per the x402 v2 A2A transport.
+   */
+  createPaymentRequiredTask(task: Task, paymentRequired: X402PaymentRequired): Task {
+    if (!task.status) {
+      task.status = { state: 'input-required' } as TaskStatus
+    } else {
+      task.status.state = 'input-required'
+    }
+    const meta = ensureStatusMetadata(task, 'Payment is required for this service.')
+    meta[X402A2AUtils.STATUS_KEY] = PaymentStatus.PAYMENT_REQUIRED
+    meta[X402A2AUtils.REQUIRED_KEY] = paymentRequired
+    return task
+  }
+
+  /**
+   * Record payment verification on a Task: sets the `x402.payment.status`
+   * metadata to `payment-verified`. Task state is left to the caller (the spec
+   * keeps it `working`).
+   */
+  recordPaymentVerified(task: Task): Task {
+    const meta = ensureStatusMetadata(task, 'Payment verification recorded.')
+    meta[X402A2AUtils.STATUS_KEY] = PaymentStatus.PAYMENT_VERIFIED
+    return task
+  }
+
+  /**
+   * Record a successful settlement on a Task: sets the `x402.payment.status`
+   * metadata to `payment-completed` and stores the SettleResponse receipt under
+   * `x402.payment.receipts` (an array, per the spec).
+   */
+  recordPaymentSuccess(task: Task, settleResponse?: SettlePermissionsResult): Task {
+    const meta = ensureStatusMetadata(task, 'Payment completed successfully.')
+    meta[X402A2AUtils.STATUS_KEY] = PaymentStatus.PAYMENT_COMPLETED
+    if (settleResponse) {
+      meta[X402A2AUtils.RECEIPTS_KEY] = [settleResponse]
+    }
+    return task
+  }
+
+  /**
+   * Record a payment failure on a Task: `x402.payment.status = payment-failed`,
+   * the error code under `x402.payment.error`, and (when available) the failed
+   * SettleResponse under `x402.payment.receipts`.
+   */
+  recordPaymentFailure(
+    task: Task,
+    errorCode: string,
+    errorResponse?: SettlePermissionsResult,
+  ): Task {
+    const meta = ensureStatusMetadata(task, 'Payment failed.')
+    meta[X402A2AUtils.STATUS_KEY] = PaymentStatus.PAYMENT_FAILED
+    meta[X402A2AUtils.ERROR_KEY] = errorCode
+    if (errorResponse) {
+      meta[X402A2AUtils.RECEIPTS_KEY] = [errorResponse]
+    }
+    return task
+  }
+}
+
+/** Shared singleton, matching the Python `X402A2AUtils()` usage pattern. */
+export const x402A2AUtils = new X402A2AUtils()

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,3 +89,17 @@ export type {
   TaskIdParams,
   GetTaskPushNotificationConfigResponse,
 } from './a2a/types.js'
+
+// x402 v2 A2A in-band transport utilities (mirrors the Python X402A2AUtils)
+export {
+  X402A2AUtils,
+  x402A2AUtils,
+  X402A2AMetadata,
+  PaymentStatus as A2APaymentStatus,
+} from './a2a/x402-a2a.js'
+export {
+  A2A_X402_EXTENSION_URI,
+  NVM_PAYMENT_EXTENSION_URI,
+  AGENT_CARD_WELL_KNOWN_PATH,
+  LEGACY_AGENT_CARD_WELL_KNOWN_PATH,
+} from './a2a/agent-card.js'

--- a/tests/integration/a2a/payments-server.test.ts
+++ b/tests/integration/a2a/payments-server.test.ts
@@ -34,7 +34,7 @@ function createNoopExecutor(): AgentExecutor {
     execute: async (_requestContext, eventBus) => {
       eventBus.finished()
     },
-    cancelTask: async () => { },
+    cancelTask: async () => {},
   }
 }
 
@@ -67,7 +67,14 @@ describe('PaymentsA2AServer', () => {
         verifyPermissions: jest.fn().mockResolvedValue({
           isValid: true,
         }),
-        settlePermissions: jest.fn().mockResolvedValue({ success: true, transaction: '0x1234567890abcdef', network: 'eip155:84532', creditsRedeemed: '1' }),
+        settlePermissions: jest
+          .fn()
+          .mockResolvedValue({
+            success: true,
+            transaction: '0x1234567890abcdef',
+            network: 'eip155:84532',
+            creditsRedeemed: '1',
+          }),
       },
       agents: {
         getAgentPlans: jest.fn().mockResolvedValue({ plans: [] }),
@@ -98,13 +105,14 @@ describe('PaymentsA2AServer', () => {
 
       servers.push({ close: result.close })
       const client = request(result.app)
-      const url =
-        basePath !== '/' ? `${basePath}/.well-known/agent.json` : '/.well-known/agent.json'
+      const prefix = basePath !== '/' ? basePath : ''
 
-      const response = await client.get(url)
-
-      expect(response.status).toBe(200)
-      expect(response.body.name).toBe('PyAgent')
+      // Canonical path (A2A >= 0.3) and legacy alias must both serve the card.
+      for (const wellKnown of ['.well-known/agent-card.json', '.well-known/agent.json']) {
+        const response = await client.get(`${prefix}/${wellKnown}`)
+        expect(response.status).toBe(200)
+        expect(response.body.name).toBe('PyAgent')
+      }
     },
     15000,
   )

--- a/tests/integration/a2a/x402-inband-flow.test.ts
+++ b/tests/integration/a2a/x402-inband-flow.test.ts
@@ -447,6 +447,66 @@ describe('x402 v2 A2A in-band transport', () => {
     expect(mockPayments.facilitator.settleCallCount).toBe(1)
   }, 15000)
 
+  test('5. streaming settlement failure -> persisted task is payment-failed, content suppressed', async () => {
+    const mockPayments = new MockPaymentsService()
+    mockPayments.facilitator.shouldFailSettle = true
+    const card = buildCard()
+    card.capabilities = { ...card.capabilities, streaming: true }
+    // Executor streams its (paid) result, incl. an artifact, then settlement throws.
+    const { client, close } = createServer(new DummyExecutor(3, true), card, mockPayments)
+    servers.push({ close })
+
+    const streamRes = await client.post('/rpc').send({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'message/stream',
+      params: {
+        message: {
+          messageId: 'msg-stream-sf',
+          contextId: 'ctx-5',
+          role: 'user',
+          parts: [{ kind: 'text', text: 'stream pay and fail' }],
+          metadata: {
+            [X402A2AMetadata.STATUS_KEY]: PaymentStatus.PAYMENT_SUBMITTED,
+            [X402A2AMetadata.PAYLOAD_KEY]: PAYMENT_PAYLOAD,
+          },
+        },
+      },
+    })
+
+    // The streamed event cannot be retracted; settlement was attempted and threw.
+    expect(mockPayments.facilitator.settleCallCount).toBe(1)
+
+    // Pull the generated taskId out of the SSE stream.
+    const taskId = streamRes.text
+      .split('\n')
+      .filter((l) => l.startsWith('data:'))
+      .map((l) => {
+        try {
+          return JSON.parse(l.slice(5).trim())
+        } catch {
+          return null
+        }
+      })
+      .map((e) => e?.result?.id ?? e?.result?.taskId)
+      .find((id) => typeof id === 'string')
+    expect(taskId).toBeTruthy()
+
+    // The PERSISTED task (tasks/get) must reflect the failure, not a paid result.
+    const getRes = await client.post('/rpc').send({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tasks/get',
+      params: { id: taskId },
+    })
+    const task = getRes.body.result
+    expect(task.status.state).toBe('failed')
+    expect(task.status.message.metadata[X402A2AMetadata.STATUS_KEY]).toBe(
+      PaymentStatus.PAYMENT_FAILED,
+    )
+    expect(task.artifacts ?? []).toHaveLength(0)
+  }, 20000)
+
   test('x402A2AUtils helpers round-trip status/required/payload on a task', () => {
     const task: Task = {
       kind: 'task',

--- a/tests/integration/a2a/x402-inband-flow.test.ts
+++ b/tests/integration/a2a/x402-inband-flow.test.ts
@@ -1,0 +1,483 @@
+/**
+ * Integration tests for the x402 v2 A2A in-band payment transport.
+ *
+ * Exercises the standards-compliant in-band flow (payment signalled through A2A
+ * Task / Message `x402.payment.*` metadata) end-to-end over supertest, plus the
+ * deprecated `payment-signature` header path as a regression.
+ *
+ * Mirrors the MCP in-band tests added in commit 3fca195 (PR #384).
+ */
+
+import type { Message, Task, TaskState, TaskStatus, TaskStatusUpdateEvent } from '@a2a-js/sdk'
+import request from 'supertest'
+import { PaymentsA2AServer } from '../../../src/a2a/server.js'
+import { buildPaymentAgentCard } from '../../../src/a2a/agent-card.js'
+import { X402A2AMetadata, PaymentStatus, x402A2AUtils } from '../../../src/a2a/x402-a2a.js'
+import * as utils from '../../../src/utils.js'
+import { encodeAccessToken } from '../../../src/utils.js'
+import type { AgentCard, ExecutionEventBus, PaymentsAgentExecutor } from '../../../src/a2a/types.js'
+import type { Payments } from '../../../src/payments.js'
+
+/**
+ * A spec-shaped x402 PaymentPayload object (the decoded form of an access
+ * token). The server re-encodes it via encodeAccessToken and the facilitator
+ * verify/settle path consumes the resulting base64 token.
+ */
+const PAYMENT_PAYLOAD = {
+  x402Version: 2,
+  accepted: {
+    scheme: 'nvm:erc4337',
+    network: 'eip155:84532',
+    planId: 'test-plan',
+    extra: { version: '1' },
+  },
+  payload: {
+    signature: '0xsig',
+    authorization: {
+      from: '0xSubscriberInBand',
+      sessionKeysProvider: 'zerodev',
+      sessionKeys: [],
+    },
+  },
+  extensions: {},
+}
+
+class MockFacilitatorAPI {
+  verifyCallCount = 0
+  settleCallCount = 0
+  lastVerifyToken: string | null = null
+  lastSettleToken: string | null = null
+  shouldFailVerify = false
+  shouldFailSettle = false
+
+  async verifyPermissions(params: any): Promise<{ isValid: boolean; invalidReason?: string }> {
+    this.verifyCallCount++
+    this.lastVerifyToken = params.x402AccessToken
+    if (this.shouldFailVerify) {
+      return { isValid: false, invalidReason: 'Insufficient credits' }
+    }
+    return { isValid: true }
+  }
+
+  async settlePermissions(params: any): Promise<{
+    success: boolean
+    transaction: string
+    network: string
+    creditsRedeemed: string
+  }> {
+    this.settleCallCount++
+    this.lastSettleToken = params.x402AccessToken
+    if (this.shouldFailSettle) {
+      throw new Error('Failed to settle credits')
+    }
+    return {
+      success: true,
+      transaction: '0xreceipt',
+      network: 'eip155:84532',
+      creditsRedeemed: String(params.maxAmount || 0),
+    }
+  }
+}
+
+class MockPaymentsService {
+  facilitator: MockFacilitatorAPI
+  agents: { getAgentPlans: () => Promise<{ plans: any[] }> }
+
+  constructor() {
+    this.facilitator = new MockFacilitatorAPI()
+    this.agents = { getAgentPlans: async () => ({ plans: [] }) }
+  }
+
+  getEnvironmentName() {
+    return 'sandbox'
+  }
+}
+
+class DummyExecutor implements PaymentsAgentExecutor {
+  creditsToUse: number
+  emitArtifact: boolean
+
+  constructor(creditsToUse = 3, emitArtifact = false) {
+    this.creditsToUse = creditsToUse
+    this.emitArtifact = emitArtifact
+  }
+
+  async execute(requestContext: any, eventBus: ExecutionEventBus): Promise<void> {
+    const taskId = requestContext.taskId || crypto.randomUUID()
+    const contextId = requestContext.contextId || 'ctx'
+
+    if (!requestContext.task) {
+      const initialTask: Task = {
+        kind: 'task',
+        id: taskId,
+        contextId,
+        status: {
+          state: 'submitted' as TaskState,
+          timestamp: new Date().toISOString(),
+        } as TaskStatus,
+        history: requestContext.userMessage ? [requestContext.userMessage] : [],
+      }
+      await eventBus.publish(initialTask)
+    }
+
+    // Optionally emit the paid result as an ARTIFACT (the x402 spec's own example
+    // delivers a generated image this way) so settlement-failure suppression can
+    // be exercised against artifacts, not just the status message.
+    if (this.emitArtifact) {
+      await eventBus.publish({
+        kind: 'artifact-update',
+        taskId,
+        contextId,
+        artifact: {
+          artifactId: 'paid-artifact',
+          parts: [{ kind: 'text', text: 'Here is your paid result!' }],
+        },
+      } as any)
+    }
+
+    const agentMessage: Message = {
+      kind: 'message',
+      messageId: crypto.randomUUID(),
+      role: 'agent',
+      parts: [{ kind: 'text', text: 'Here is your paid result!' }],
+      taskId,
+      contextId,
+    }
+
+    const finalStatusUpdate: TaskStatusUpdateEvent = {
+      kind: 'status-update',
+      taskId,
+      contextId,
+      status: {
+        state: 'completed' as TaskState,
+        message: agentMessage,
+        timestamp: new Date().toISOString(),
+      } as TaskStatus,
+      metadata: { creditsUsed: this.creditsToUse },
+      final: true,
+    }
+    await eventBus.publish(finalStatusUpdate)
+    eventBus.finished()
+  }
+
+  async cancelTask(): Promise<void> {}
+}
+
+function buildCard(): AgentCard {
+  // buildPaymentAgentCard declares BOTH the nvm extension and the official
+  // a2a-x402 extension. The latter is what flips the middleware into the in-band
+  // "return input-required instead of HTTP 402" behavior when no token arrives.
+  return buildPaymentAgentCard(
+    {
+      name: 'InBandAgent',
+      capabilities: {},
+    } as unknown as AgentCard,
+    {
+      paymentType: 'fixed',
+      credits: 10,
+      agentId: 'test-agent-123',
+      planId: 'test-plan',
+      costDescription: '10 credits per call',
+    },
+  )
+}
+
+function createServer(
+  executor: PaymentsAgentExecutor,
+  agentCard: AgentCard,
+  paymentsService: any,
+): { client: ReturnType<typeof request>; close: () => Promise<void> } {
+  const result = PaymentsA2AServer.start({
+    agentCard,
+    executor,
+    paymentsService: paymentsService as any as Payments,
+    port: 0,
+    basePath: '/rpc',
+    exposeDefaultRoutes: true,
+  })
+  return { client: request(result.app), close: result.close }
+}
+
+describe('x402 v2 A2A in-band transport', () => {
+  let decodeSpy: jest.SpyInstance
+  let servers: Array<{ close: () => Promise<void> }> = []
+
+  beforeAll(() => {
+    // The server re-encodes the in-band payload into a token (encodeAccessToken
+    // stays REAL so we can assert the round-trip), then decodes that token in
+    // validateRequest/executeRedemption. Force decode to the known payload so the
+    // facilitator path reads subscriberAddress/scheme deterministically.
+    decodeSpy = jest
+      .spyOn(utils, 'decodeAccessToken')
+      .mockImplementation(() => PAYMENT_PAYLOAD as any)
+  })
+
+  afterAll(() => {
+    decodeSpy?.mockRestore()
+  })
+
+  afterEach(async () => {
+    for (const s of servers) await s.close()
+    servers = []
+  })
+
+  test('1. payment-gated message with no token returns input-required + payment-required metadata', async () => {
+    const mockPayments = new MockPaymentsService()
+    const { client, close } = createServer(new DummyExecutor(), buildCard(), mockPayments)
+    servers.push({ close })
+
+    const payload = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'message/send',
+      params: {
+        message: {
+          messageId: 'msg-no-token',
+          contextId: 'ctx-1',
+          role: 'user',
+          parts: [{ kind: 'text', text: 'Generate an image' }],
+        },
+      },
+    }
+
+    // No payment-signature header and no in-band payload.
+    const response = await client.post('/rpc').send(payload)
+
+    expect(response.status).toBe(200)
+    const task = response.body.result
+    expect(task.kind).toBe('task')
+    expect(task.status.state).toBe('input-required')
+
+    const meta = task.status.message.metadata
+    expect(meta[X402A2AMetadata.STATUS_KEY]).toBe(PaymentStatus.PAYMENT_REQUIRED)
+
+    const required = meta[X402A2AMetadata.REQUIRED_KEY]
+    expect(required).toBeDefined()
+    expect(required.x402Version).toBe(2)
+    expect(Array.isArray(required.accepts)).toBe(true)
+    expect(required.accepts[0].planId).toBe('test-plan')
+
+    // The agent must NOT have executed, and no settlement happened.
+    expect(mockPayments.facilitator.verifyCallCount).toBe(0)
+    expect(mockPayments.facilitator.settleCallCount).toBe(0)
+  }, 15000)
+
+  test('2. follow-up message with x402.payment.payload verifies, executes, settles, and stamps payment-completed + receipts', async () => {
+    const mockPayments = new MockPaymentsService()
+    const { client, close } = createServer(new DummyExecutor(4), buildCard(), mockPayments)
+    servers.push({ close })
+
+    // Step 1: provoke a payment-required task to get the correlation taskId.
+    const first = await client.post('/rpc').send({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'message/send',
+      params: {
+        message: {
+          messageId: 'msg-1',
+          contextId: 'ctx-2',
+          role: 'user',
+          parts: [{ kind: 'text', text: 'Generate an image' }],
+        },
+      },
+    })
+    const taskId = first.body.result.id
+    expect(first.body.result.status.state).toBe('input-required')
+
+    // Step 2: submit the payment in band, correlated by taskId.
+    const second = await client.post('/rpc').send({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'message/send',
+      params: {
+        message: {
+          taskId,
+          messageId: 'msg-2',
+          contextId: 'ctx-2',
+          role: 'user',
+          parts: [{ kind: 'text', text: 'Here is the payment authorization.' }],
+          metadata: {
+            [X402A2AMetadata.STATUS_KEY]: PaymentStatus.PAYMENT_SUBMITTED,
+            [X402A2AMetadata.PAYLOAD_KEY]: PAYMENT_PAYLOAD,
+          },
+        },
+      },
+    })
+
+    expect(second.status).toBe(200)
+    const task = second.body.result
+    expect(task.kind).toBe('task')
+    expect(task.status.state).toBe('completed')
+    expect(task.status.message.parts[0].text).toBe('Here is your paid result!')
+
+    // In-band settlement metadata stamped on the final task.
+    const meta = task.status.message.metadata
+    expect(meta[X402A2AMetadata.STATUS_KEY]).toBe(PaymentStatus.PAYMENT_COMPLETED)
+    const receipts = meta[X402A2AMetadata.RECEIPTS_KEY]
+    expect(Array.isArray(receipts)).toBe(true)
+    expect(receipts[0].success).toBe(true)
+    expect(receipts[0].transaction).toBe('0xreceipt')
+
+    // Verify + settle both ran, and on the re-encoded in-band token.
+    expect(mockPayments.facilitator.verifyCallCount).toBe(1)
+    expect(mockPayments.facilitator.settleCallCount).toBe(1)
+    // The token the facilitator saw is exactly encodeAccessToken(PAYMENT_PAYLOAD).
+    expect(mockPayments.facilitator.lastVerifyToken).toBe(encodeAccessToken(PAYMENT_PAYLOAD))
+    expect(mockPayments.facilitator.lastSettleToken).toBe(encodeAccessToken(PAYMENT_PAYLOAD))
+  }, 20000)
+
+  test('3. settlement failure on the in-band path -> payment-failed + error, agent content suppressed', async () => {
+    const mockPayments = new MockPaymentsService()
+    mockPayments.facilitator.shouldFailSettle = true
+    // Executor emits the paid result as an artifact too, so we prove suppression
+    // covers artifacts (not only the status message).
+    const { client, close } = createServer(new DummyExecutor(2, true), buildCard(), mockPayments)
+    servers.push({ close })
+
+    // Single-shot in-band payment (no prior taskId): the in-band payload alone
+    // authorizes, the agent runs, then settlement fails.
+    const response = await client.post('/rpc').send({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'message/send',
+      params: {
+        message: {
+          messageId: 'msg-sf',
+          contextId: 'ctx-3',
+          role: 'user',
+          parts: [{ kind: 'text', text: 'pay and run' }],
+          metadata: {
+            [X402A2AMetadata.STATUS_KEY]: PaymentStatus.PAYMENT_SUBMITTED,
+            [X402A2AMetadata.PAYLOAD_KEY]: PAYMENT_PAYLOAD,
+          },
+        },
+      },
+    })
+
+    expect(response.status).toBe(200)
+    const task = response.body.result
+    expect(task.kind).toBe('task')
+    // Content suppressed: the task is failed, not the agent's "completed" result.
+    expect(task.status.state).toBe('failed')
+    expect(task.status.message.parts[0].text).not.toBe('Here is your paid result!')
+    // ...and the paid content must not leak through artifacts (the executor emitted
+    // the result as one) nor anywhere else in the returned task.
+    expect(task.artifacts ?? []).toHaveLength(0)
+    expect(JSON.stringify(task)).not.toContain('Here is your paid result!')
+
+    const meta = task.status.message.metadata
+    expect(meta[X402A2AMetadata.STATUS_KEY]).toBe(PaymentStatus.PAYMENT_FAILED)
+    expect(meta[X402A2AMetadata.ERROR_KEY]).toBeDefined()
+    const receipts = meta[X402A2AMetadata.RECEIPTS_KEY]
+    expect(Array.isArray(receipts)).toBe(true)
+    expect(receipts[0].success).toBe(false)
+
+    // Verify passed; settle was attempted and failed.
+    expect(mockPayments.facilitator.verifyCallCount).toBe(1)
+    expect(mockPayments.facilitator.settleCallCount).toBe(1)
+  }, 20000)
+
+  test('3b. verification failure on the in-band path -> HTTP 402 (no execution)', async () => {
+    const mockPayments = new MockPaymentsService()
+    mockPayments.facilitator.shouldFailVerify = true
+    const { client, close } = createServer(new DummyExecutor(), buildCard(), mockPayments)
+    servers.push({ close })
+
+    const response = await client.post('/rpc').send({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'message/send',
+      params: {
+        message: {
+          messageId: 'msg-vf',
+          contextId: 'ctx-3b',
+          role: 'user',
+          parts: [{ kind: 'text', text: 'bad payment' }],
+          metadata: {
+            [X402A2AMetadata.STATUS_KEY]: PaymentStatus.PAYMENT_SUBMITTED,
+            [X402A2AMetadata.PAYLOAD_KEY]: PAYMENT_PAYLOAD,
+          },
+        },
+      },
+    })
+
+    // Verification failure is surfaced by the middleware as a 402 before execution.
+    expect(response.status).toBe(402)
+    expect(mockPayments.facilitator.verifyCallCount).toBe(1)
+    expect(mockPayments.facilitator.settleCallCount).toBe(0)
+  }, 15000)
+
+  test('4. legacy payment-signature header path still works (regression)', async () => {
+    const mockPayments = new MockPaymentsService()
+    const { client, close } = createServer(new DummyExecutor(5), buildCard(), mockPayments)
+    servers.push({ close })
+
+    const response = await client
+      .post('/rpc')
+      .set('payment-signature', 'LEGACY_TOKEN')
+      .send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'message/send',
+        params: {
+          message: {
+            messageId: 'msg-legacy',
+            contextId: 'ctx-4',
+            role: 'user',
+            parts: [{ kind: 'text', text: 'legacy header pay' }],
+          },
+        },
+      })
+
+    expect(response.status).toBe(200)
+    const task = response.body.result
+    expect(task.kind).toBe('task')
+    expect(task.status.state).toBe('completed')
+    expect(task.status.message.parts[0].text).toBe('Here is your paid result!')
+
+    // Header path: the facilitator saw the raw header token, not a re-encoding.
+    expect(mockPayments.facilitator.lastVerifyToken).toBe('LEGACY_TOKEN')
+    expect(mockPayments.facilitator.lastSettleToken).toBe('LEGACY_TOKEN')
+
+    // Header path does NOT stamp the in-band x402.payment.* completion metadata.
+    const meta = task.status.message.metadata || {}
+    expect(meta[X402A2AMetadata.STATUS_KEY]).toBeUndefined()
+
+    expect(mockPayments.facilitator.verifyCallCount).toBe(1)
+    expect(mockPayments.facilitator.settleCallCount).toBe(1)
+  }, 15000)
+
+  test('x402A2AUtils helpers round-trip status/required/payload on a task', () => {
+    const task: Task = {
+      kind: 'task',
+      id: 't1',
+      contextId: 'c1',
+      status: { state: 'submitted' },
+    }
+    const required = { x402Version: 2, resource: { url: '' }, accepts: [], extensions: {} } as any
+    x402A2AUtils.createPaymentRequiredTask(task, required)
+    expect(task.status.state).toBe('input-required')
+    expect(x402A2AUtils.getPaymentStatus(task)).toBe(PaymentStatus.PAYMENT_REQUIRED)
+    expect(x402A2AUtils.getPaymentRequirements(task)).toEqual(required)
+
+    // Oversized payloads are rejected (defense-in-depth, parity with MCP).
+    const big: Message = {
+      kind: 'message',
+      messageId: 'm',
+      role: 'user',
+      parts: [],
+      metadata: { [X402A2AMetadata.PAYLOAD_KEY]: { blob: 'x'.repeat(70 * 1024) } },
+    }
+    expect(x402A2AUtils.getPaymentPayloadFromMessage(big)).toBeUndefined()
+
+    // Arrays / null are rejected (mirrors isinstance(value, dict)).
+    const arr: Message = {
+      kind: 'message',
+      messageId: 'm2',
+      role: 'user',
+      parts: [],
+      metadata: { [X402A2AMetadata.PAYLOAD_KEY]: [1, 2, 3] as any },
+    }
+    expect(x402A2AUtils.getPaymentPayloadFromMessage(arr)).toBeUndefined()
+  })
+})

--- a/tests/unit/a2a/agent-card.test.ts
+++ b/tests/unit/a2a/agent-card.test.ts
@@ -17,9 +17,14 @@ describe('buildPaymentAgentCard', () => {
       costDescription: '5 credits per call',
     } as any as PaymentAgentCardMetadata
     const card = buildPaymentAgentCard(baseCard, metadata)
-    const ext = card.capabilities?.extensions?.[card.capabilities.extensions.length - 1]
+    const ext = card.capabilities?.extensions?.find((e) => e.uri === 'urn:nevermined:payment')
     expect(ext?.uri).toBe('urn:nevermined:payment')
     expect(ext?.params?.agentId).toBe('agent-1')
+    // The official a2a-x402 extension is also declared (additive, for one release).
+    const x402Ext = card.capabilities?.extensions?.find(
+      (e) => e.uri === 'https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2',
+    )
+    expect(x402Ext).toBeDefined()
   })
 
   test.each([

--- a/tests/unit/a2a/payments-client-inband.test.ts
+++ b/tests/unit/a2a/payments-client-inband.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the PaymentsClient in-band x402 transport (client side).
+ *
+ * Asserts the client carries the payment in band via `x402.payment.payload`
+ * message metadata (primary path), keeps the deprecated `payment-signature`
+ * header (fallback), and resubmits correlated to a taskId when the server
+ * replies with an `input-required` payment-required task.
+ */
+
+import { A2AClient } from '@a2a-js/sdk/client'
+import { PaymentsClient } from '../../../src/a2a/paymentsClient.js'
+import { X402A2AMetadata, PaymentStatus } from '../../../src/a2a/x402-a2a.js'
+import type { Payments } from '../../../src/payments.js'
+
+jest.mock('@a2a-js/sdk/client')
+
+// A real base64-JSON token so decodeAccessToken recovers the PaymentPayload.
+const PAYLOAD = {
+  x402Version: 2,
+  accepted: { scheme: 'nvm:erc4337', network: 'eip155:84532', planId: '1', extra: {} },
+  payload: { signature: '0xs', authorization: { from: '0xFrom', sessionKeysProvider: 'zerodev', sessionKeys: [] } },
+  extensions: {},
+}
+const TOKEN = Buffer.from(JSON.stringify(PAYLOAD)).toString('base64')
+
+class DummyPayments {
+  public x402: any
+  public requests: any
+  constructor() {
+    this.requests = {}
+    this.x402 = { getX402AccessToken: jest.fn().mockResolvedValue({ accessToken: TOKEN }) }
+  }
+}
+
+describe('PaymentsClient in-band x402 transport', () => {
+  let paymentsClient: PaymentsClient
+  let dummyPayments: DummyPayments
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    dummyPayments = new DummyPayments()
+    const mockA2AClient = {
+      getAgentCard: jest.fn().mockResolvedValue({ capabilities: { extensions: [] } }),
+    }
+    ;(A2AClient.fromCardUrl as jest.Mock).mockResolvedValue(mockA2AClient)
+    paymentsClient = await PaymentsClient.create(
+      'https://agent.example',
+      dummyPayments as any as Payments,
+      'agent1',
+      '1',
+      undefined,
+      { delegationId: 'd' },
+    )
+  })
+
+  test('injects x402.payment.payload metadata in band AND keeps the header fallback', async () => {
+    const mockPostRpc = jest.fn().mockResolvedValue({ result: { kind: 'task', status: { state: 'completed' } } })
+    ;(paymentsClient as any)._postRpcRequestWithHeaders = mockPostRpc
+
+    await paymentsClient.sendA2AMessage({
+      message: { messageId: 'm', role: 'user', parts: [] },
+    } as any)
+
+    const [, params, headers] = mockPostRpc.mock.calls[0]
+    // Deprecated header still present (fallback for one release).
+    expect(headers['payment-signature']).toBe(TOKEN)
+    // In-band payload carried in message metadata, decoded back to the object.
+    const meta = params.message.metadata
+    expect(meta[X402A2AMetadata.STATUS_KEY]).toBe(PaymentStatus.PAYMENT_SUBMITTED)
+    expect(meta[X402A2AMetadata.PAYLOAD_KEY]).toEqual(PAYLOAD)
+  })
+
+  test('resubmits correlated to taskId when the server returns input-required payment-required', async () => {
+    const mockPostRpc = jest
+      .fn()
+      // First response: payment-required task.
+      .mockResolvedValueOnce({
+        result: {
+          kind: 'task',
+          id: 'task-xyz',
+          status: {
+            state: 'input-required',
+            message: {
+              kind: 'message',
+              messageId: 's',
+              role: 'agent',
+              parts: [],
+              metadata: { [X402A2AMetadata.STATUS_KEY]: PaymentStatus.PAYMENT_REQUIRED },
+            },
+          },
+        },
+      })
+      // Second (follow-up) response: completed.
+      .mockResolvedValueOnce({ result: { kind: 'task', id: 'task-xyz', status: { state: 'completed' } } })
+    ;(paymentsClient as any)._postRpcRequestWithHeaders = mockPostRpc
+
+    const res = await paymentsClient.sendA2AMessage({
+      message: { messageId: 'm', role: 'user', parts: [] },
+    } as any)
+
+    expect(mockPostRpc).toHaveBeenCalledTimes(2)
+    // The follow-up correlates to the task id and re-sends the in-band payload.
+    const followUpParams = mockPostRpc.mock.calls[1][1]
+    expect(followUpParams.message.taskId).toBe('task-xyz')
+    expect(followUpParams.message.metadata[X402A2AMetadata.PAYLOAD_KEY]).toEqual(PAYLOAD)
+    expect((res as any).result.status.state).toBe('completed')
+  })
+
+  test('does NOT resubmit when the first response already completes', async () => {
+    const mockPostRpc = jest
+      .fn()
+      .mockResolvedValue({ result: { kind: 'task', id: 't', status: { state: 'completed' } } })
+    ;(paymentsClient as any)._postRpcRequestWithHeaders = mockPostRpc
+
+    await paymentsClient.sendA2AMessage({ message: { messageId: 'm', role: 'user', parts: [] } } as any)
+    expect(mockPostRpc).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/a2a/x402-a2a.test.ts
+++ b/tests/unit/a2a/x402-a2a.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Unit tests for the x402 v2 A2A in-band utilities (X402A2AUtils).
+ *
+ * Mirrors the MCP in-band helper unit tests (tests/unit/mcp/x402_inband.test.ts):
+ * spec-key constants, status lifecycle, payload guards (array/null/oversized),
+ * and the encode/decode token round-trip the in-band transport relies on.
+ */
+
+import type { Message, Task } from '@a2a-js/sdk'
+import {
+  PaymentStatus,
+  X402A2AMetadata,
+  X402A2AUtils,
+  x402A2AUtils,
+} from '../../../src/a2a/x402-a2a.js'
+import { decodeAccessToken, encodeAccessToken } from '../../../src/utils.js'
+
+function emptyTask(): Task {
+  return { kind: 'task', id: 't-1', contextId: 'c-1', status: { state: 'submitted' } }
+}
+
+function messageWith(metadata: Record<string, unknown>): Message {
+  return { kind: 'message', messageId: 'm-1', role: 'user', parts: [], metadata }
+}
+
+describe('X402A2AMetadata spec keys', () => {
+  test('match the A2A x402 specification exactly', () => {
+    expect(X402A2AMetadata.STATUS_KEY).toBe('x402.payment.status')
+    expect(X402A2AMetadata.REQUIRED_KEY).toBe('x402.payment.required')
+    expect(X402A2AMetadata.PAYLOAD_KEY).toBe('x402.payment.payload')
+    expect(X402A2AMetadata.RECEIPTS_KEY).toBe('x402.payment.receipts')
+    expect(X402A2AMetadata.ERROR_KEY).toBe('x402.payment.error')
+  })
+
+  test('PaymentStatus lifecycle values match the spec', () => {
+    expect(PaymentStatus.PAYMENT_REQUIRED).toBe('payment-required')
+    expect(PaymentStatus.PAYMENT_SUBMITTED).toBe('payment-submitted')
+    expect(PaymentStatus.PAYMENT_VERIFIED).toBe('payment-verified')
+    expect(PaymentStatus.PAYMENT_REJECTED).toBe('payment-rejected')
+    expect(PaymentStatus.PAYMENT_COMPLETED).toBe('payment-completed')
+    expect(PaymentStatus.PAYMENT_FAILED).toBe('payment-failed')
+  })
+})
+
+describe('X402A2AUtils extraction', () => {
+  const utils = new X402A2AUtils()
+
+  test('getPaymentStatus / getPaymentRequirements / getPaymentPayload read task status metadata', () => {
+    const required = { x402Version: 2, resource: { url: '' }, accepts: [], extensions: {} } as any
+    const payload = { x402Version: 2, payload: { signature: '0x1' } }
+    const task: Task = {
+      kind: 'task',
+      id: 't',
+      contextId: 'c',
+      status: {
+        state: 'input-required',
+        message: messageWith({
+          [X402A2AMetadata.STATUS_KEY]: PaymentStatus.PAYMENT_REQUIRED,
+          [X402A2AMetadata.REQUIRED_KEY]: required,
+          [X402A2AMetadata.PAYLOAD_KEY]: payload,
+        }),
+      },
+    }
+    expect(utils.getPaymentStatus(task)).toBe(PaymentStatus.PAYMENT_REQUIRED)
+    expect(utils.getPaymentRequirements(task)).toEqual(required)
+    expect(utils.getPaymentPayload(task)).toEqual(payload)
+  })
+
+  test('returns undefined for missing/non-object metadata', () => {
+    expect(utils.getPaymentStatus(emptyTask())).toBeUndefined()
+    expect(utils.getPaymentStatus(null)).toBeUndefined()
+    expect(utils.getPaymentPayloadFromMessage(messageWith({}))).toBeUndefined()
+  })
+
+  test('rejects array and null payloads (mirrors isinstance(value, dict))', () => {
+    expect(
+      utils.getPaymentPayloadFromMessage(messageWith({ [X402A2AMetadata.PAYLOAD_KEY]: [1, 2] as any })),
+    ).toBeUndefined()
+    expect(
+      utils.getPaymentPayloadFromMessage(
+        messageWith({ [X402A2AMetadata.PAYLOAD_KEY]: null as any }),
+      ),
+    ).toBeUndefined()
+  })
+
+  test('rejects oversized payloads (>64KB) as defense-in-depth', () => {
+    const big = messageWith({ [X402A2AMetadata.PAYLOAD_KEY]: { blob: 'x'.repeat(70 * 1024) } })
+    expect(utils.getPaymentPayloadFromMessage(big)).toBeUndefined()
+  })
+})
+
+describe('X402A2AUtils stamping', () => {
+  const utils = new X402A2AUtils()
+
+  test('createPaymentRequiredTask sets input-required + required metadata', () => {
+    const task = emptyTask()
+    const required = { x402Version: 2, resource: { url: '/x' }, accepts: [], extensions: {} } as any
+    utils.createPaymentRequiredTask(task, required)
+    expect(task.status.state).toBe('input-required')
+    expect(task.status.message?.metadata?.[X402A2AMetadata.STATUS_KEY]).toBe(
+      PaymentStatus.PAYMENT_REQUIRED,
+    )
+    expect(task.status.message?.metadata?.[X402A2AMetadata.REQUIRED_KEY]).toEqual(required)
+  })
+
+  test('recordPaymentSuccess stamps payment-completed + receipts array', () => {
+    const task = emptyTask()
+    utils.recordPaymentSuccess(task, {
+      success: true,
+      transaction: '0xabc',
+      network: 'eip155:84532',
+    })
+    const meta = task.status.message?.metadata as Record<string, any>
+    expect(meta[X402A2AMetadata.STATUS_KEY]).toBe(PaymentStatus.PAYMENT_COMPLETED)
+    expect(Array.isArray(meta[X402A2AMetadata.RECEIPTS_KEY])).toBe(true)
+    expect(meta[X402A2AMetadata.RECEIPTS_KEY][0].transaction).toBe('0xabc')
+  })
+
+  test('recordPaymentFailure stamps payment-failed + error code + receipts', () => {
+    const task = emptyTask()
+    utils.recordPaymentFailure(task, 'EXPIRED_PAYMENT', {
+      success: false,
+      errorReason: 'expired',
+      transaction: '',
+      network: 'eip155:84532',
+    })
+    const meta = task.status.message?.metadata as Record<string, any>
+    expect(meta[X402A2AMetadata.STATUS_KEY]).toBe(PaymentStatus.PAYMENT_FAILED)
+    expect(meta[X402A2AMetadata.ERROR_KEY]).toBe('EXPIRED_PAYMENT')
+    expect(meta[X402A2AMetadata.RECEIPTS_KEY][0].success).toBe(false)
+  })
+
+  test('recordPaymentVerified stamps payment-verified', () => {
+    const task = emptyTask()
+    utils.recordPaymentVerified(task)
+    expect(task.status.message?.metadata?.[X402A2AMetadata.STATUS_KEY]).toBe(
+      PaymentStatus.PAYMENT_VERIFIED,
+    )
+  })
+
+  test('exports a shared singleton instance', () => {
+    expect(x402A2AUtils).toBeInstanceOf(X402A2AUtils)
+  })
+})
+
+describe('in-band token round-trip (encode/decode)', () => {
+  test('a decoded PaymentPayload re-encodes to a token decodeAccessToken accepts', () => {
+    const payload = {
+      x402Version: 2,
+      accepted: { scheme: 'nvm:erc4337', network: 'eip155:84532', planId: 'p', extra: {} },
+      payload: {
+        signature: '0xsig',
+        authorization: { from: '0xFrom', sessionKeysProvider: 'zerodev', sessionKeys: [] },
+      },
+      extensions: {},
+    }
+    const token = encodeAccessToken(payload)
+    expect(typeof token).toBe('string')
+    // unpadded base64url
+    expect(token).not.toContain('=')
+    expect(decodeAccessToken(token)).toEqual(payload)
+  })
+})


### PR DESCRIPTION
## Why

The A2A integration only interoperated with Nevermined's **own** SDK. The agent card was served at the pre-spec `/.well-known/agent.json`, but every current A2A client — including `@a2a-js/sdk`'s own default — discovers it at `/.well-known/agent-card.json`, so stock A2A clients 404'd on Nevermined agents (and vice-versa). And payment used a home-grown HTTP-header paywall rather than the standard, so a generic A2A agent couldn't pay a Nevermined agent. A2A's whole value is cross-vendor interoperability, so this defeated the purpose.

This is the A2A analog of the MCP in-band migration the team just shipped (#384), applying the same approach to the A2A transport.

## What

### 1. Canonical agent-card discovery (interop fix)
- Serve the card at the canonical `/.well-known/agent-card.json`, keeping `/.well-known/agent.json` as a backward-compat **alias**.
- `PaymentsClient` defaults to the canonical path with a legacy fetch fallback.
- Bump `@a2a-js/sdk` `^0.3.4` → `^0.3.13` (stable line; 1.0 is still alpha).

### 2. In-band x402 v2 A2A transport (standards payment flow)
Per the [Coinbase x402 v2 A2A transport spec](https://github.com/coinbase/x402/blob/main/specs/transports-v2/a2a.md) + the official [a2a-x402 extension](https://github.com/google-agentic-commerce/a2a-x402):
- The agent card now declares the official extension URI (`.../a2a-x402/blob/main/spec/v0.2`) alongside `urn:nevermined:payment` (kept one release).
- **Payment required** → server returns an `input-required` Task with `x402.payment.status: payment-required` + `x402.payment.required` metadata (no HTTP 402).
- **Payment submitted** → the payload is read from the message's `x402.payment.payload` metadata, re-encoded via `encodeAccessToken` to the base64 token the facilitator verify/settle path already expects.
- **Settlement** is stamped in band (`payment-completed` + `x402.payment.receipts`). **A settlement failure forces `failed`/`payment-failed` and suppresses paid content — both the status message AND any artifacts — so a paid result is never delivered without settlement landing.**
- The legacy `payment-signature` header flow is kept as a **deprecated fallback (one release)**.

New module `src/a2a/x402-a2a.ts` ports the in-band task helpers (status enum, metadata-key constants, `createPaymentRequiredTask`/`recordPaymentSuccess`/`recordPaymentFailure`, …), mirroring the Python SDK.

## Backward compatibility
- Legacy `/.well-known/agent.json` still served (alias); legacy `payment-signature` header flow still works (deprecated).
- All changes additive — no existing public signature changed. `openclaw/` and `cli/` use no A2A APIs.

## Tests
- New coverage: first-contact → `input-required`; in-band payload → verify/execute/settle/receipts; verify/settle failure with **content + artifact** suppression; legacy-header regression.
- `pnpm build` + `pnpm lint` clean; **50 a2a / 332 full suite** green.

## Deferred (out of scope)
- **A2A 1.0** — `@a2a-js/sdk` 1.0 is still alpha; revisit when stable (keep TS/Python parity).
- **AP2 embedded flow** — the in-band structures are AP2-nestable; build when a counterparty exists.
- **Agent-card JWS signing** — production hardening, later.

## Pre-release note
The in-band token round-trip is verified at the codec level + against the mocked facilitator. A live-facilitator E2E pass on staging is worth running before release, same caveat as the MCP PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
