### PR TITLE
fix(a2a): in-band x402 v2 review follow-ups (#393)

### DIFF
--- a/markdown/a2a-integration.md
+++ b/markdown/a2a-integration.md
@@ -128,6 +128,8 @@ Lifecycle:
 
 Metadata keys: `x402.payment.status`, `x402.payment.required`, `x402.payment.payload`, `x402.payment.receipts`, `x402.payment.error`.
 
+> **Batch (deferred) settlement.** If the server settles credits in batch, a successful call returns `x402.payment.status: "payment-verified"` (not `payment-completed`) plus the Nevermined marker `x402.payment.settlement: "deferred"` — the payment was verified but settled out-of-band, so there is no in-band receipt. Spec-only clients ignore the unknown key.
+
 > ⚠️ **Header flow deprecated.** The legacy `payment-signature` HTTP header still works but is now a **deprecated fallback, kept for one release**. New integrations should rely on the in-band metadata flow above.
 
 ## Implement Executor

--- a/src/a2a/paymentsClient.ts
+++ b/src/a2a/paymentsClient.ts
@@ -88,10 +88,27 @@ export class PaymentsClient extends A2AClient {
     try {
       return await load(agentCardPath)
     } catch (err) {
-      if (agentCardPath !== LEGACY_AGENT_CARD_WELL_KNOWN_PATH) {
-        return await load(LEGACY_AGENT_CARD_WELL_KNOWN_PATH)
+      if (agentCardPath === LEGACY_AGENT_CARD_WELL_KNOWN_PATH) {
+        throw err
       }
-      throw err
+      // Canonical path failed — fall back to the legacy path. Warn, because a
+      // silent fallback to a typosquattable legacy path is a discovery risk.
+      console.warn(
+        `[PaymentsA2A] agent card not found at '${agentCardPath}', falling back to '${LEGACY_AGENT_CARD_WELL_KNOWN_PATH}':`,
+        err instanceof Error ? err.message : String(err),
+      )
+      try {
+        return await load(LEGACY_AGENT_CARD_WELL_KNOWN_PATH)
+      } catch (legacyErr) {
+        // Both failed. Surface the legacy error but preserve the canonical-path
+        // root cause (a TLS/DNS/5xx there is otherwise masked by a clean 404).
+        const message = legacyErr instanceof Error ? legacyErr.message : String(legacyErr)
+        const wrapped = new Error(
+          `Failed to fetch agent card from '${agentCardPath}' or legacy '${LEGACY_AGENT_CARD_WELL_KNOWN_PATH}': ${message}`,
+        )
+        ;(wrapped as Error & { cause?: unknown }).cause = err
+        throw wrapped
+      }
     }
   }
 

--- a/src/a2a/paymentsClient.ts
+++ b/src/a2a/paymentsClient.ts
@@ -103,11 +103,14 @@ export class PaymentsClient extends A2AClient {
         // Both failed. Surface the legacy error but preserve the canonical-path
         // root cause (a TLS/DNS/5xx there is otherwise masked by a clean 404).
         const message = legacyErr instanceof Error ? legacyErr.message : String(legacyErr)
-        const wrapped = new Error(
-          `Failed to fetch agent card from '${agentCardPath}' or legacy '${LEGACY_AGENT_CARD_WELL_KNOWN_PATH}': ${message}`,
+        // `new Error(msg, { cause })` would be idiomatic but the ES2020 lib target
+        // types Error with 0-1 args, so attach `cause` via Object.assign instead.
+        throw Object.assign(
+          new Error(
+            `Failed to fetch agent card from '${agentCardPath}' or legacy '${LEGACY_AGENT_CARD_WELL_KNOWN_PATH}': ${message}`,
+          ),
+          { cause: err },
         )
-        ;(wrapped as Error & { cause?: unknown }).cause = err
-        throw wrapped
       }
     }
   }

--- a/src/a2a/paymentsRequestHandler.ts
+++ b/src/a2a/paymentsRequestHandler.ts
@@ -497,7 +497,8 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
       // rather than reading a completed task as "nothing owed".
       x402A2AUtils.recordPaymentDeferred(task)
     } else {
-      // Verified, nothing to settle (no credits consumed).
+      // Defensive default: verified, but no settlement result AND not batch-deferred
+      // (e.g. a settle that returned nothing). Record a bare verify.
       x402A2AUtils.recordPaymentVerified(task)
     }
   }
@@ -571,6 +572,21 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
                     httpContext,
                     response as SettlePermissionsResult,
                   )
+                  await resultManager.processEvent(task)
+                }
+              }
+            } else {
+              // Batch redemption: on-chain settlement is deferred out-of-band. The
+              // stream already yielded the content (can't retract), but stamp the
+              // PERSISTED task with payment-verified + the deferred marker so a
+              // streaming client (via tasks/get + resubscribe) isn't left reading a
+              // completed task as "nothing owed" — matching the non-streaming path.
+              const httpContext =
+                requestHttpContext ?? this.getHttpRequestContextForTask(event.taskId)
+              if (httpContext?.inBand) {
+                const task = resultManager.getCurrentTask()
+                if (task) {
+                  this.recordInBandSettlement(task, httpContext, undefined, true)
                   await resultManager.processEvent(task)
                 }
               }

--- a/src/a2a/paymentsRequestHandler.ts
+++ b/src/a2a/paymentsRequestHandler.ts
@@ -338,10 +338,16 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
       throw A2AError.internalError('HTTP context not found for task or message.')
     }
 
-    // 2. Extract bearer token and validate presence of required fields
+    // 2. Extract bearer token and validate presence of required fields.
+    // This path only runs for an *authorized* context (a token was supplied), so
+    // both bearerToken and validation must be present — assert the invariant
+    // explicitly instead of carrying an `undefined as any`.
     const { bearerToken, validation } = httpContext
     if (!bearerToken) {
       throw PaymentsError.unauthorized('Missing bearer token for payment validation.')
+    }
+    if (!validation) {
+      throw PaymentsError.unauthorized('Missing validation context for payment.')
     }
 
     // 3. Validate credits before executing the task
@@ -470,6 +476,7 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
     task: Task | undefined,
     httpContext: HttpRequestContext | undefined,
     settlement?: SettlePermissionsResult,
+    settlementDeferred = false,
   ): void {
     if (!task || !httpContext?.inBand) {
       return
@@ -482,8 +489,15 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
       )
     } else if (settlement) {
       x402A2AUtils.recordPaymentSuccess(task, settlement)
+    } else if (settlementDeferred) {
+      // No in-band settlement result because redemption is BATCHED: the payload was
+      // verified but on-chain settlement is deferred out-of-band (this handler never
+      // confirms it). Mark payment-verified + the deferred marker, NOT
+      // payment-completed — so the client knows it will be charged out-of-band
+      // rather than reading a completed task as "nothing owed".
+      x402A2AUtils.recordPaymentDeferred(task)
     } else {
-      // Verified but no on-chain settlement (free / no-credit call).
+      // Verified, nothing to settle (no credits consumed).
       x402A2AUtils.recordPaymentVerified(task)
     }
   }
@@ -818,9 +832,12 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
     ) {
       let settlement: SettlePermissionsResult | undefined
       let settlementError: unknown
+      let settlementDeferred = false
       try {
         // Get redemption configuration from server (not from client metadata)
         const redemptionConfig = await this.getRedemptionConfig()
+        // Batch redemption defers on-chain settlement out-of-band (no receipt here).
+        settlementDeferred = redemptionConfig.useBatch ?? false
 
         if (!redemptionConfig.useBatch) {
           // Execute redemption with server configuration for non-batch requests
@@ -881,7 +898,12 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
         })
       } else if (httpContext?.inBand) {
         // Stamp in-band settlement state onto the final event's status message.
-        this.recordInBandSettlement({ status: event.status } as any, httpContext, settlement)
+        this.recordInBandSettlement(
+          { status: event.status } as any,
+          httpContext,
+          settlement,
+          settlementDeferred,
+        )
       }
 
       try {

--- a/src/a2a/server.ts
+++ b/src/a2a/server.ts
@@ -235,7 +235,6 @@ async function bearerTokenMiddleware(
       associate({
         urlRequested: absoluteUrl,
         httpMethodRequested: req.method,
-        validation: undefined as any,
         paymentRequired,
       })
       next()

--- a/src/a2a/types.ts
+++ b/src/a2a/types.ts
@@ -161,19 +161,33 @@ export interface AgentOptions {
 
 /**
  * HTTP context associated with a task or message (for internal request tracking).
+ *
+ * INVARIANT — exactly one of two mutually-exclusive states:
+ * - **payment-required**: a payment-gated request arrived with NO token, so only
+ *   `paymentRequired` is set (`bearerToken`/`validation` are absent). The handler
+ *   short-circuits to an `input-required` task instead of executing the agent.
+ * - **authorized**: a token was supplied (in band via `x402.payment.payload` when
+ *   `inBand` is true, else the deprecated `payment-signature` header), so
+ *   `bearerToken` + `validation` are set (`paymentRequired` is absent).
+ *
+ * A `mode`-discriminated union would enforce this at the type level (tracked as a
+ * follow-up); for now consumers guard the field they need — e.g. the settlement
+ * path asserts `bearerToken` + `validation` are present.
  */
 export type HttpRequestContext = {
+  /** Set only in the authorized state. */
   bearerToken?: string
   urlRequested?: string
   httpMethodRequested?: string
-  validation: StartAgentRequest
+  /** The validated request — set only in the authorized state. */
+  validation?: StartAgentRequest
   /**
    * x402 v2 A2A in-band transport: set by the server middleware when a
    * payment-gated request arrives with NO token (neither in-band
    * `x402.payment.payload` nor the deprecated `payment-signature` header). The
    * handler short-circuits and returns an `input-required` task carrying this
    * X402PaymentRequired object under `x402.payment.required`, instead of
-   * executing the agent.
+   * executing the agent. Set only in the payment-required state.
    */
   paymentRequired?: import('../x402/facilitator-api.js').X402PaymentRequired
   /**

--- a/src/a2a/x402-a2a.ts
+++ b/src/a2a/x402-a2a.ts
@@ -62,6 +62,14 @@ export const X402A2AMetadata = {
 } as const
 
 /**
+ * Nevermined-specific (non-core-spec) marker set alongside `payment-verified`
+ * when on-chain settlement is **deferred** to a batch process this handler does
+ * not confirm. Lets a client distinguish "verified, will be charged out-of-band"
+ * from a plain verify; spec-only clients ignore the unknown key. Value: `'deferred'`.
+ */
+export const X402_SETTLEMENT_DEFERRED_KEY = 'x402.payment.settlement'
+
+/**
  * Upper bound on the serialized size of an in-band payment payload. The payload
  * is untrusted client input that gets re-encoded into a token, so cap it as
  * defense-in-depth (parity with the MCP `readPaymentPayload` and the Python
@@ -146,7 +154,18 @@ export class X402A2AUtils {
   getPaymentRequirementsFromMessage(message?: Message | null): X402PaymentRequired | undefined {
     const meta = metaOf(message)
     const value = meta?.[X402A2AUtils.REQUIRED_KEY]
-    return isPlainObject(value) ? (value as unknown as X402PaymentRequired) : undefined
+    // Structural guard before asserting the typed shape: a valid
+    // X402PaymentRequired is a plain object carrying a numeric `x402Version` and
+    // an `accepts` array. Anything else is treated as absent (never assert the
+    // rich interface over arbitrary, unvalidated metadata).
+    if (
+      !isPlainObject(value) ||
+      typeof (value as Record<string, unknown>).x402Version !== 'number' ||
+      !Array.isArray((value as Record<string, unknown>).accepts)
+    ) {
+      return undefined
+    }
+    return value as unknown as X402PaymentRequired
   }
 
   /** Extract the X402PaymentRequired object from a Task's status message metadata. */
@@ -208,6 +227,20 @@ export class X402A2AUtils {
   recordPaymentVerified(task: Task): Task {
     const meta = ensureStatusMetadata(task, 'Payment verification recorded.')
     meta[X402A2AUtils.STATUS_KEY] = PaymentStatus.PAYMENT_VERIFIED
+    return task
+  }
+
+  /**
+   * Record a deferred (batch) settlement on a Task: the payload was verified but
+   * on-chain settlement is deferred out-of-band (the handler never confirms it).
+   * Sets `payment-verified` PLUS the Nevermined `x402.payment.settlement: 'deferred'`
+   * marker, so a client can tell it will be charged out-of-band — distinct from a
+   * plain verify where nothing is owed.
+   */
+  recordPaymentDeferred(task: Task): Task {
+    const meta = ensureStatusMetadata(task, 'Payment verified; settlement deferred.')
+    meta[X402A2AUtils.STATUS_KEY] = PaymentStatus.PAYMENT_VERIFIED
+    meta[X402_SETTLEMENT_DEFERRED_KEY] = 'deferred'
     return task
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,7 @@ export {
   X402A2AUtils,
   x402A2AUtils,
   X402A2AMetadata,
+  X402_SETTLEMENT_DEFERRED_KEY,
   PaymentStatus as A2APaymentStatus,
 } from './a2a/x402-a2a.js'
 export {

--- a/tests/integration/a2a/x402-inband-flow.test.ts
+++ b/tests/integration/a2a/x402-inband-flow.test.ts
@@ -12,7 +12,12 @@ import type { Message, Task, TaskState, TaskStatus, TaskStatusUpdateEvent } from
 import request from 'supertest'
 import { PaymentsA2AServer } from '../../../src/a2a/server.js'
 import { buildPaymentAgentCard } from '../../../src/a2a/agent-card.js'
-import { X402A2AMetadata, PaymentStatus, x402A2AUtils } from '../../../src/a2a/x402-a2a.js'
+import {
+  X402A2AMetadata,
+  PaymentStatus,
+  x402A2AUtils,
+  X402_SETTLEMENT_DEFERRED_KEY,
+} from '../../../src/a2a/x402-a2a.js'
 import * as utils from '../../../src/utils.js'
 import { encodeAccessToken } from '../../../src/utils.js'
 import type { AgentCard, ExecutionEventBus, PaymentsAgentExecutor } from '../../../src/a2a/types.js'
@@ -163,7 +168,7 @@ class DummyExecutor implements PaymentsAgentExecutor {
   async cancelTask(): Promise<void> {}
 }
 
-function buildCard(): AgentCard {
+function buildCard(extraMetadata: Record<string, unknown> = {}): AgentCard {
   // buildPaymentAgentCard declares BOTH the nvm extension and the official
   // a2a-x402 extension. The latter is what flips the middleware into the in-band
   // "return input-required instead of HTTP 402" behavior when no token arrives.
@@ -178,6 +183,7 @@ function buildCard(): AgentCard {
       agentId: 'test-agent-123',
       planId: 'test-plan',
       costDescription: '10 credits per call',
+      ...extraMetadata,
     },
   )
 }
@@ -505,6 +511,64 @@ describe('x402 v2 A2A in-band transport', () => {
       PaymentStatus.PAYMENT_FAILED,
     )
     expect(task.artifacts ?? []).toHaveLength(0)
+  }, 20000)
+
+  test('6. streaming + batch redemption -> persisted task stamps payment-verified + deferred', async () => {
+    const mockPayments = new MockPaymentsService()
+    // Batch redemption: on-chain settlement is deferred out-of-band (settle is
+    // never invoked here). The streaming path must still stamp the persisted task.
+    const card = buildCard({ redemptionConfig: { useBatch: true } })
+    card.capabilities = { ...card.capabilities, streaming: true }
+    const { client, close } = createServer(new DummyExecutor(3), card, mockPayments)
+    servers.push({ close })
+
+    const streamRes = await client.post('/rpc').send({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'message/stream',
+      params: {
+        message: {
+          messageId: 'msg-stream-batch',
+          contextId: 'ctx-6',
+          role: 'user',
+          parts: [{ kind: 'text', text: 'stream pay (batch)' }],
+          metadata: {
+            [X402A2AMetadata.STATUS_KEY]: PaymentStatus.PAYMENT_SUBMITTED,
+            [X402A2AMetadata.PAYLOAD_KEY]: PAYMENT_PAYLOAD,
+          },
+        },
+      },
+    })
+
+    // Batch defers settlement: the facilitator settle path is NOT invoked here.
+    expect(mockPayments.facilitator.settleCallCount).toBe(0)
+
+    const taskId = streamRes.text
+      .split('\n')
+      .filter((l) => l.startsWith('data:'))
+      .map((l) => {
+        try {
+          return JSON.parse(l.slice(5).trim())
+        } catch {
+          return null
+        }
+      })
+      .map((e) => e?.result?.id ?? e?.result?.taskId)
+      .find((id) => typeof id === 'string')
+    expect(taskId).toBeTruthy()
+
+    // The PERSISTED task carries payment-verified + the deferred marker (NOT a
+    // bare completed task that reads as "nothing owed") — matching non-streaming.
+    const getRes = await client.post('/rpc').send({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tasks/get',
+      params: { id: taskId },
+    })
+    const meta = getRes.body.result.status.message.metadata
+    expect(meta[X402A2AMetadata.STATUS_KEY]).toBe(PaymentStatus.PAYMENT_VERIFIED)
+    expect(meta[X402_SETTLEMENT_DEFERRED_KEY]).toBe('deferred')
+    expect(meta[X402A2AMetadata.RECEIPTS_KEY]).toBeUndefined()
   }, 20000)
 
   test('x402A2AUtils helpers round-trip status/required/payload on a task', () => {

--- a/tests/unit/a2a/payments-client-inband.test.ts
+++ b/tests/unit/a2a/payments-client-inband.test.ts
@@ -18,7 +18,10 @@ jest.mock('@a2a-js/sdk/client')
 const PAYLOAD = {
   x402Version: 2,
   accepted: { scheme: 'nvm:erc4337', network: 'eip155:84532', planId: '1', extra: {} },
-  payload: { signature: '0xs', authorization: { from: '0xFrom', sessionKeysProvider: 'zerodev', sessionKeys: [] } },
+  payload: {
+    signature: '0xs',
+    authorization: { from: '0xFrom', sessionKeysProvider: 'zerodev', sessionKeys: [] },
+  },
   extensions: {},
 }
 const TOKEN = Buffer.from(JSON.stringify(PAYLOAD)).toString('base64')
@@ -54,7 +57,9 @@ describe('PaymentsClient in-band x402 transport', () => {
   })
 
   test('injects x402.payment.payload metadata in band AND keeps the header fallback', async () => {
-    const mockPostRpc = jest.fn().mockResolvedValue({ result: { kind: 'task', status: { state: 'completed' } } })
+    const mockPostRpc = jest
+      .fn()
+      .mockResolvedValue({ result: { kind: 'task', status: { state: 'completed' } } })
     ;(paymentsClient as any)._postRpcRequestWithHeaders = mockPostRpc
 
     await paymentsClient.sendA2AMessage({
@@ -91,7 +96,9 @@ describe('PaymentsClient in-band x402 transport', () => {
         },
       })
       // Second (follow-up) response: completed.
-      .mockResolvedValueOnce({ result: { kind: 'task', id: 'task-xyz', status: { state: 'completed' } } })
+      .mockResolvedValueOnce({
+        result: { kind: 'task', id: 'task-xyz', status: { state: 'completed' } },
+      })
     ;(paymentsClient as any)._postRpcRequestWithHeaders = mockPostRpc
 
     const res = await paymentsClient.sendA2AMessage({
@@ -112,7 +119,76 @@ describe('PaymentsClient in-band x402 transport', () => {
       .mockResolvedValue({ result: { kind: 'task', id: 't', status: { state: 'completed' } } })
     ;(paymentsClient as any)._postRpcRequestWithHeaders = mockPostRpc
 
-    await paymentsClient.sendA2AMessage({ message: { messageId: 'm', role: 'user', parts: [] } } as any)
+    await paymentsClient.sendA2AMessage({
+      message: { messageId: 'm', role: 'user', parts: [] },
+    } as any)
     expect(mockPostRpc).toHaveBeenCalledTimes(1)
+  })
+
+  test('does NOT resubmit on a NON-payment input-required response (no double-pay)', async () => {
+    // input-required, but WITHOUT x402.payment.status: payment-required — a genuine
+    // input request, not a paywall. The client must send exactly once.
+    const mockPostRpc = jest.fn().mockResolvedValue({
+      result: {
+        kind: 'task',
+        id: 't',
+        status: {
+          state: 'input-required',
+          message: { kind: 'message', messageId: 's', role: 'agent', parts: [], metadata: {} },
+        },
+      },
+    })
+    ;(paymentsClient as any)._postRpcRequestWithHeaders = mockPostRpc
+
+    await paymentsClient.sendA2AMessage({
+      message: { messageId: 'm', role: 'user', parts: [] },
+    } as any)
+    expect(mockPostRpc).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('PaymentsClient agent-card discovery fallback', () => {
+  const card = { capabilities: { extensions: [] } }
+  const clientFor = (c: any) => ({ getAgentCard: jest.fn().mockResolvedValue(c) })
+
+  beforeEach(() => jest.clearAllMocks())
+
+  test('falls back to the legacy path when the canonical path fails (and warns)', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    ;(A2AClient.fromCardUrl as jest.Mock).mockImplementation((url: string) =>
+      url.includes('agent-card.json')
+        ? Promise.reject(new Error('canonical 404'))
+        : Promise.resolve(clientFor(card)),
+    )
+
+    const client = await PaymentsClient.create(
+      'https://agent.example/',
+      new DummyPayments() as any as Payments,
+      'a',
+      '1',
+    )
+    expect(client).toBeInstanceOf(PaymentsClient)
+    expect(warn).toHaveBeenCalled() // silent fallback would be a discovery risk
+    warn.mockRestore()
+  })
+
+  test('throws preserving the canonical-path root cause when both paths fail', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const canonicalErr = new Error('canonical TLS error')
+    ;(A2AClient.fromCardUrl as jest.Mock).mockImplementation((url: string) =>
+      url.includes('agent-card.json')
+        ? Promise.reject(canonicalErr)
+        : Promise.reject(new Error('legacy 404')),
+    )
+
+    await expect(
+      PaymentsClient.create(
+        'https://agent.example/',
+        new DummyPayments() as any as Payments,
+        'a',
+        '1',
+      ),
+    ).rejects.toMatchObject({ cause: canonicalErr })
+    ;(console.warn as jest.Mock).mockRestore()
   })
 })

--- a/tests/unit/a2a/x402-a2a.test.ts
+++ b/tests/unit/a2a/x402-a2a.test.ts
@@ -12,6 +12,7 @@ import {
   X402A2AMetadata,
   X402A2AUtils,
   x402A2AUtils,
+  X402_SETTLEMENT_DEFERRED_KEY,
 } from '../../../src/a2a/x402-a2a.js'
 import { decodeAccessToken, encodeAccessToken } from '../../../src/utils.js'
 
@@ -74,7 +75,9 @@ describe('X402A2AUtils extraction', () => {
 
   test('rejects array and null payloads (mirrors isinstance(value, dict))', () => {
     expect(
-      utils.getPaymentPayloadFromMessage(messageWith({ [X402A2AMetadata.PAYLOAD_KEY]: [1, 2] as any })),
+      utils.getPaymentPayloadFromMessage(
+        messageWith({ [X402A2AMetadata.PAYLOAD_KEY]: [1, 2] as any }),
+      ),
     ).toBeUndefined()
     expect(
       utils.getPaymentPayloadFromMessage(
@@ -86,6 +89,28 @@ describe('X402A2AUtils extraction', () => {
   test('rejects oversized payloads (>64KB) as defense-in-depth', () => {
     const big = messageWith({ [X402A2AMetadata.PAYLOAD_KEY]: { blob: 'x'.repeat(70 * 1024) } })
     expect(utils.getPaymentPayloadFromMessage(big)).toBeUndefined()
+  })
+
+  test('getPaymentRequirements structurally guards before asserting the typed shape', () => {
+    // Plain object but not a valid X402PaymentRequired -> treated as absent.
+    expect(
+      utils.getPaymentRequirementsFromMessage(
+        messageWith({ [X402A2AMetadata.REQUIRED_KEY]: { foo: 'bar' } as any }),
+      ),
+    ).toBeUndefined()
+    // `accepts` not an array -> absent.
+    expect(
+      utils.getPaymentRequirementsFromMessage(
+        messageWith({ [X402A2AMetadata.REQUIRED_KEY]: { x402Version: 2, accepts: {} } as any }),
+      ),
+    ).toBeUndefined()
+    // Valid shape -> returned.
+    const ok = { x402Version: 2, resource: { url: '/x' }, accepts: [], extensions: {} }
+    expect(
+      utils.getPaymentRequirementsFromMessage(
+        messageWith({ [X402A2AMetadata.REQUIRED_KEY]: ok as any }),
+      ),
+    ).toEqual(ok)
   })
 })
 
@@ -136,6 +161,18 @@ describe('X402A2AUtils stamping', () => {
     expect(task.status.message?.metadata?.[X402A2AMetadata.STATUS_KEY]).toBe(
       PaymentStatus.PAYMENT_VERIFIED,
     )
+    // Plain verify carries no deferred marker (distinct from batch-deferred).
+    expect(task.status.message?.metadata?.[X402_SETTLEMENT_DEFERRED_KEY]).toBeUndefined()
+  })
+
+  test('recordPaymentDeferred stamps payment-verified + the deferred marker (batch)', () => {
+    const task = emptyTask()
+    utils.recordPaymentDeferred(task)
+    const meta = task.status.message?.metadata as Record<string, any>
+    expect(meta[X402A2AMetadata.STATUS_KEY]).toBe(PaymentStatus.PAYMENT_VERIFIED)
+    expect(meta[X402_SETTLEMENT_DEFERRED_KEY]).toBe('deferred')
+    // Never completed (no receipt) — settlement happens out-of-band.
+    expect(meta[X402A2AMetadata.RECEIPTS_KEY]).toBeUndefined()
   })
 
   test('exports a shared singleton instance', () => {


### PR DESCRIPTION
Addresses #393 — the four review follow-ups from #392's review. TS-only (the Python SDK is already clean on these).

## Changes

**1. Batch settlement gets a distinct deferred marker.** The no-settlement branch in `recordInBandSettlement` is reachable *only* in the batch case (the `creditsToBurn` guard already excludes free/no-credit calls), so the old "free / no-credit" comment was wrong and a bare `payment-verified` conflated "nothing owed" with "charged out-of-band". Batch now stamps `payment-verified` **plus** the Nevermined marker `x402.payment.settlement: "deferred"` (exported as `X402_SETTLEMENT_DEFERRED_KEY`; spec-only clients ignore it).

**2a. `HttpRequestContext` invariant documented + cast removed.** `validation` is now optional, the two mutually-exclusive states (payment-required vs authorized) are documented, the `validation: undefined as any` cast is gone, and the settlement consumer asserts the invariant explicitly. (A full `mode`-discriminated union remains a reasonable future refactor.)

**2b. `getPaymentRequirements` runtime guard.** Structurally validates (numeric `x402Version` + `accepts` array) before asserting `X402PaymentRequired`, instead of a blind `as unknown as` over arbitrary metadata.

**3. `_fetchAgentCard` fallback hardening.** Warns on the canonical→legacy fallback (a silent fallback to a typosquattable path is a discovery risk) and preserves the canonical-path root cause as `{ cause }` when both paths fail (a TLS/DNS/5xx is otherwise masked by a clean legacy 404).

## Tests (point 4 + guards for the above)
- `recordPaymentDeferred` sets the deferred marker; plain verify does not.
- `getPaymentRequirements` rejects non-conforming objects.
- Client does **not** resubmit on a non-payment `input-required` response (no double-pay).
- `_fetchAgentCard`: canonical-fails→legacy-succeeds (warns) + both-fail throws with the canonical `cause`.

56 a2a tests pass (+5); `pnpm build` + `pnpm lint` clean; full suite 344 pass. `openclaw/`/`cli/` use no A2A APIs; all changes additive.

## Note
The staging-e2e item in #393 is a separate **pre-release validation** (run the in-band flow against a live facilitator), not a code change — it's the gate before the patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
