### PR TITLE
docs(mcp): plan-centric MCP server config (agentId optional)

### DIFF
--- a/markdown/mcp-integration.md
+++ b/markdown/mcp-integration.md
@@ -33,7 +33,7 @@ These endpoints are generated automatically—no manual configuration required.
 
 ## Configure MCP
 
-Initialize the MCP integration with your agent details:
+Initialize the MCP integration with your plan details:
 
 ```typescript
 import { Payments, EnvironmentName } from '@nevermined-io/payments'
@@ -401,7 +401,7 @@ async function fetchAlerts() {
 | Option          | Type                   | Description                                                                                                                                                                                                                             |
 | --------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `credits`       | `bigint` or `function` | Credits to consume per call                                                                                                                                                                                                             |
-| `planId`        | `string`               | Optional override for the plan ID (otherwise inferred from token)                                                                                                                                                                       |
+| `planId`        | `string`               | Per-handler plan ID override. A server-level `planId` (set via `configure`/`start`) is required; set this only to charge a different plan for this handler.                                                                               |
 | `maxAmount`     | `bigint`               | Max credits to verify during authentication (default: `1n`)                                                                                                                                                                             |
 | `onRedeemError` | `string`               | On post-execution settlement failure: `'ignore'` (default) returns the in-band payment error; `'propagate'` throws a JSON-RPC error. Tool content is always suppressed either way (paid content is never delivered without settlement). |
 
@@ -411,7 +411,20 @@ The MCP transport follows the [x402 v2 MCP transport spec](https://github.com/co
 
 ### Request — payment payload
 
-The client sends the x402 `PaymentPayload` in the request params `_meta["x402/payment"]` (plain JSON). For backwards compatibility an `Authorization: Bearer <token>` header is still accepted as a **deprecated fallback** when `_meta["x402/payment"]` is absent.
+The client sends the x402 `PaymentPayload` in the request params `_meta["x402/payment"]` (plain JSON). Note this is the **payment** channel — separate from session auth: the MCP session is an OAuth-protected resource, so the client must also send an `Authorization: Bearer <accessToken>` header on the transport to establish the session (`initialize` returns `401` without it). For backwards compatibility the server also reads the payment from that header alone (no `_meta`) as a **deprecated fallback** for one release.
+
+```typescript
+import { decodeAccessToken } from '@nevermined-io/payments'
+
+const { accessToken } = await payments.x402.getX402AccessToken(planId) // agentId is optional
+
+await client.callTool({
+  name: 'get_weather',
+  arguments: { city: 'Madrid' },
+  // Carry the payment in band (the spec-defined transport):
+  _meta: { 'x402/payment': decodeAccessToken(accessToken) },
+})
+```
 
 ### Response — settlement receipt
 

--- a/markdown/mcp-integration.md
+++ b/markdown/mcp-integration.md
@@ -416,7 +416,17 @@ The client sends the x402 `PaymentPayload` in the request params `_meta["x402/pa
 ```typescript
 import { decodeAccessToken } from '@nevermined-io/payments'
 
-const { accessToken } = await payments.x402.getX402AccessToken(planId) // agentId is optional
+// Mint a token against a delegation (create one first). `agentId` (2nd arg) is
+// optional, but `delegationConfig` is required.
+const { delegationId } = await payments.delegation.createDelegation({
+  provider: 'erc4337', // 'stripe' | 'braintree' | 'visa' for fiat plans
+  spendingLimitCents: 10000,
+  durationSecs: 604800,
+  currency: 'usdc', // 'usd' for fiat plans
+})
+const { accessToken } = await payments.x402.getX402AccessToken(planId, undefined, {
+  delegationConfig: { delegationId },
+})
 
 await client.callTool({
   name: 'get_weather',


### PR DESCRIPTION
## What

Updates the SDK doc source `markdown/mcp-integration.md` (the source of truth for the docs site's `api-reference/typescript/**`, regenerated by the release bot) so the next release sync carries the remaining plan-centric / agentId-optional wording to the site.

The bulk of the agentId-optional doc changes already landed with the agentId-optional feature. This PR fills the two remaining gaps plus one intro line:

- **Handler-options `planId` row** — now describes it as a per-handler override of the *required* server-level `planId` (was the stale "inferred from token").
- **In-band "Request — payment payload"** — clarifies that the `Authorization: Bearer <accessToken>` header authenticates the OAuth-protected MCP **session** (`initialize` returns `401` without it), which is separate from the in-band `_meta["x402/payment"]` **payment**; header-only payment is a deprecated one-release fallback. Adds a short client example.
- **"Configure MCP" intro** — "agent details" → "plan details".

## Why

The docs-site `api-reference/**` is generated from this repo — hand-editing it in the docs repo gets overwritten on the next release sync. This puts the change at the source so it flows correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)