### PR TITLE
chore(release): name GitHub Release after the tag only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -433,13 +433,13 @@ jobs:
 
           if [ "$USE_AUTO_NOTES" = "true" ]; then
             gh release create "$TAG" \
-              --title "Nevermined Payments $TAG" \
+              --title "$TAG" \
               --generate-notes \
               $PRERELEASE_FLAG \
               sdk-tarball/*.tgz cli-tarballs/*.tar.gz openclaw-tarball/*.tgz
           else
             gh release create "$TAG" \
-              --title "Nevermined Payments $TAG" \
+              --title "$TAG" \
               --notes-file /tmp/release_notes.md \
               $PRERELEASE_FLAG \
               sdk-tarball/*.tgz cli-tarballs/*.tar.gz openclaw-tarball/*.tgz


### PR DESCRIPTION
## Description

The two `gh release create "$TAG"` calls in `.github/workflows/release.yml` both hardcoded `--title "Nevermined Payments $TAG"`, producing GitHub Release names like **`Nevermined Payments v1.9.0`**. This changes the title to `$TAG` on **both** branches (the `--generate-notes` path at the old line 436 and the `--notes-file` path at 442 — only one runs per release depending on `USE_AUTO_NOTES`, but both are changed so the name is tag-only either way).

Now the GitHub Release name is exactly the tag, e.g. **`v1.9.0`**.

Out of scope (left as-is): the CLI release workflow (`build-cli.yml`) body header `## Nevermined Payments CLI v…`, tarball assets, and notes generation.

## Is this PR related with an open issue?

Related to Issue nevermined-io/payments#400

Closes #400
Part of nevermined-io/nvm-monorepo#2004

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

_No tests: `.github/workflows/` is not covered by the unit/integration/e2e suites. No SDK docs change: this is internal release infrastructure with no user-facing API surface._

🤖 Generated with [Claude Code](https://claude.com/claude-code)