### PR TITLE
docs(cli): document real register-agent-and-plan config schemas

### DIFF
--- a/cli/docs/agents.md
+++ b/cli/docs/agents.md
@@ -58,9 +58,11 @@ Register a new AI agent and associate it with one or more existing payment plans
 ```bash
 nvm agents register-agent \
   --agent-metadata agent-metadata.json \
-  --agent-api "https://api.example.com/v1/agent" \
+  --agent-api agent-api.json \
   --payment-plans "plan-id-1,plan-id-2"
 ```
+
+`--agent-api` is a JSON object (`AgentAPIAttributes`), not a bare URL — pass a file or an inline JSON string. See [Config schemas](#config-schemas) for the full shape.
 
 **agent-metadata.json**:
 
@@ -86,16 +88,33 @@ Register a new AI agent and create a payment plan for it in a single command:
 ```bash
 nvm agents register-agent-and-plan \
   --agent-metadata agent-metadata.json \
-  --agent-api "https://api.example.com/v1/agent" \
+  --agent-api agent-api.json \
   --plan-metadata plan-metadata.json \
   --price-config price-config.json \
   --credits-config credits-config.json
 ```
 
 Optional flags:
-- `--access-limit` — Limit the number of times the plan can be ordered
+- `--access-limit` — `credits` or `time`. When omitted, it is derived from the credits config: `time` if `durationSecs > 0`, otherwise `credits`.
 
-**plan-metadata.json**:
+Each `--*` flag accepts **either** a path to a `.json` file **or** an inline JSON string (anything ending in `.json` is read as a file; everything else is parsed as JSON). Note that `--agent-api` is a JSON **object** (`AgentAPIAttributes`), not a bare URL.
+
+The four config flags map to the SDK types — see [Config schemas](#config-schemas) below for the full field reference and the helper commands that generate them.
+
+**agent-api.json** (`AgentAPIAttributes`):
+
+```json
+{
+  "endpoints": [{ "POST": "https://api.example.com/v1/agents/:agentId/tasks" }],
+  "openEndpoints": ["https://api.example.com/v1/docs"],
+  "authType": "bearer",
+  "token": "your-upstream-bearer-token"
+}
+```
+
+Only `endpoints` is commonly needed; `openEndpoints` and the auth fields (`authType`, `username`, `password`, `token`) are optional.
+
+**plan-metadata.json** (`PlanMetadata`):
 
 ```json
 {
@@ -105,25 +124,112 @@ Optional flags:
 }
 ```
 
-**price-config.json**:
+**price-config.json** (`PlanPriceConfig`) — a free plan (no charge to subscribe):
 
 ```json
 {
-  "tokenAddress": "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
-  "price": 1000000,
-  "amountOfCredits": 100
+  "isCrypto": true,
+  "amounts": [],
+  "receivers": [],
+  "tokenAddress": "0x0000000000000000000000000000000000000000",
+  "contractAddress": "0x0000000000000000000000000000000000000000",
+  "feeController": "0x0000000000000000000000000000000000000000",
+  "externalPriceAddress": "0x0000000000000000000000000000000000000000",
+  "templateAddress": "0x0000000000000000000000000000000000000000"
 }
 ```
 
-**credits-config.json**:
+To charge a fixed crypto price instead, set `amounts` to the price in the token's smallest unit and `receivers` to the wallet that collects it (this is what `nvm plans get-native-token-price-config` / `get-erc20-price-config` emit):
 
 ```json
 {
-  "subscriptionType": "credits",
-  "accessType": "credits",
-  "minCreditsToCharge": 1,
-  "maxCreditsToCharge": 10
+  "isCrypto": true,
+  "amounts": [1000000],
+  "receivers": ["0xYourReceiverWallet"],
+  "tokenAddress": "0x0000000000000000000000000000000000000000",
+  "contractAddress": "0x0000000000000000000000000000000000000000",
+  "feeController": "0x0000000000000000000000000000000000000000",
+  "externalPriceAddress": "0x0000000000000000000000000000000000000000",
+  "templateAddress": "0x0000000000000000000000000000000000000000"
 }
+```
+
+**credits-config.json** (`PlanCreditsConfig`) — grant 100 credits, burn 1 per request:
+
+```json
+{
+  "isRedemptionAmountFixed": true,
+  "redemptionType": 4,
+  "onchainMirror": false,
+  "durationSecs": 0,
+  "amount": 100,
+  "minAmount": 1,
+  "maxAmount": 1
+}
+```
+
+### Config schemas
+
+`register-agent-and-plan` (and `nvm plans register-credits-plan`) accept these JSON shapes. They match the SDK types exactly — the easiest way to produce a valid file is to run the matching `nvm plans get-*-config` command and save its output, rather than hand-crafting the JSON.
+
+#### `--price-config` (`PlanPriceConfig`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `isCrypto` | boolean | `true` for crypto/native/ERC-20 payments, `false` for fiat (Stripe/Braintree). Required. |
+| `amounts` | number[] | Price(s) in the token's smallest unit (6-decimal units for USDC/EURC; `2000000` = $2.00). Empty `[]` for a free plan. |
+| `receivers` | string[] | Wallet address(es) that collect the payment. Empty `[]` for a free plan. Same length as `amounts`. |
+| `tokenAddress` | string | ERC-20 token address, or the zero address (`0x0000…0000`) for the native token / free / fiat plans. |
+| `contractAddress` | string | Price-calculator contract. Zero address unless using a smart-contract price. |
+| `feeController` | string | Fee-controller contract. Zero address uses the default. |
+| `externalPriceAddress` | string | External price contract. Zero address when unused. |
+| `templateAddress` | string | Template contract. Zero address except for pay-as-you-go plans. |
+| `currency` | string | Optional: `USD`, `EUR`, `USDC`, or `EURC`. When omitted, the backend infers it from the payment type. |
+
+Generators that emit this shape: `nvm plans get-free-price-config`, `get-native-token-price-config`, `get-crypto-price-config`, `get-erc20-price-config`, `get-eurc-price-config`, `get-fiat-price-config`, `get-pay-as-you-go-price-config`.
+
+#### `--credits-config` (`PlanCreditsConfig`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `isRedemptionAmountFixed` | boolean | `true` when every request burns a fixed number of credits (`minAmount == maxAmount`), `false` for a dynamic range. |
+| `redemptionType` | number | Who may redeem credits: `0` = global burner role, `1` = plan owner, `2` = plan role, `4` = subscriber. SDK helpers use `4` (`ONLY_SUBSCRIBER`). |
+| `onchainMirror` | boolean | `false` keeps the credit ledger off-chain (default). `true` mirrors each burn to the on-chain `NFT1155Credits` contract. |
+| `durationSecs` | number | Plan lifetime in seconds. `0` = non-expirable (credit-limited). `> 0` makes it a time-limited plan. |
+| `amount` | number | Credits granted when the plan is purchased. |
+| `minAmount` | number | Minimum credits burned per request. |
+| `maxAmount` | number | Maximum credits burned per request (equal to `minAmount` for fixed plans). |
+| `nftAddress` | string | Optional: NFT contract representing the plan's credits. Normally omitted — assigned by the backend. |
+
+Generators that emit this shape: `nvm plans get-fixed-credits-config`, `get-dynamic-credits-config`, `get-expirable-duration-config`, `get-non-expirable-duration-config`, `get-pay-as-you-go-credits-config`.
+
+#### `--agent-api` (`AgentAPIAttributes`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `endpoints` | object[] | Allowlist of paid upstream endpoints, each `{ "<HTTP-VERB>": "<url>" }` (e.g. `{ "POST": "https://…/:agentId/tasks" }`). Optional defense-in-depth on top of your library middleware. |
+| `openEndpoints` | string[] | Endpoints that do **not** require a subscription (docs, health, etc.). Optional. |
+| `agentDefinitionUrl` | string | Optional link to an OpenAPI spec, MCP manifest, or A2A agent card (metadata only). |
+| `authType` | string | Upstream auth: `none`, `basic`, `bearer`, or `oauth`. Optional. |
+| `username` / `password` | string | Upstream credentials when `authType` is `basic`. |
+| `token` | string | Upstream bearer token when `authType` is `bearer` or `oauth`. |
+
+The CLI passes this object straight to the SDK, which wraps it as `agentApiAttributes` in the request body — you supply the unwrapped `AgentAPIAttributes` shown above.
+
+#### Generating valid configs
+
+```bash
+# A free plan that grants 100 credits, burning 1 per request:
+nvm plans get-free-price-config --format json > price-config.json
+nvm plans get-fixed-credits-config --credits-granted 100 --credits-per-request 1 \
+  --format json > credits-config.json
+
+nvm agents register-agent-and-plan \
+  --agent-metadata agent-metadata.json \
+  --agent-api agent-api.json \
+  --plan-metadata plan-metadata.json \
+  --price-config price-config.json \
+  --credits-config credits-config.json
 ```
 
 ## Updating Agents
@@ -135,10 +241,10 @@ Modify agent name, description, API endpoint, or other metadata:
 ```bash
 nvm agents update-agent-metadata <agent-id> \
   --agent-metadata updated-metadata.json \
-  --agent-api "https://api-v2.example.com/agent"
+  --agent-api updated-agent-api.json
 ```
 
-Both `--agent-metadata` and `--agent-api` are required.
+Both `--agent-metadata` and `--agent-api` are required. As with registration, `--agent-api` is a JSON object (`AgentAPIAttributes`), not a bare URL.
 
 **updated-metadata.json**:
 
@@ -211,7 +317,7 @@ echo "Created plan: $PLAN_ID"
 # 2. Register the agent with the plan
 AGENT_ID=$(nvm agents register-agent \
   --agent-metadata agent.json \
-  --agent-api "https://api.example.com/agent" \
+  --agent-api agent-api.json \
   --payment-plans "$PLAN_ID" \
   --format json | jq -r '.agentId')
 
@@ -220,7 +326,7 @@ echo "Registered agent: $AGENT_ID"
 # 3. Update agent metadata if needed
 nvm agents update-agent-metadata $AGENT_ID \
   --agent-metadata updated-agent.json \
-  --agent-api "https://api.example.com/agent"
+  --agent-api agent-api.json
 
 # 4. Verify agent is accessible
 nvm agents get-agent $AGENT_ID
@@ -235,7 +341,7 @@ Register an agent and its payment plan in a single command:
 ```bash
 nvm agents register-agent-and-plan \
   --agent-metadata agent.json \
-  --agent-api "https://api.example.com/agent" \
+  --agent-api agent-api.json \
   --plan-metadata plan.json \
   --price-config price.json \
   --credits-config credits.json
@@ -263,7 +369,7 @@ PREMIUM_PLAN=$(nvm plans register-credits-plan \
 # Register agent with both plans
 nvm agents register-agent \
   --agent-metadata agent.json \
-  --agent-api "https://api.example.com" \
+  --agent-api agent-api.json \
   --payment-plans "$BASIC_PLAN,$PREMIUM_PLAN"
 ```
 
@@ -313,7 +419,7 @@ Always test agents in sandbox environment:
 # Register in sandbox
 nvm --profile sandbox agents register-agent \
   --agent-metadata agent.json \
-  --agent-api "https://staging-api.example.com" \
+  --agent-api staging-agent-api.json \
   --payment-plans "$STAGING_PLAN_ID"
 
 # Test the agent
@@ -322,7 +428,7 @@ nvm --profile sandbox agents get-agent $STAGING_AGENT_ID
 # Once verified, deploy to production
 nvm --profile production agents register-agent \
   --agent-metadata agent.json \
-  --agent-api "https://api.example.com" \
+  --agent-api agent-api.json \
   --payment-plans "$PROD_PLAN_ID"
 ```
 

--- a/cli/docs/plans.md
+++ b/cli/docs/plans.md
@@ -114,24 +114,32 @@ nvm plans register-credits-plan \
 }
 ```
 
-**price-config.json**:
+**price-config.json** (`PlanPriceConfig`) — charge a fixed crypto price; `amounts` is in the token's smallest unit (e.g. `1000000` = 1 USDC at 6 decimals) and `receivers` collects it (this is what `nvm plans get-erc20-price-config` / `get-native-token-price-config` emit):
 
 ```json
 {
-  "tokenAddress": "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
-  "price": 1000000,
-  "amountOfCredits": 100
+  "isCrypto": true,
+  "amounts": [1000000],
+  "receivers": ["0xYourReceiverWallet"],
+  "tokenAddress": "0x0000000000000000000000000000000000000000",
+  "contractAddress": "0x0000000000000000000000000000000000000000",
+  "feeController": "0x0000000000000000000000000000000000000000",
+  "externalPriceAddress": "0x0000000000000000000000000000000000000000",
+  "templateAddress": "0x0000000000000000000000000000000000000000"
 }
 ```
 
-**credits-config.json**:
+**credits-config.json** (`PlanCreditsConfig`) — grant 100 credits, burn 1 per request (what `nvm plans get-fixed-credits-config` emits):
 
 ```json
 {
-  "subscriptionType": "credits",
-  "accessType": "credits",
-  "minCreditsToCharge": 1,
-  "maxCreditsToCharge": 10
+  "isRedemptionAmountFixed": true,
+  "redemptionType": 4,
+  "onchainMirror": false,
+  "durationSecs": 0,
+  "amount": 100,
+  "minAmount": 1,
+  "maxAmount": 1
 }
 ```
 
@@ -146,17 +154,21 @@ nvm plans register-time-plan \
   --credits-config credits-config.json
 ```
 
-**credits-config.json** (for time plan):
+**credits-config.json** (for time plan) (`PlanCreditsConfig`) — a time-limited plan sets `durationSecs > 0` (what `nvm plans get-expirable-duration-config` emits):
 
 ```json
 {
-  "subscriptionType": "time",
-  "accessType": "time",
-  "duration": 2592000
+  "isRedemptionAmountFixed": false,
+  "redemptionType": 4,
+  "onchainMirror": false,
+  "durationSecs": 2592000,
+  "amount": 1,
+  "minAmount": 1,
+  "maxAmount": 1
 }
 ```
 
-Duration is in seconds (2592000 = 30 days).
+`durationSecs` is in seconds (2592000 = 30 days).
 
 ### Trial Plans
 
@@ -366,22 +378,30 @@ cat > plan.json << EOF
 }
 EOF
 
-# 2. Create price configuration
+# 2. Create price configuration (PlanPriceConfig)
 cat > price.json << EOF
 {
-  "tokenAddress": "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
-  "price": 10000000,
-  "amountOfCredits": 100
+  "isCrypto": true,
+  "amounts": [10000000],
+  "receivers": ["0xYourReceiverWallet"],
+  "tokenAddress": "0x0000000000000000000000000000000000000000",
+  "contractAddress": "0x0000000000000000000000000000000000000000",
+  "feeController": "0x0000000000000000000000000000000000000000",
+  "externalPriceAddress": "0x0000000000000000000000000000000000000000",
+  "templateAddress": "0x0000000000000000000000000000000000000000"
 }
 EOF
 
-# 3. Create credits configuration
+# 3. Create credits configuration (PlanCreditsConfig) — 100 credits, burn 1-5 per request
 cat > credits.json << EOF
 {
-  "subscriptionType": "credits",
-  "accessType": "credits",
-  "minCreditsToCharge": 1,
-  "maxCreditsToCharge": 5
+  "isRedemptionAmountFixed": false,
+  "redemptionType": 4,
+  "onchainMirror": false,
+  "durationSecs": 0,
+  "amount": 100,
+  "minAmount": 1,
+  "maxAmount": 5
 }
 EOF
 
@@ -424,12 +444,12 @@ Make your plans discoverable with clear names and descriptions:
 
 ### 2. Set Appropriate Credit Limits
 
-Configure min/max credits to prevent abuse:
+Configure the min/max credits burned per request to prevent abuse (fields of `PlanCreditsConfig`):
 
 ```json
 {
-  "minCreditsToCharge": 1,
-  "maxCreditsToCharge": 10
+  "minAmount": 1,
+  "maxAmount": 10
 }
 ```
 


### PR DESCRIPTION
## Description

The CLI docs for `nvm agents register-agent-and-plan` (in `cli/docs/agents.md`) showed JSON config examples that do **not** match what the command accepts — discovered while building fixtures for the x402 v2 tutorials.

The flags are parsed as JSON (`parseJsonInput`) and forwarded to `payments.agents.registerAgentAndPlan(...)`, so they must match the SDK types. The old examples were wrong:

| Flag | Old (wrong) | Actual SDK type |
|------|-------------|-----------------|
| `--price-config` | `{tokenAddress, price, amountOfCredits}` | `PlanPriceConfig` `{isCrypto, amounts[], receivers[], tokenAddress, contractAddress, feeController, externalPriceAddress, templateAddress, currency?}` |
| `--credits-config` | `{subscriptionType, accessType, minCreditsToCharge, maxCreditsToCharge}` | `PlanCreditsConfig` `{isRedemptionAmountFixed, redemptionType, onchainMirror, durationSecs, amount, minAmount, maxAmount, nftAddress?}` |
| `--agent-api` | a bare URL string `"https://..."` | `AgentAPIAttributes` JSON object `{endpoints, openEndpoints, authType, ...}` |

(The bare-URL `--agent-api` examples were outright broken: `parseJsonInput` `JSON.parse`s any non-`.json` input, and a raw URL is not valid JSON.)

### Note on the issue's premise (stale)
The issue suggested that, via the CLI, you must pass the **wrapped** `agentApiAttributes` shape. That is **not** true of current code: the SDK (`agents-api.ts`) wraps the `agentApi` object into `agentApiAttributes` in the request body itself, so the CLI/user supplies the **unwrapped** `AgentAPIAttributes`. The docs now describe this actual current behavior.

### What changed (docs-only)
**`cli/docs/agents.md`** (the issue's named command):
- Replaced the `register-agent-and-plan` example configs with the real shapes, grounded in `src/plans.ts`, `src/common/types.ts`, and `cli/src/base-command.ts` (every field verified against source — none invented).
- Fixed every bare-URL `--agent-api` usage across the file (`register-agent`, `update-agent-metadata`, the integration scripts, best-practices) to a JSON `AgentAPIAttributes` file.
- Added a **Config schemas** reference section: a field-by-field table for each of `--price-config`, `--credits-config`, `--agent-api`, plus the `nvm plans get-*-config` generator commands that emit valid configs (the recommended way to produce them).
- Clarified `--access-limit` (derived from `durationSecs` when omitted).

**`cli/docs/plans.md`** (second file — same defect):
- The identical wrong `PlanPriceConfig` / `PlanCreditsConfig` examples also appeared here for `nvm plans register-credits-plan` / `register-time-plan` and the worked examples. Fixed those JSON blocks to the real shapes too — leaving them stale would contradict the just-fixed `agents.md` and a reader copying from `plans.md` would still hit backend validation errors. Scoped strictly to the wrong schema JSON; no restructuring.

`cli/docs/*` is published to the docs site at `docs_mintlify/docs/api-reference/cli/` by `release.yml`, so this repo is the source of truth — no docs-repo edit needed.

## Is this PR related with an open issue?

Related to Issue nevermined-io/payments#389

Closes #389
Part of nevermined-io/nvm-monorepo#2004

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Follows the code style of this project.
- [ ] Tests Cover Changes
- [x] Documentation

_Docs-only; no code changed, so no test coverage applies._

🤖 Generated with [Claude Code](https://claude.com/claude-code)