### PR TITLE
feat: derive environment from NVM API key prefix; deprecate `environment` option

### DIFF
--- a/markdown/initializing-the-library.md
+++ b/markdown/initializing-the-library.md
@@ -28,13 +28,14 @@ Most applications will use a builder key for server-side operations.
 For Node.js applications, use the `getInstance` method:
 
 ```typescript
-import { Payments, EnvironmentName } from '@nevermined-io/payments'
+import { Payments } from '@nevermined-io/payments'
 
 const payments = Payments.getInstance({
   nvmApiKey: process.env.NVM_API_KEY!,
-  environment: 'sandbox' as EnvironmentName,
 })
 ```
+
+The environment is derived automatically from your API key — see [Environment derivation](#environment-derivation) below.
 
 ### Configuration Options
 
@@ -42,13 +43,27 @@ The `getInstance` method accepts a `PaymentOptions` object:
 
 ```typescript
 interface PaymentOptions {
-  nvmApiKey: string          // Your Nevermined API key (required)
-  environment: EnvironmentName  // Target environment (required)
-  returnUrl?: string         // OAuth callback URL (optional, for browser)
-  appId?: string             // Your application ID (optional)
-  version?: string           // Your application version (optional)
+  nvmApiKey: string           // Your Nevermined API key (required)
+  environment?: EnvironmentName  // @deprecated — derived from the API key (optional)
+  returnUrl?: string          // OAuth callback URL (optional, for browser)
+  appId?: string              // Your application ID (optional)
+  version?: string            // Backend API version pin, MAJOR.MINOR (optional)
 }
 ```
+
+### Environment derivation
+
+NVM API keys are prefixed with the environment they belong to
+(`<prefix>:<jwt>`), so the SDK resolves the target environment from the key —
+you no longer need to pass `environment`.
+
+The `environment` option is **deprecated** but still accepted:
+
+- When the key prefix maps to a known environment, the **key always wins** and
+  the `environment` option is ignored (a one-time deprecation warning is logged).
+- When the key has no recognized prefix (for example a local/custom build), the
+  SDK falls back to the `environment` option, and finally to `custom`. This
+  keeps local and custom-backend workflows working unchanged.
 
 ### Complete Server-Side Example
 

--- a/src/api/base-payments.ts
+++ b/src/api/base-payments.ts
@@ -3,7 +3,16 @@ import { API_VERSION_HEADER, LOCKED_API_VERSION } from '../common/api-version.js
 import { jsonReplacer } from '../common/helper.js'
 import { PaymentsError } from '../common/payments.error.js'
 import { PaymentOptions, PaymentScheme } from '../common/types.js'
-import { EnvironmentInfo, EnvironmentName, Environments } from '../environments.js'
+import {
+  EnvironmentInfo,
+  EnvironmentName,
+  Environments,
+  getEnvironmentFromApiKey,
+} from '../environments.js'
+
+// Emit the `environment` deprecation notice at most once per process to avoid
+// log spam when many sub-API instances are constructed from the same options.
+let environmentOptionDeprecationWarned = false
 
 /**
  * Header used by the Nevermined backend to resolve the active organization
@@ -87,8 +96,8 @@ export abstract class BasePaymentsAPI {
     this.nvmApiKey = options.nvmApiKey
     this.scheme = options.scheme || 'nvm'
     this.returnUrl = options.returnUrl || ''
-    this.environment = Environments[options.environment as EnvironmentName]
-    this.environmentName = options.environment
+    this.environmentName = this.resolveEnvironmentName(options)
+    this.environment = Environments[this.environmentName]
     this.appId = options.appId
     // `version` is the backend API pin (MAJOR.MINOR) sent verbatim as
     // Nevermined-Version. Fail fast on a malformed value rather than shipping
@@ -105,6 +114,34 @@ export abstract class BasePaymentsAPI {
     const { accountAddress, heliconeApiKey } = this.parseNvmApiKey()
     this.accountAddress = accountAddress
     this.heliconeApiKey = heliconeApiKey
+  }
+
+  /**
+   * Resolves the active environment for this instance.
+   *
+   * The environment is derived from the NVM API key prefix
+   * (`<prefix>:<jwt>`); the key wins whenever its prefix is recognized. The
+   * deprecated `environment` option is still honored as a fallback when the
+   * key has no recognized prefix (e.g. local/custom dev), and ultimately
+   * defaults to `custom`. Passing `environment` emits a one-time deprecation
+   * warning.
+   */
+  private resolveEnvironmentName(options: PaymentOptions): EnvironmentName {
+    const fromKey = getEnvironmentFromApiKey(options.nvmApiKey)
+
+    if (options.environment && !environmentOptionDeprecationWarned) {
+      environmentOptionDeprecationWarned = true
+      const override =
+        fromKey && fromKey !== options.environment
+          ? ` It is ignored in favor of the environment derived from the API key ('${fromKey}').`
+          : ''
+      console.warn(
+        "[DEPRECATED] The 'environment' option is deprecated; the environment is now derived " +
+          `from the NVM API key prefix.${override} Remove the 'environment' option to silence this warning.`,
+      )
+    }
+
+    return fromKey ?? options.environment ?? 'custom'
   }
 
   /**

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -11,10 +11,15 @@ export type PaymentScheme = 'nvm'
 export interface PaymentOptions {
   /**
    * The Nevermined environment to connect to.
-   * If you are developing an agent it's recommended to use the "sandbox" environment.
-   * When deploying to live use the "live" environment.
+   *
+   * @deprecated The environment is now derived from the NVM API key prefix
+   * (`<prefix>:<jwt>`), so this option is no longer required. It is still
+   * accepted for backward compatibility and as a fallback when the key prefix
+   * is unrecognized (e.g. local/custom development), but when the prefix maps
+   * to a known environment the key wins and this option is ignored (a one-time
+   * deprecation warning is emitted). It will be removed in a future release.
    */
-  environment: EnvironmentName
+  environment?: EnvironmentName
 
   /**
    * The Nevermined API Key. This key identify your user and is required to interact with the Nevermined API.

--- a/src/environments.ts
+++ b/src/environments.ts
@@ -18,6 +18,34 @@ export const ZeroAddress = '0x0000000000000000000000000000000000000000'
 export type EnvironmentName = 'staging_sandbox' | 'staging_live' | 'sandbox' | 'live' | 'custom'
 
 /**
+ * Maps the prefix of an NVM API key (`<prefix>:<jwt>`) to the environment the
+ * key targets. This is the inverse of the backend's `addPrefixToToken`: a key
+ * minted for `staging_sandbox` carries the prefix `sandbox-staging`, i.e.
+ * `{env}-{deployment}` on the wire maps to `{deployment}_{env}` here.
+ *
+ * @param nvmApiKey - The full NVM API key (`<prefix>:<jwt>`), or a bare JWT.
+ * @returns The mapped {@link EnvironmentName}, or `undefined` when the key has
+ *   no prefix or the prefix is not recognized (caller falls back to the
+ *   deprecated `environment` option, else `custom`).
+ */
+export const getEnvironmentFromApiKey = (nvmApiKey: string): EnvironmentName | undefined => {
+  if (!nvmApiKey || !nvmApiKey.includes(':')) return undefined
+  const prefix = nvmApiKey.slice(0, nvmApiKey.indexOf(':'))
+  switch (prefix) {
+    case 'sandbox-staging':
+      return 'staging_sandbox'
+    case 'live-staging':
+      return 'staging_live'
+    case 'sandbox':
+      return 'sandbox'
+    case 'live':
+      return 'live'
+    default:
+      return undefined
+  }
+}
+
+/**
  * Represents the different environments and their corresponding URLs.
  */
 export const Environments: Record<EnvironmentName, EnvironmentInfo> = {

--- a/src/environments.ts
+++ b/src/environments.ts
@@ -30,7 +30,10 @@ export type EnvironmentName = 'staging_sandbox' | 'staging_live' | 'sandbox' | '
  */
 export const getEnvironmentFromApiKey = (nvmApiKey: string): EnvironmentName | undefined => {
   if (!nvmApiKey || !nvmApiKey.includes(':')) return undefined
-  const prefix = nvmApiKey.slice(0, nvmApiKey.indexOf(':'))
+  // Backend-minted prefixes are always lowercase; lowercasing keeps this in
+  // exact parity with the payments-py sibling and tolerates a non-canonical
+  // uppercase prefix.
+  const prefix = nvmApiKey.slice(0, nvmApiKey.indexOf(':')).toLowerCase()
   switch (prefix) {
     case 'sandbox-staging':
       return 'staging_sandbox'

--- a/tests/unit/environment-from-key-prefix.test.ts
+++ b/tests/unit/environment-from-key-prefix.test.ts
@@ -39,6 +39,11 @@ describe('getEnvironmentFromApiKey', () => {
     expect(getEnvironmentFromApiKey(keyWithPrefix(prefix))).toBe(expected)
   })
 
+  test('matches the prefix case-insensitively (parity with the py sibling)', () => {
+    expect(getEnvironmentFromApiKey(keyWithPrefix('Sandbox-Staging'))).toBe('staging_sandbox')
+    expect(getEnvironmentFromApiKey(keyWithPrefix('LIVE'))).toBe('live')
+  })
+
   test('returns undefined for a key without a prefix (bare JWT)', () => {
     expect(getEnvironmentFromApiKey(JWT)).toBeUndefined()
   })

--- a/tests/unit/environment-from-key-prefix.test.ts
+++ b/tests/unit/environment-from-key-prefix.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for deriving the environment from the NVM API key prefix
+ * (`<prefix>:<jwt>`) and the deprecation of the `environment` init option
+ * (nevermined-io/payments#399, part of nvm-monorepo#2004).
+ *
+ * Settled mapping (inverse of the backend `addPrefixToToken`):
+ *   sandbox-staging -> staging_sandbox
+ *   live-staging    -> staging_live
+ *   sandbox         -> sandbox
+ *   live            -> live
+ *   (other / none)  -> fall back to the `environment` option, else `custom`
+ *
+ * The key wins over the option; passing `environment` emits a single
+ * deprecation warning. Each test re-imports the modules so the module-level
+ * "warned once" flag starts fresh.
+ */
+
+// A decodable JWT body (carries `sub`/`o11y`) reused across keys; only the
+// environment prefix differs. Mirrors the shared test fixture JWT.
+const JWT =
+  'eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweDU4MzhCNTUxMmNGOWYxMkZFOWYyYmVjY0IyMGViNDcyMTFGOUIwYmMiLCJzdWIiOiIweDIxRjc5ZjlkM2I2ZDUyZUY4Y2M4QjFhN0YyNjFCY2Y1ZjJFRjM1NGEiLCJqdGkiOiIweGUxMjIwMmRkMzZlZmQ4N2FkMjE1MmRlMjlkM2MwNmE5ZDU5N2M4NWJhOGMxOTQ1YjQ5MjlkYTYyYTRiZjQ1NGYiLCJleHAiOjE3OTEwNDc0OTcsIm8xMXkiOiJzay1oZWxpY29uZS13amUzYXdpLW5ud2V5M2EtdzdndnY3YS1oYmh3bm1pIn0.JI14qfSWHCWRvHOK9TAg3HEXWX7oKEI6fU6gaaWlyDl5btBWLh8FQo1ZnuzixPmgsUR3gc4oRlenLPUuTy-mORw'
+
+const keyWithPrefix = (prefix: string): string => `${prefix}:${JWT}`
+
+describe('getEnvironmentFromApiKey', () => {
+  let getEnvironmentFromApiKey: (key: string) => string | undefined
+
+  beforeEach(async () => {
+    jest.resetModules()
+    ;({ getEnvironmentFromApiKey } = await import('../../src/environments.js'))
+  })
+
+  test.each([
+    ['sandbox-staging', 'staging_sandbox'],
+    ['live-staging', 'staging_live'],
+    ['sandbox', 'sandbox'],
+    ['live', 'live'],
+  ])('maps prefix %s -> %s', (prefix, expected) => {
+    expect(getEnvironmentFromApiKey(keyWithPrefix(prefix))).toBe(expected)
+  })
+
+  test('returns undefined for a key without a prefix (bare JWT)', () => {
+    expect(getEnvironmentFromApiKey(JWT)).toBeUndefined()
+  })
+
+  test('returns undefined for an unrecognized prefix', () => {
+    expect(getEnvironmentFromApiKey(keyWithPrefix('local'))).toBeUndefined()
+  })
+
+  test('returns undefined for an empty key', () => {
+    expect(getEnvironmentFromApiKey('')).toBeUndefined()
+  })
+})
+
+describe('environment resolution at Payments.getInstance', () => {
+  let warnSpy: jest.SpyInstance
+  let Payments: typeof import('../../src/payments.js').Payments
+
+  beforeEach(async () => {
+    jest.resetModules()
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+    ;({ Payments } = await import('../../src/payments.js'))
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  const deprecationWarnings = (): string[] =>
+    warnSpy.mock.calls.map((args) => String(args[0])).filter((msg) => msg.includes('[DEPRECATED]'))
+
+  test('derives the environment from the key prefix when no option is passed', () => {
+    const payments = Payments.getInstance({ nvmApiKey: keyWithPrefix('sandbox-staging') })
+    expect(payments.getEnvironmentName()).toBe('staging_sandbox')
+    expect(deprecationWarnings()).toHaveLength(0)
+  })
+
+  test('key prefix wins over a conflicting environment option', () => {
+    const payments = Payments.getInstance({
+      nvmApiKey: keyWithPrefix('live'),
+      environment: 'staging_sandbox',
+    })
+    expect(payments.getEnvironmentName()).toBe('live')
+  })
+
+  test('passing environment emits a single deprecation warning', () => {
+    Payments.getInstance({
+      nvmApiKey: keyWithPrefix('sandbox-staging'),
+      environment: 'staging_sandbox',
+    })
+    // getInstance constructs several sub-API instances from the same options,
+    // but the warning must fire at most once per process.
+    expect(deprecationWarnings()).toHaveLength(1)
+    expect(deprecationWarnings()[0]).toMatch(/environment.*derived.*API key/i)
+  })
+
+  test('falls back to the environment option for an unrecognized key prefix', () => {
+    const payments = Payments.getInstance({
+      nvmApiKey: keyWithPrefix('local'),
+      environment: 'custom',
+    })
+    expect(payments.getEnvironmentName()).toBe('custom')
+    // The option was used (fallback), so the deprecation warning still fires.
+    expect(deprecationWarnings()).toHaveLength(1)
+  })
+
+  test('falls back to custom when neither key prefix nor option resolves', () => {
+    const payments = Payments.getInstance({ nvmApiKey: keyWithPrefix('local') })
+    expect(payments.getEnvironmentName()).toBe('custom')
+    expect(deprecationWarnings()).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Description

NVM API keys are prefixed with the environment they target (`<prefix>:<jwt>`, e.g. `sandbox-staging:eyJ…`), so the SDK now resolves the environment from the key instead of requiring the `environment` init option.

**Non-breaking** — `environment` is still accepted (now optional + `@deprecated`); existing callers compile and run unchanged, they just see a one-time deprecation warning.

### Behavior
1. The environment is derived from the API-key prefix and the **key always wins** when its prefix is recognized.
2. `environment` is now optional with an `@deprecated` JSDoc tag.
3. Passing `environment` emits a single `[DEPRECATED]` `console.warn` (once per process, matching the SDK's existing deprecation pattern in `a2a/server.ts`).
4. Unrecognized/local key prefix → falls back to the provided `environment`, then to `custom` — local/custom-backend workflows are unaffected.

### Settled prefix → environment mapping
Inverse of the backend `addPrefixToToken` (`{env}-{deployment}` on the wire → `{deployment}_{env}`):

| Key prefix | EnvironmentName |
|------------|-----------------|
| `sandbox-staging` | `staging_sandbox` |
| `live-staging` | `staging_live` |
| `sandbox` | `sandbox` |
| `live` | `live` |
| other / none | fall back to `environment` option, else `custom` |

Verified against real code (not guessed): the TS test fixtures use `sandbox-staging:…` keys, and the Python sibling (`payments-py base_payments.py`) already requires the `prefix:jwt` split — so the mapping agrees with the actual key format. The existing whole-string `decodeJwt` in `parseNvmApiKey` is left untouched (jose decodes the JWT payload correctly regardless of the prefix).

### Files
- `src/environments.ts` — new `getEnvironmentFromApiKey()` helper.
- `src/api/base-payments.ts` — `resolveEnvironmentName()` in the base constructor (single chokepoint for all sub-APIs); once-per-process deprecation warning.
- `src/common/types.ts` — `environment?` optional + `@deprecated`.
- `markdown/initializing-the-library.md` — corrected the "(required)" claim, added an **Environment derivation** section. (The docs-site api-reference is generated from `markdown/`; not hand-edited.)
- `tests/unit/environment-from-key-prefix.test.ts` — 12 cases (mapping + resolution + deprecation-warning-once + fallbacks).

### Validation
- `pnpm build` clean, `pnpm lint` clean (2 pre-existing tsdoc warnings, not in changed files).
- Full unit suite green: 31 suites, 315 passed / 1 skipped.

## Is this PR related with an open issue?

Related to Issue nevermined-io/payments#399

Closes #399
Part of nevermined-io/nvm-monorepo#2004

> Sibling (identical change in `payments-py`): nevermined-io/payments-py#242 (separate task).

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)