### PR TITLE
fix(cli): rename binary from `nvm` to `nevermined` (#388)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,7 @@ E2E tests run directly against the **staging environment**. When making changes:
 This repo contains two in-tree consumers of the SDK that import directly from `src/`:
 
 - **`openclaw/`** — OpenClaw plugin for LLM tool-use (tools, auto-pay, MCP bridge). CI: `.github/workflows/openclaw-sync-and-test.yml`
-- **`cli/`** — CLI tool (`nvm` command). CI: `.github/workflows/cli-sync-and-test.yml`
+- **`cli/`** — CLI tool (`nevermined` command). CI: `.github/workflows/cli-sync-and-test.yml`
 
 **CRITICAL:** When changing public SDK interfaces (function signatures, types, options), you MUST also update `openclaw/` and `cli/` source files, tests, and mocks. The openclaw and CLI CI workflows build and test independently — they will fail if call sites don't match the new signatures.
 

--- a/cli/CLI_GUIDE.md
+++ b/cli/CLI_GUIDE.md
@@ -40,7 +40,7 @@ yarn build:manifest
 ### 1. Initialize Configuration
 
 ```bash
-nvm config init
+nevermined config init
 ```
 
 This will prompt you for:
@@ -51,19 +51,19 @@ This will prompt you for:
 ### 2. List Available Plans
 
 ```bash
-nvm plans get-plans
+nevermined plans get-plans
 ```
 
 ### 3. Get Plan Details
 
 ```bash
-nvm plans get-plan <plan-id>
+nevermined plans get-plan <plan-id>
 ```
 
 ### 4. Check Your Balance
 
 ```bash
-nvm plans get-plan-balance <plan-id>
+nevermined plans get-plan-balance <plan-id>
 ```
 
 ## Configuration
@@ -101,10 +101,10 @@ export NVM_ENVIRONMENT=sandbox
 
 ```bash
 # Use specific profile
-nvm --profile production plans get-plans
+nevermined --profile production plans get-plans
 
 # Set active profile
-nvm config set activeProfile production
+nevermined config set activeProfile production
 ```
 
 ## Commands
@@ -112,47 +112,47 @@ nvm config set activeProfile production
 ### Config Commands
 
 ```bash
-nvm config init               # Initialize configuration
-nvm config show               # Display current configuration
-nvm config set <key> <value>  # Set configuration value
+nevermined config init               # Initialize configuration
+nevermined config show               # Display current configuration
+nevermined config set <key> <value>  # Set configuration value
 ```
 
 ### Plans Commands
 
 ```bash
 # List all plans
-nvm plans get-plans [--format json]
+nevermined plans get-plans [--format json]
 
 # Get plan details
-nvm plans get-plan <plan-id>
+nevermined plans get-plan <plan-id>
 
 # Get plan balance
-nvm plans get-plan-balance <plan-id> [--account-address <address>]
+nevermined plans get-plan-balance <plan-id> [--account-address <address>]
 
 # Register a credits plan
-nvm plans register-credits-plan \
+nevermined plans register-credits-plan \
   --plan-metadata metadata.json \
   --price-config price.json \
   --credits-config credits.json
 
 # Order a plan
-nvm plans order-plan <plan-id>
+nevermined plans order-plan <plan-id>
 ```
 
 ### Agents Commands
 
 ```bash
 # Get agent details
-nvm agents get-agent <agent-id>
+nevermined agents get-agent <agent-id>
 
 # Register an agent
-nvm agents register-agent \
+nevermined agents register-agent \
   --agent-metadata '{"name": "My Agent", "description": "AI Assistant"}' \
   --agent-api "https://api.example.com" \
   --payment-plans "plan-id-1,plan-id-2"
 
 # Update agent metadata
-nvm agents update-agent-metadata <agent-id> \
+nevermined agents update-agent-metadata <agent-id> \
   --agent-metadata updated-metadata.json
 ```
 
@@ -160,37 +160,37 @@ nvm agents update-agent-metadata <agent-id> \
 
 ```bash
 # Get X402 access token (crypto, default)
-nvm x402token get-x402-access-token <plan-id>
+nevermined x402token get-x402-access-token <plan-id>
 
 # Get X402 access token (fiat/card-delegation, auto-selects first enrolled card)
-nvm x402token get-x402-access-token <plan-id> --payment-type fiat
+nevermined x402token get-x402-access-token <plan-id> --payment-type fiat
 
 # Get X402 access token (fiat with specific card and limits)
-nvm x402token get-x402-access-token <plan-id> --payment-type fiat \
+nevermined x402token get-x402-access-token <plan-id> --payment-type fiat \
     --payment-method-id pm_1AbCdEfGhIjKlM \
     --spending-limit-cents 5000 \
     --delegation-duration-secs 7200
 
 # Auto-detect crypto vs fiat from plan metadata
-nvm x402token get-x402-access-token <plan-id> --auto-resolve-scheme
+nevermined x402token get-x402-access-token <plan-id> --auto-resolve-scheme
 ```
 
 ### Delegation Commands
 
 ```bash
 # List enrolled payment methods (credit/debit cards)
-nvm delegation list-payment-methods
+nevermined delegation list-payment-methods
 ```
 
 ### Facilitator Commands
 
 ```bash
 # Verify permissions
-nvm facilitator verify-permissions \
+nevermined facilitator verify-permissions \
   --verify-permissions-params params.json
 
 # Settle permissions
-nvm facilitator settle-permissions \
+nevermined facilitator settle-permissions \
   --settle-permissions-params params.json
 ```
 
@@ -198,11 +198,11 @@ nvm facilitator settle-permissions \
 
 ```bash
 # Create organization member
-nvm organizations create-member \
+nevermined organizations create-member \
   --member-data member.json
 
 # List members
-nvm organizations get-members
+nevermined organizations get-members
 ```
 
 ## Global Flags
@@ -221,19 +221,19 @@ All commands support these flags:
 **Table (default)**: Human-readable table output
 
 ```bash
-nvm plans get-plans
+nevermined plans get-plans
 ```
 
 **JSON**: Machine-readable JSON output
 
 ```bash
-nvm plans get-plans --format json
+nevermined plans get-plans --format json
 ```
 
 **Quiet**: Minimal output for scripting
 
 ```bash
-nvm plans get-plans --format quiet
+nevermined plans get-plans --format quiet
 ```
 
 ## Development
@@ -315,7 +315,7 @@ import { BaseCommand } from '../../base-command.js'
 export default class MyCommand extends BaseCommand {
   static override description = 'My command description'
 
-  static override examples = ['$ nvm mytopic mycommand <arg>']
+  static override examples = ['$ nevermined mytopic mycommand <arg>']
 
   static override flags = {
     ...BaseCommand.baseFlags,
@@ -466,7 +466,7 @@ yarn build:manifest
 Initialize configuration:
 
 ```bash
-nvm config init
+nevermined config init
 ```
 
 Or set environment variable:
@@ -498,7 +498,7 @@ yarn build
 Enable verbose output for debugging:
 
 ```bash
-nvm <command> --verbose
+nevermined <command> --verbose
 ```
 
 This shows:
@@ -511,13 +511,13 @@ This shows:
 
 ```bash
 # General help
-nvm --help
+nevermined --help
 
 # Topic help
-nvm plans --help
+nevermined plans --help
 
 # Command help
-nvm plans get-plan --help
+nevermined plans get-plan --help
 ```
 
 ## Best Practices
@@ -526,30 +526,30 @@ nvm plans get-plan --help
 
 ```bash
 # Development
-nvm --profile dev plans get-plans
+nevermined --profile dev plans get-plans
 
 # Production
-nvm --profile prod plans get-plans
+nevermined --profile prod plans get-plans
 ```
 
 ### 2. Use JSON Output for Scripting
 
 ```bash
 # Get plan and extract ID
-PLAN_ID=$(nvm plans get-plans --format json | jq -r '.plans[0].id')
+PLAN_ID=$(nevermined plans get-plans --format json | jq -r '.plans[0].id')
 ```
 
 ### 3. Use JSON Files for Complex Inputs
 
 ```bash
 # Instead of inline JSON
-nvm agents register-agent --agent-metadata metadata.json
+nevermined agents register-agent --agent-metadata metadata.json
 ```
 
 ### 4. Check Command Help First
 
 ```bash
-nvm <topic> <command> --help
+nevermined <topic> <command> --help
 ```
 
 ## Contributing

--- a/cli/CLI_IMPLEMENTATION.md
+++ b/cli/CLI_IMPLEMENTATION.md
@@ -2,7 +2,7 @@
 
 ## Status: Phase 1 Complete ✅
 
-The Nevermined Payments CLI (`nvm`) has been successfully implemented with core functionality and infrastructure in place.
+The Nevermined Payments CLI (`nevermined`) has been successfully implemented with core functionality and infrastructure in place.
 
 ## What's Been Implemented
 
@@ -65,42 +65,42 @@ cli/
 
 #### Configuration Commands
 
-- ✅ `nvm config init` - Initialize configuration
+- ✅ `nevermined config init` - Initialize configuration
   - Interactive mode with prompts
   - Flag-based mode (--api-key, --environment)
   - Profile support
-- ✅ `nvm config show` - Display configuration
+- ✅ `nevermined config show` - Display configuration
   - Show active profile
   - Show all profiles (--all flag)
-- ✅ `nvm config set <key> <value>` - Set configuration values
+- ✅ `nevermined config set <key> <value>` - Set configuration values
   - Validates environment values
   - Profile support
 
 #### Plans Commands
 
-- ✅ `nvm plans get-plans` - List all payment plans
+- ✅ `nevermined plans get-plans` - List all payment plans
   - Table output with key columns
   - JSON output support
   - Uses `payments.plans.getPlans()`
-- ✅ `nvm plans get-plan <planId>` - Get plan details
+- ✅ `nevermined plans get-plan <planId>` - Get plan details
   - Full plan object output
   - Uses `payments.plans.getPlan()`
-- ✅ `nvm plans register-plan` - Register plan (placeholder)
+- ✅ `nevermined plans register-plan` - Register plan (placeholder)
   - Directs to specialized commands
   - Supports --config for JSON input
 
 #### Agents Commands
 
-- ✅ `nvm agents list` - List agents (placeholder)
+- ✅ `nevermined agents list` - List agents (placeholder)
   - Provides guidance on using getAgent
-- ✅ `nvm agents get <agentId>` - Get agent details
+- ✅ `nevermined agents get <agentId>` - Get agent details
   - Uses `payments.agents.getAgent()`
-- ✅ `nvm agents register` - Register agent (placeholder)
+- ✅ `nevermined agents register` - Register agent (placeholder)
   - Supports --config for JSON input
 
 #### X402 Commands
 
-- ✅ `nvm x402 get-token <planId>` - Get X402 access token
+- ✅ `nevermined x402 get-token <planId>` - Get X402 access token
   - Uses `payments.x402.getX402AccessToken()`
   - Formatted output with usage instructions
 
@@ -185,13 +185,13 @@ cli/
 
 #### Phase 2: Additional Manual Commands
 
-- `nvm plans register-credits` - Credits-based plans
-- `nvm plans register-time` - Time-based plans
-- `nvm plans get-plan-balance <planId>` - Check plan balance
-- `nvm plans order <planId>` - Order a plan
-- `nvm x402 verify` - Verify permissions
-- `nvm x402 settle` - Settle permissions
-- `nvm organizations list-members` - List org members
+- `nevermined plans register-credits` - Credits-based plans
+- `nevermined plans register-time` - Time-based plans
+- `nevermined plans get-plan-balance <planId>` - Check plan balance
+- `nevermined plans order <planId>` - Order a plan
+- `nevermined x402 verify` - Verify permissions
+- `nevermined x402 settle` - Settle permissions
+- `nevermined organizations list-members` - List org members
 
 #### Phase 3: Auto-generation System
 
@@ -254,39 +254,39 @@ cli/
 npm install -g @nevermined-io/cli
 
 # 2. Configure
-nvm config init
+nevermined config init
 
 # 3. List plans
-nvm plans get-plans
+nevermined plans get-plans
 
 # 4. Get plan details
-nvm plans get-plan did:nvm:abc123
+nevermined plans get-plan did:nvm:abc123
 
 # 5. Get access token
-nvm x402 get-token did:nvm:abc123
+nevermined x402 get-token did:nvm:abc123
 ```
 
 ### Using Profiles
 
 ```bash
 # Create production profile
-nvm config init --profile production
+nevermined config init --profile production
 
 # Use specific profile
-nvm plans get-plans --profile production
+nevermined plans get-plans --profile production
 
 # View all profiles
-nvm config show --all
+nevermined config show --all
 ```
 
 ### JSON Output
 
 ```bash
 # For scripting
-nvm plans get-plans --format json | jq '.[] | .did'
+nevermined plans get-plans --format json | jq '.[] | .did'
 
 # Quiet mode
-if nvm x402 get-token did:nvm:abc123 --format quiet; then
+if nevermined x402 get-token did:nvm:abc123 --format quiet; then
   echo "Success"
 fi
 ```

--- a/cli/CLI_SUMMARY.md
+++ b/cli/CLI_SUMMARY.md
@@ -70,32 +70,32 @@ cli/
 #### Configuration Commands (3)
 
 ```bash
-nvm config init               # Initialize configuration
-nvm config show               # Display configuration
-nvm config set <key> <value>  # Set configuration value
+nevermined config init               # Initialize configuration
+nevermined config show               # Display configuration
+nevermined config set <key> <value>  # Set configuration value
 ```
 
 #### Plans Commands (4)
 
 ```bash
-nvm plans get-plans                # List all plans
-nvm plans get <planId>        # Get plan details
-nvm plans balance <planId>    # Check plan balance
-nvm plans register            # Register plan (placeholder)
+nevermined plans get-plans                # List all plans
+nevermined plans get <planId>        # Get plan details
+nevermined plans balance <planId>    # Check plan balance
+nevermined plans register            # Register plan (placeholder)
 ```
 
 #### Agents Commands (3)
 
 ```bash
-nvm agents list               # List agents (placeholder)
-nvm agents get <agentId>      # Get agent details
-nvm agents register           # Register agent (placeholder)
+nevermined agents list               # List agents (placeholder)
+nevermined agents get <agentId>      # Get agent details
+nevermined agents register           # Register agent (placeholder)
 ```
 
 #### X402 Commands (1)
 
 ```bash
-nvm x402 get-token <planId>   # Get X402 access token
+nevermined x402 get-token <planId>   # Get X402 access token
 ```
 
 ## Testing Results

--- a/cli/CLI_USAGE.md
+++ b/cli/CLI_USAGE.md
@@ -15,7 +15,7 @@ yarn build
 
 ```bash
 npm install -g @nevermined-io/cli
-nvm --help
+nevermined --help
 ```
 
 ### Option 3: Via npx (No Installation)

--- a/cli/README.md
+++ b/cli/README.md
@@ -31,7 +31,7 @@ pnpm build
 ### 1. Initialize Configuration
 
 ```bash
-nvm config init
+nevermined config init
 ```
 
 This will prompt you for:
@@ -44,25 +44,25 @@ Configuration is saved to `~/.config/nvm/config.json`.
 ### 2. List Plans
 
 ```bash
-nvm plans get-plans
+nevermined plans get-plans
 ```
 
 ### 3. Get Plan Details
 
 ```bash
-nvm plans get-plan did:nvm:abc123
+nevermined plans get-plan did:nvm:abc123
 ```
 
 ### 4. Get X402 Access Token
 
 ```bash
-nvm x402token get-x402-access-token did:nvm:plan123
+nevermined x402token get-x402-access-token did:nvm:plan123
 ```
 
 ## Usage
 
 ```
-nvm [COMMAND]
+nevermined [COMMAND]
 
 TOPICS
   agents   Manage AI agents
@@ -71,14 +71,14 @@ TOPICS
   x402     X402 protocol operations
 
 COMMANDS
-  help     Display help for nvm
+  help     Display help for nevermined
 ```
 
 ## Configuration
 
 ### Using Environment Variables
 
-Instead of `nvm config init`, you can set environment variables:
+Instead of `nevermined config init`, you can set environment variables:
 
 ```bash
 export NVM_API_KEY=nvm-your-api-key
@@ -91,13 +91,13 @@ Support for multiple profiles:
 
 ```bash
 # Initialize a production profile
-nvm config init --profile production
+nevermined config init --profile production
 
 # Use a specific profile
-nvm plans get-plans --profile production
+nevermined plans get-plans --profile production
 
 # Show all profiles
-nvm config show --all
+nevermined config show --all
 ```
 
 ## Output Formats
@@ -106,47 +106,47 @@ All commands support multiple output formats:
 
 ```bash
 # Table format (default)
-nvm plans get-plans
+nevermined plans get-plans
 
 # JSON format
-nvm plans get-plans --format json
+nevermined plans get-plans --format json
 
 # Quiet mode (no output, useful for scripts)
-nvm plans get-plans --format quiet
+nevermined plans get-plans --format quiet
 ```
 
 ## Commands
 
 ### Configuration Commands
 
-- `nvm config init` - Initialize CLI configuration
-- `nvm config show` - Display current configuration
-- `nvm config set <key> <value>` - Set a configuration value
+- `nevermined config init` - Initialize CLI configuration
+- `nevermined config show` - Display current configuration
+- `nevermined config set <key> <value>` - Set a configuration value
 
 ### Plan Commands
 
-- `nvm plans get-plans` - List all payment plans
-- `nvm plans get-plan <planId>` - Get details of a specific plan
-- `nvm plans get-plan-balance <planId>` - Get plan balance for a subscriber
-- `nvm plans register-plan` - Register a new payment plan (flexible)
-- `nvm plans register-credits-plan` - Register a credits-based plan
-- `nvm plans register-time-plan` - Register a time-based plan
-- `nvm plans register-credits-trial-plan` - Register a trial credits plan
-- `nvm plans register-time-trial-plan` - Register a trial time plan
+- `nevermined plans get-plans` - List all payment plans
+- `nevermined plans get-plan <planId>` - Get details of a specific plan
+- `nevermined plans get-plan-balance <planId>` - Get plan balance for a subscriber
+- `nevermined plans register-plan` - Register a new payment plan (flexible)
+- `nevermined plans register-credits-plan` - Register a credits-based plan
+- `nevermined plans register-time-plan` - Register a time-based plan
+- `nevermined plans register-credits-trial-plan` - Register a trial credits plan
+- `nevermined plans register-time-trial-plan` - Register a trial time plan
 
 ### Agent Commands
 
-- `nvm agents get-agent <agentId>` - Get details of a specific agent
-- `nvm agents get-agent-plans <agentId>` - Get plans associated with an agent
-- `nvm agents register-agent` - Register a new AI agent
-- `nvm agents register-agent-and-plan` - Register an agent with a plan
-- `nvm agents add-plan-to-agent <planId>` - Associate a plan with an agent
-- `nvm agents remove-plan-from-agent <planId>` - Remove a plan from an agent
-- `nvm agents update-agent-metadata <agentId>` - Update agent metadata
+- `nevermined agents get-agent <agentId>` - Get details of a specific agent
+- `nevermined agents get-agent-plans <agentId>` - Get plans associated with an agent
+- `nevermined agents register-agent` - Register a new AI agent
+- `nevermined agents register-agent-and-plan` - Register an agent with a plan
+- `nevermined agents add-plan-to-agent <planId>` - Associate a plan with an agent
+- `nevermined agents remove-plan-from-agent <planId>` - Remove a plan from an agent
+- `nevermined agents update-agent-metadata <agentId>` - Update agent metadata
 
 ### X402 Commands
 
-- `nvm x402token get-x402-access-token <planId>` - Get an X402 access token for a plan
+- `nevermined x402token get-x402-access-token <planId>` - Get an X402 access token for a plan
 
 ## Examples
 
@@ -154,23 +154,23 @@ nvm plans get-plans --format quiet
 
 ```bash
 # Initialize config
-nvm config init
+nevermined config init
 
 # Get X402 token for a plan
-nvm x402token get-x402-access-token did:nvm:abc123 --format json
+nevermined x402token get-x402-access-token did:nvm:abc123 --format json
 
 # Get plan details
-nvm plans get-plan did:nvm:abc123
+nevermined plans get-plan did:nvm:abc123
 ```
 
 ### Using JSON Config Files
 
 ```bash
 # Register plan from JSON config
-nvm plans register-plan --config plan-config.json
+nevermined plans register-plan --config plan-config.json
 
 # Register agent from JSON config
-nvm agents register-agent did:nvm:plan123 --config agent-config.json
+nevermined agents register-agent did:nvm:plan123 --config agent-config.json
 ```
 
 ## Development

--- a/cli/docs/ID_FORMAT_UPDATE.md
+++ b/cli/docs/ID_FORMAT_UPDATE.md
@@ -32,23 +32,23 @@ Plan IDs and Agent IDs are returned as large numeric strings (BigInt format):
 ### Plans Documentation
 **Before**:
 ```bash
-nvm plans get-plan did:nvm:abc123
+nevermined plans get-plan did:nvm:abc123
 ```
 
 **After**:
 ```bash
-nvm plans get-plan "123456789012345678"
+nevermined plans get-plan "123456789012345678"
 ```
 
 ### Agents Documentation
 **Before**:
 ```bash
-nvm agents get-agent did:nvm:agent123
+nevermined agents get-agent did:nvm:agent123
 ```
 
 **After**:
 ```bash
-nvm agents get-agent "987654321098765432"
+nevermined agents get-agent "987654321098765432"
 ```
 
 ### Variable Assignments

--- a/cli/docs/README.md
+++ b/cli/docs/README.md
@@ -1,6 +1,6 @@
 # Nevermined Payments CLI Documentation
 
-Complete documentation for the Nevermined Payments CLI (`nvm`).
+Complete documentation for the Nevermined Payments CLI (`nevermined`).
 
 ## Overview
 
@@ -95,57 +95,57 @@ npx @nevermined-io/cli --help
 
 ```bash
 # Authenticate via browser (recommended)
-nvm login
+nevermined login
 
 # Or initialize configuration manually
-nvm config init
+nevermined config init
 
 # List available plans
-nvm plans get-plans
+nevermined plans get-plans
 
 # Get plan details
-nvm plans get-plan <plan-id>
+nevermined plans get-plan <plan-id>
 
 # Order a plan
-nvm plans order-plan <plan-id>
+nevermined plans order-plan <plan-id>
 
 # Get access token
-nvm x402token get-x402-access-token <plan-id>
+nevermined x402token get-x402-access-token <plan-id>
 ```
 
 ### Common Commands
 
 ```bash
 # Authentication
-nvm login                    # Authenticate via browser
-nvm logout                   # Remove API key from config
+nevermined login                    # Authenticate via browser
+nevermined logout                   # Remove API key from config
 
 # Configuration
-nvm config init              # Initialize configuration
-nvm config show              # Display current config
-nvm config set <key> <value> # Update configuration
+nevermined config init              # Initialize configuration
+nevermined config show              # Display current config
+nevermined config set <key> <value> # Update configuration
 
 # Plans
-nvm plans get-plans                          # List all plans
-nvm plans get-plan <plan-id>            # Get plan details
-nvm plans get-plan-balance <plan-id>    # Check balance
-nvm plans order-plan <plan-id>          # Purchase plan
+nevermined plans get-plans                          # List all plans
+nevermined plans get-plan <plan-id>            # Get plan details
+nevermined plans get-plan-balance <plan-id>    # Check balance
+nevermined plans order-plan <plan-id>          # Purchase plan
 
 # Agents
-nvm agents get-agent <agent-id>         # Get agent details
-nvm agents get-agent-plans <agent-id>   # List agent's plans
-nvm agents register-agent \             # Register new agent
+nevermined agents get-agent <agent-id>         # Get agent details
+nevermined agents get-agent-plans <agent-id>   # List agent's plans
+nevermined agents register-agent \             # Register new agent
   --agent-metadata metadata.json \
   --agent-api "https://api.example.com" \
   --payment-plans "plan-id-1,plan-id-2"
 
 # X402 Tokens
-nvm x402token get-x402-access-token <plan-id>  # Get access token
+nevermined x402token get-x402-access-token <plan-id>  # Get access token
 
 # Organizations
-nvm organizations get-members                          # List members
-nvm organizations create-member <user-id>              # Add member
-nvm organizations connect-stripe-account \             # Connect Stripe
+nevermined organizations get-members                          # List members
+nevermined organizations create-member <user-id>              # Add member
+nevermined organizations connect-stripe-account \             # Connect Stripe
   --user-email "user@example.com" \
   --user-country-code "US" \
   --return-url "https://yourapp.com/callback"
@@ -167,7 +167,7 @@ All commands support these global flags:
 Human-readable table output for interactive use:
 
 ```bash
-nvm plans get-plans
+nevermined plans get-plans
 ```
 
 ### JSON
@@ -175,7 +175,7 @@ nvm plans get-plans
 Machine-readable JSON for scripting:
 
 ```bash
-nvm plans get-plans --format json
+nevermined plans get-plans --format json
 ```
 
 ### Quiet
@@ -183,7 +183,7 @@ nvm plans get-plans --format json
 Minimal output for automation:
 
 ```bash
-nvm plans get-plans --format quiet
+nevermined plans get-plans --format quiet
 ```
 
 ## Configuration Profiles
@@ -192,14 +192,14 @@ Use profiles to manage multiple environments:
 
 ```bash
 # Create production profile
-nvm config set profiles.production.nvmApiKey live:eyJxxxxaaaabbbbbbbb
-nvm config set profiles.production.environment live
+nevermined config set profiles.production.nvmApiKey live:eyJxxxxaaaabbbbbbbb
+nevermined config set profiles.production.environment live
 
 # Use production profile
-nvm --profile production plans get-plans
+nevermined --profile production plans get-plans
 
 # Switch active profile
-nvm config set activeProfile production
+nevermined config set activeProfile production
 ```
 
 ## Environment Guide
@@ -218,23 +218,23 @@ nvm config set activeProfile production
 # Complete workflow: Setup -> Purchase -> Query
 
 # 1. Initialize configuration
-nvm config init
+nevermined config init
 
 # 2. List available plans
-nvm plans get-plans
+nevermined plans get-plans
 
 # 3. Get plan details
 PLAN_ID="123456789012345678"
-nvm plans get-plan $PLAN_ID
+nevermined plans get-plan $PLAN_ID
 
 # 4. Purchase plan
-nvm plans order-plan $PLAN_ID
+nevermined plans order-plan $PLAN_ID
 
 # 5. Check balance
-nvm plans get-plan-balance $PLAN_ID
+nevermined plans get-plan-balance $PLAN_ID
 
 # 6. Get access token
-TOKEN=$(nvm x402token get-x402-access-token $PLAN_ID --format json | jq -r '.token')
+TOKEN=$(nevermined x402token get-x402-access-token $PLAN_ID --format json | jq -r '.token')
 
 # 7. Query agent
 curl -H "payment-signature: $TOKEN" https://agent-api.example.com/query
@@ -247,21 +247,21 @@ curl -H "payment-signature: $TOKEN" https://agent-api.example.com/query
 # Register an AI agent with payment plan
 
 # 1. Create payment plan
-PLAN_ID=$(nvm plans register-credits-plan \
+PLAN_ID=$(nevermined plans register-credits-plan \
   --plan-metadata plan.json \
   --price-config price.json \
   --credits-config credits.json \
   --format json | jq -r '.planId')
 
 # 2. Register agent with plan
-AGENT_ID=$(nvm agents register-agent \
+AGENT_ID=$(nevermined agents register-agent \
   --agent-metadata agent.json \
   --agent-api "https://api.example.com" \
   --payment-plans "$PLAN_ID" \
   --format json | jq -r '.agentId')
 
 # 3. Verify agent is accessible
-nvm agents get-agent $AGENT_ID
+nevermined agents get-agent $AGENT_ID
 ```
 
 ## Getting Help
@@ -270,14 +270,14 @@ nvm agents get-agent $AGENT_ID
 
 ```bash
 # General help
-nvm --help
+nevermined --help
 
 # Topic help
-nvm plans --help
-nvm agents --help
+nevermined plans --help
+nevermined agents --help
 
 # Command help
-nvm plans get-plan --help
+nevermined plans get-plan --help
 ```
 
 ### Documentation
@@ -303,7 +303,7 @@ The CLI is designed for automation:
 0 */6 * * * /path/to/check-credits.sh
 
 # CI/CD integration
-- run: nvm agents register-agent --agent-metadata agent.json
+- run: nevermined agents register-agent --agent-metadata agent.json
 ```
 
 ### Scripting
@@ -312,12 +312,12 @@ Use JSON output for scripting:
 
 ```bash
 # Extract data with jq
-BALANCE=$(nvm plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
+BALANCE=$(nevermined plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
 
 # Loop over plans
-PLANS=$(nvm plans get-plans --format json | jq -r '.[].id')
+PLANS=$(nevermined plans get-plans --format json | jq -r '.[].id')
 for PLAN in $PLANS; do
-  nvm plans get-plan $PLAN
+  nevermined plans get-plan $PLAN
 done
 ```
 
@@ -327,10 +327,10 @@ Integrate with other tools:
 
 ```bash
 # Export to CSV
-nvm plans get-plans --format json | jq -r '.[] | [.id, .name, .price] | @csv' > plans.csv
+nevermined plans get-plans --format json | jq -r '.[] | [.id, .name, .price] | @csv' > plans.csv
 
 # Send to monitoring
-BALANCE=$(nvm plans get-plan-balance $PLAN_ID --format json)
+BALANCE=$(nevermined plans get-plan-balance $PLAN_ID --format json)
 curl -X POST monitoring-api.com/metrics -d "$BALANCE"
 ```
 
@@ -352,10 +352,10 @@ npm install -g @nevermined-io/cli
 
 ```bash
 # Browser login (recommended)
-nvm login
+nevermined login
 
 # Or initialize configuration manually
-nvm config init
+nevermined config init
 
 # Or set environment variable
 export NVM_API_KEY=your-api-key
@@ -391,7 +391,7 @@ Current version: 1.0.2
 Check your version:
 
 ```bash
-nvm --version
+nevermined --version
 ```
 
 Update to latest:

--- a/cli/docs/TESTING_NPM.md
+++ b/cli/docs/TESTING_NPM.md
@@ -45,7 +45,7 @@ $ npm list -g @nevermined-io/cli
 
 ### 1. Version Command
 
-**Command**: `nvm --version`
+**Command**: `nevermined --version`
 
 **Output**:
 ```
@@ -59,7 +59,7 @@ $ npm list -g @nevermined-io/cli
 
 ### 2. Main Help Command
 
-**Command**: `nvm --help`
+**Command**: `nevermined --help`
 
 **Output**:
 ```
@@ -69,7 +69,7 @@ VERSION
   @nevermined-io/cli/1.0.3-rc2 linux-x64 node-v24.10.0
 
 USAGE
-  $ nvm [COMMAND]
+  $ nevermined [COMMAND]
 
 TOPICS
   agents        Manage AI agents
@@ -81,7 +81,7 @@ TOPICS
   x402token     Create a permission and get an X402 access token...
 
 COMMANDS
-  help     Display help for nvm.
+  help     Display help for nevermined.
   plugins  List installed plugins.
 ```
 
@@ -94,14 +94,14 @@ COMMANDS
 
 #### 3.1 Config Help
 
-**Command**: `nvm config --help`
+**Command**: `nevermined config --help`
 
 **Output**:
 ```
 Manage CLI configuration
 
 USAGE
-  $ nvm config COMMAND
+  $ nevermined config COMMAND
 
 COMMANDS
   config init  Initialize CLI configuration
@@ -114,7 +114,7 @@ COMMANDS
 
 #### 3.2 Config Show
 
-**Command**: `nvm config show`
+**Command**: `nevermined config show`
 
 **Output**:
 ```
@@ -139,14 +139,14 @@ COMMANDS
 
 #### 4.1 Plans Help
 
-**Command**: `nvm plans --help`
+**Command**: `nevermined plans --help`
 
 **Output**:
 ```
 Manage payment plans
 
 USAGE
-  $ nvm plans COMMAND
+  $ nevermined plans COMMAND
 
 COMMANDS
   plans get-agents-associated-to-a-plan
@@ -168,14 +168,14 @@ COMMANDS
 
 #### 4.2 Get Plan Command Help
 
-**Command**: `nvm plans get-plan --help`
+**Command**: `nevermined plans get-plan --help`
 
 **Output**:
 ```
 Gets the information about a Payment Plan by its identifier.
 
 USAGE
-  $ nvm plans get-plan PLAN [-p <value>] [-f table|json|quiet] [-v]
+  $ nevermined plans get-plan PLAN [-p <value>] [-f table|json|quiet] [-v]
 
 ARGUMENTS
   PLAN  plan identifier
@@ -190,7 +190,7 @@ DESCRIPTION
   Gets the information about a Payment Plan by its identifier.
 
 EXAMPLES
-  $ nvm plans get-plan <planId>
+  $ nevermined plans get-plan <planId>
 ```
 
 **Status**: ✅ Working correctly
@@ -198,7 +198,7 @@ EXAMPLES
 
 #### 4.3 Error Handling - Missing Arguments
 
-**Command**: `nvm plans get-plan`
+**Command**: `nevermined plans get-plan`
 
 **Output**:
 ```
@@ -207,7 +207,7 @@ EXAMPLES
  ›   See more help with --help
 
 USAGE
-  $ nvm plans get-plan PLAN [-p <value>] [-f table|json|quiet] [-v]
+  $ nevermined plans get-plan PLAN [-p <value>] [-f table|json|quiet] [-v]
 ```
 
 **Status**: ✅ Error handling working correctly
@@ -217,14 +217,14 @@ USAGE
 
 ### 5. Agents Commands
 
-**Command**: `nvm agents --help`
+**Command**: `nevermined agents --help`
 
 **Output**:
 ```
 Manage AI agents
 
 USAGE
-  $ nvm agents COMMAND
+  $ nevermined agents COMMAND
 
 COMMANDS
   agents add-plan-to-agent
@@ -256,7 +256,7 @@ COMMANDS
 
 ### 6. X402 Token Commands
 
-**Command**: `nvm x402token --help`
+**Command**: `nevermined x402token --help`
 
 **Output**:
 ```
@@ -266,7 +266,7 @@ The token contains cryptographically signed session keys that delegate specific
 permissions (order, burn) to the agent.
 
 USAGE
-  $ nvm x402token COMMAND
+  $ nevermined x402token COMMAND
 
 COMMANDS
   x402token get-x402-access-token
@@ -280,7 +280,7 @@ COMMANDS
 
 ### 7. Facilitator Commands
 
-**Command**: `nvm facilitator --help`
+**Command**: `nevermined facilitator --help`
 
 **Output**:
 ```
@@ -289,7 +289,7 @@ the actual credit consumption, burning the specified number of credits from
 the subscriber's balance...
 
 USAGE
-  $ nvm facilitator COMMAND
+  $ nevermined facilitator COMMAND
 
 COMMANDS
   facilitator settle-permissions
@@ -306,14 +306,14 @@ COMMANDS
 
 ### 8. Organizations Commands
 
-**Command**: `nvm organizations --help`
+**Command**: `nevermined organizations --help`
 
 **Output**:
 ```
 Manage organizations
 
 USAGE
-  $ nvm organizations COMMAND
+  $ nevermined organizations COMMAND
 
 COMMANDS
   organizations connect-stripe-account  Connect user with Stripe
@@ -341,7 +341,7 @@ All commands support the `--format` flag with three options:
 
 Commands support the `--profile` flag to use specific configuration profiles.
 
-**Example**: `nvm --profile production plans get-plans`
+**Example**: `nevermined --profile production plans get-plans`
 
 **Status**: ✅ Flag working correctly
 
@@ -418,11 +418,11 @@ Commands support the `--verbose` or `-v` flag for detailed output.
 
 **Fix Applied**:
 ```diff
-- nvm facilitator verify-permissions --verify-permissions-params verify.json
-+ nvm facilitator verify-permissions --params verify.json
+- nevermined facilitator verify-permissions --verify-permissions-params verify.json
++ nevermined facilitator verify-permissions --params verify.json
 
-- nvm facilitator settle-permissions --settle-permissions-params settle.json
-+ nvm facilitator settle-permissions --params settle.json
+- nevermined facilitator settle-permissions --settle-permissions-params settle.json
++ nevermined facilitator settle-permissions --params settle.json
 ```
 
 **Status**: ✅ Fixed in both documentation files

--- a/cli/docs/agents.md
+++ b/cli/docs/agents.md
@@ -21,13 +21,13 @@ AI agents are services that users can access by purchasing payment plans. Agents
 Get the list of plans that can be ordered to access an agent:
 
 ```bash
-nvm agents get-agent-plans <agent-id>
+nevermined agents get-agent-plans <agent-id>
 
 # With pagination
-nvm agents get-agent-plans <agent-id> --pagination '{"page": 1, "offset": 10}'
+nevermined agents get-agent-plans <agent-id> --pagination '{"page": 1, "offset": 10}'
 
 # JSON output
-nvm agents get-agent-plans <agent-id> --format json
+nevermined agents get-agent-plans <agent-id> --format json
 ```
 
 ## Getting Agent Details
@@ -35,13 +35,13 @@ nvm agents get-agent-plans <agent-id> --format json
 Retrieve detailed information about a specific agent:
 
 ```bash
-nvm agents get-agent <agent-id>
+nevermined agents get-agent <agent-id>
 ```
 
 Example:
 
 ```bash
-nvm agents get-agent "did:nvm:abc123"
+nevermined agents get-agent "did:nvm:abc123"
 ```
 
 Output includes:
@@ -56,7 +56,7 @@ Output includes:
 Register a new AI agent and associate it with one or more existing payment plans:
 
 ```bash
-nvm agents register-agent \
+nevermined agents register-agent \
   --agent-metadata agent-metadata.json \
   --agent-api agent-api.json \
   --payment-plans "plan-id-1,plan-id-2"
@@ -86,7 +86,7 @@ nvm agents register-agent \
 Register a new AI agent and create a payment plan for it in a single command:
 
 ```bash
-nvm agents register-agent-and-plan \
+nevermined agents register-agent-and-plan \
   --agent-metadata agent-metadata.json \
   --agent-api agent-api.json \
   --plan-metadata plan-metadata.json \
@@ -139,7 +139,7 @@ Only `endpoints` is commonly needed; `openEndpoints` and the auth fields (`authT
 }
 ```
 
-To charge a fixed crypto price instead, set `amounts` to the price in the token's smallest unit and `receivers` to the wallet that collects it (this is what `nvm plans get-native-token-price-config` / `get-erc20-price-config` emit):
+To charge a fixed crypto price instead, set `amounts` to the price in the token's smallest unit and `receivers` to the wallet that collects it (this is what `nevermined plans get-native-token-price-config` / `get-erc20-price-config` emit):
 
 ```json
 {
@@ -170,7 +170,7 @@ To charge a fixed crypto price instead, set `amounts` to the price in the token'
 
 ### Config schemas
 
-`register-agent-and-plan` (and `nvm plans register-credits-plan`) accept these JSON shapes. They match the SDK types exactly — the easiest way to produce a valid file is to run the matching `nvm plans get-*-config` command and save its output, rather than hand-crafting the JSON.
+`register-agent-and-plan` (and `nevermined plans register-credits-plan`) accept these JSON shapes. They match the SDK types exactly — the easiest way to produce a valid file is to run the matching `nevermined plans get-*-config` command and save its output, rather than hand-crafting the JSON.
 
 #### `--price-config` (`PlanPriceConfig`)
 
@@ -186,7 +186,7 @@ To charge a fixed crypto price instead, set `amounts` to the price in the token'
 | `templateAddress` | string | Template contract. Zero address except for pay-as-you-go plans. |
 | `currency` | string | Optional: `USD`, `EUR`, `USDC`, or `EURC`. When omitted, the backend infers it from the payment type. |
 
-Generators that emit this shape: `nvm plans get-free-price-config`, `get-native-token-price-config`, `get-crypto-price-config`, `get-erc20-price-config`, `get-eurc-price-config`, `get-fiat-price-config`, `get-pay-as-you-go-price-config`.
+Generators that emit this shape: `nevermined plans get-free-price-config`, `get-native-token-price-config`, `get-crypto-price-config`, `get-erc20-price-config`, `get-eurc-price-config`, `get-fiat-price-config`, `get-pay-as-you-go-price-config`.
 
 #### `--credits-config` (`PlanCreditsConfig`)
 
@@ -201,7 +201,7 @@ Generators that emit this shape: `nvm plans get-free-price-config`, `get-native-
 | `maxAmount` | number | Maximum credits burned per request (equal to `minAmount` for fixed plans). |
 | `nftAddress` | string | Optional: NFT contract representing the plan's credits. Normally omitted — assigned by the backend. |
 
-Generators that emit this shape: `nvm plans get-fixed-credits-config`, `get-dynamic-credits-config`, `get-expirable-duration-config`, `get-non-expirable-duration-config`, `get-pay-as-you-go-credits-config`.
+Generators that emit this shape: `nevermined plans get-fixed-credits-config`, `get-dynamic-credits-config`, `get-expirable-duration-config`, `get-non-expirable-duration-config`, `get-pay-as-you-go-credits-config`.
 
 #### `--agent-api` (`AgentAPIAttributes`)
 
@@ -220,11 +220,11 @@ The CLI passes this object straight to the SDK, which wraps it as `agentApiAttri
 
 ```bash
 # A free plan that grants 100 credits, burning 1 per request:
-nvm plans get-free-price-config --format json > price-config.json
-nvm plans get-fixed-credits-config --credits-granted 100 --credits-per-request 1 \
+nevermined plans get-free-price-config --format json > price-config.json
+nevermined plans get-fixed-credits-config --credits-granted 100 --credits-per-request 1 \
   --format json > credits-config.json
 
-nvm agents register-agent-and-plan \
+nevermined agents register-agent-and-plan \
   --agent-metadata agent-metadata.json \
   --agent-api agent-api.json \
   --plan-metadata plan-metadata.json \
@@ -239,7 +239,7 @@ nvm agents register-agent-and-plan \
 Modify agent name, description, API endpoint, or other metadata:
 
 ```bash
-nvm agents update-agent-metadata <agent-id> \
+nevermined agents update-agent-metadata <agent-id> \
   --agent-metadata updated-metadata.json \
   --agent-api updated-agent-api.json
 ```
@@ -264,13 +264,13 @@ Both `--agent-metadata` and `--agent-api` are required. As with registration, `-
 Associate an existing payment plan with an agent:
 
 ```bash
-nvm agents add-plan-to-agent <plan-id> --agent-id <agent-id>
+nevermined agents add-plan-to-agent <plan-id> --agent-id <agent-id>
 ```
 
 Example:
 
 ```bash
-nvm agents add-plan-to-agent "did:nvm:plan123" --agent-id "did:nvm:agent456"
+nevermined agents add-plan-to-agent "did:nvm:plan123" --agent-id "did:nvm:agent456"
 ```
 
 ### Remove Payment Plan from Agent
@@ -278,13 +278,13 @@ nvm agents add-plan-to-agent "did:nvm:plan123" --agent-id "did:nvm:agent456"
 Disassociate a payment plan from an agent:
 
 ```bash
-nvm agents remove-plan-from-agent <plan-id> --agent-id <agent-id>
+nevermined agents remove-plan-from-agent <plan-id> --agent-id <agent-id>
 ```
 
 Example:
 
 ```bash
-nvm agents remove-plan-from-agent "did:nvm:plan123" --agent-id "did:nvm:agent456"
+nevermined agents remove-plan-from-agent "did:nvm:plan123" --agent-id "did:nvm:agent456"
 ```
 
 ### List Plans Associated with Agent
@@ -292,7 +292,7 @@ nvm agents remove-plan-from-agent "did:nvm:plan123" --agent-id "did:nvm:agent456
 See which plans give access to an agent:
 
 ```bash
-nvm agents get-agent-plans <agent-id>
+nevermined agents get-agent-plans <agent-id>
 ```
 
 ## Integration Examples
@@ -306,7 +306,7 @@ Complete workflow to register and configure an AI agent:
 # Complete agent setup script
 
 # 1. Create a payment plan first
-PLAN_ID=$(nvm plans register-credits-plan \
+PLAN_ID=$(nevermined plans register-credits-plan \
   --plan-metadata plan.json \
   --price-config price.json \
   --credits-config credits.json \
@@ -315,7 +315,7 @@ PLAN_ID=$(nvm plans register-credits-plan \
 echo "Created plan: $PLAN_ID"
 
 # 2. Register the agent with the plan
-AGENT_ID=$(nvm agents register-agent \
+AGENT_ID=$(nevermined agents register-agent \
   --agent-metadata agent.json \
   --agent-api agent-api.json \
   --payment-plans "$PLAN_ID" \
@@ -324,12 +324,12 @@ AGENT_ID=$(nvm agents register-agent \
 echo "Registered agent: $AGENT_ID"
 
 # 3. Update agent metadata if needed
-nvm agents update-agent-metadata $AGENT_ID \
+nevermined agents update-agent-metadata $AGENT_ID \
   --agent-metadata updated-agent.json \
   --agent-api agent-api.json
 
 # 4. Verify agent is accessible
-nvm agents get-agent $AGENT_ID
+nevermined agents get-agent $AGENT_ID
 
 echo "Agent setup complete!"
 ```
@@ -339,7 +339,7 @@ echo "Agent setup complete!"
 Register an agent and its payment plan in a single command:
 
 ```bash
-nvm agents register-agent-and-plan \
+nevermined agents register-agent-and-plan \
   --agent-metadata agent.json \
   --agent-api agent-api.json \
   --plan-metadata plan.json \
@@ -353,21 +353,21 @@ Register an agent with multiple pricing tiers:
 
 ```bash
 # Create basic plan
-BASIC_PLAN=$(nvm plans register-credits-plan \
+BASIC_PLAN=$(nevermined plans register-credits-plan \
   --plan-metadata basic-plan.json \
   --price-config basic-price.json \
   --credits-config basic-credits.json \
   --format json | jq -r '.planId')
 
 # Create premium plan
-PREMIUM_PLAN=$(nvm plans register-credits-plan \
+PREMIUM_PLAN=$(nevermined plans register-credits-plan \
   --plan-metadata premium-plan.json \
   --price-config premium-price.json \
   --credits-config premium-credits.json \
   --format json | jq -r '.planId')
 
 # Register agent with both plans
-nvm agents register-agent \
+nevermined agents register-agent \
   --agent-metadata agent.json \
   --agent-api agent-api.json \
   --payment-plans "$BASIC_PLAN,$PREMIUM_PLAN"
@@ -379,7 +379,7 @@ Use `--format json` to integrate with other tools:
 
 ```bash
 # Get agent data
-AGENT=$(nvm agents get-agent "did:nvm:agent123" --format json)
+AGENT=$(nevermined agents get-agent "did:nvm:agent123" --format json)
 
 # Extract fields
 NAME=$(echo $AGENT | jq -r '.name')
@@ -417,16 +417,16 @@ Always test agents in sandbox environment:
 
 ```bash
 # Register in sandbox
-nvm --profile sandbox agents register-agent \
+nevermined --profile sandbox agents register-agent \
   --agent-metadata agent.json \
   --agent-api staging-agent-api.json \
   --payment-plans "$STAGING_PLAN_ID"
 
 # Test the agent
-nvm --profile sandbox agents get-agent $STAGING_AGENT_ID
+nevermined --profile sandbox agents get-agent $STAGING_AGENT_ID
 
 # Once verified, deploy to production
-nvm --profile production agents register-agent \
+nevermined --profile production agents register-agent \
   --agent-metadata agent.json \
   --agent-api agent-api.json \
   --payment-plans "$PROD_PLAN_ID"
@@ -440,10 +440,10 @@ Verify the payment plan exists and you're using the correct plan ID:
 
 ```bash
 # List all your plans
-nvm plans get-plans
+nevermined plans get-plans
 
 # Verify specific plan
-nvm plans get-plan <plan-id>
+nevermined plans get-plan <plan-id>
 ```
 
 ### "Insufficient permissions"
@@ -452,10 +452,10 @@ Ensure you're the agent owner or have proper permissions:
 
 ```bash
 # Check agent details
-nvm agents get-agent <agent-id>
+nevermined agents get-agent <agent-id>
 
 # Verify you're using the correct profile
-nvm config show
+nevermined config show
 ```
 
 ## Next Steps

--- a/cli/docs/getting-started.md
+++ b/cli/docs/getting-started.md
@@ -24,7 +24,7 @@ To interact with the Nevermined API, you need an API key. Follow the [Get Your A
 
 ### Option 1: Global Installation (Recommended)
 
-Install the CLI globally to use the `nvm` command from anywhere:
+Install the CLI globally to use the `nevermined` command from anywhere:
 
 ```bash
 npm install -g @nevermined-io/cli
@@ -33,8 +33,10 @@ npm install -g @nevermined-io/cli
 Verify installation:
 
 ```bash
-nvm --version
+nevermined --version
 ```
+
+> **Renamed from `nvm`**: earlier versions installed the binary as `nvm`, which collided with [Node Version Manager](https://github.com/nvm-sh/nvm). The command is now `nevermined`. Update any scripts that called `nvm <command>`.
 
 ### Option 2: Using npx (No Installation)
 
@@ -72,7 +74,7 @@ pnpm build:manifest
 The quickest way to authenticate:
 
 ```bash
-nvm login
+nevermined login
 ```
 
 This opens your browser to sign in with Google, X, or email. After login,
@@ -86,9 +88,9 @@ Options:
 Examples:
 
 ```bash
-nvm login --environment live
-nvm login --profile production --environment live
-nvm login --no-browser
+nevermined login --environment live
+nevermined login --profile production --environment live
+nevermined login --no-browser
 ```
 
 ### Logout
@@ -96,9 +98,9 @@ nvm login --no-browser
 Remove your API key from the CLI config:
 
 ```bash
-nvm logout
-nvm logout --profile production
-nvm logout --all-profiles
+nevermined logout
+nevermined logout --profile production
+nevermined logout --all-profiles
 ```
 
 ## Configuration
@@ -108,7 +110,7 @@ nvm logout --all-profiles
 The easiest way to configure the CLI is using the interactive setup:
 
 ```bash
-nvm config init
+nevermined config init
 ```
 
 This will prompt you for:
@@ -120,7 +122,7 @@ This will prompt you for:
 Example:
 
 ```bash
-$ nvm config init
+$ nevermined config init
 
 ? Enter your NVM API Key: sandbox:eyJxxxxaaaabbbbbbbb
 ? Select environment: sandbox
@@ -150,20 +152,20 @@ Create multiple profiles for different environments or accounts:
 
 ```bash
 # Initialize with default profile
-nvm config init
+nevermined config init
 
 # Create a production profile
-nvm config set profiles.production.nvmApiKey nvm-yyyyyyyy...
-nvm config set profiles.production.environment live
+nevermined config set profiles.production.nvmApiKey nvm-yyyyyyyy...
+nevermined config set profiles.production.environment live
 
 # Switch active profile
-nvm config set activeProfile production
+nevermined config set activeProfile production
 ```
 
 Use a specific profile for a command:
 
 ```bash
-nvm --profile production plans get-plans
+nevermined --profile production plans get-plans
 ```
 
 ### Environment Variables
@@ -178,7 +180,7 @@ export NVM_API_KEY=sandbox:eyJxxxxaaaabbbbbbbb
 export NVM_ENVIRONMENT=sandbox
 
 # Run commands
-nvm plans get-plans
+nevermined plans get-plans
 ```
 
 This is useful for:
@@ -191,7 +193,7 @@ This is useful for:
 Display your current configuration:
 
 ```bash
-nvm config show
+nevermined config show
 ```
 
 Output:
@@ -209,7 +211,7 @@ API Key:        live:eyJxxxxaaaabbbbbbbb (truncated)
 Test your configuration by listing available plans:
 
 ```bash
-nvm plans get-plans
+nevermined plans get-plans
 ```
 
 If configured correctly, you should see a table of available payment plans.
@@ -227,9 +229,9 @@ Choose the right environment for your use case:
 
 ## Common Issues
 
-### "Command not found: nvm"
+### "Command not found: nevermined"
 
-After global installation, if `nvm` command is not found:
+After global installation, if `nevermined` command is not found:
 
 1. Verify installation: `npm list -g @nevermined-io/cli`
 2. Check your PATH includes npm global bin directory
@@ -242,10 +244,10 @@ If you get an API key error:
 
 ```bash
 # Browser login (recommended)
-nvm login
+nevermined login
 
 # Or initialize configuration manually
-nvm config init
+nevermined config init
 
 # Or set environment variable
 export NVM_API_KEY=your-api-key-here
@@ -277,13 +279,13 @@ Get help for any command:
 
 ```bash
 # General help
-nvm --help
+nevermined --help
 
 # Topic help
-nvm plans --help
+nevermined plans --help
 
 # Command help
-nvm plans get-plan --help
+nevermined plans get-plan --help
 ```
 
 For support:

--- a/cli/docs/other-commands.md
+++ b/cli/docs/other-commands.md
@@ -15,10 +15,10 @@ Reference guide for additional CLI commands including configuration, facilitator
 Authenticate via browser login. Opens your browser, waits for you to sign in, and saves the API key to your CLI config:
 
 ```bash
-nvm login
-nvm login --environment live
-nvm login --profile production --environment live
-nvm login --no-browser  # Print URL instead of opening browser
+nevermined login
+nevermined login --environment live
+nevermined login --profile production --environment live
+nevermined login --no-browser  # Print URL instead of opening browser
 ```
 
 ### Logout
@@ -26,9 +26,9 @@ nvm login --no-browser  # Print URL instead of opening browser
 Remove your API key from the local configuration so you need to authenticate again:
 
 ```bash
-nvm logout
-nvm logout --profile production
-nvm logout --all-profiles  # Remove API keys from every profile
+nevermined logout
+nevermined logout --profile production
+nevermined logout --all-profiles  # Remove API keys from every profile
 ```
 
 ### Initialize Configuration
@@ -36,7 +36,7 @@ nvm logout --all-profiles  # Remove API keys from every profile
 Set up your CLI configuration interactively:
 
 ```bash
-nvm config init
+nevermined config init
 ```
 
 Interactive prompts:
@@ -54,10 +54,10 @@ Flags:
 Display your current configuration:
 
 ```bash
-nvm config show
+nevermined config show
 
 # Show all profiles
-nvm config show --all
+nevermined config show --all
 ```
 
 Output:
@@ -76,13 +76,13 @@ Update specific configuration values:
 
 ```bash
 # Set API key
-nvm config set nvmApiKey sandbox:eyJxxxxaaaa...bbbbbbbb
+nevermined config set nvmApiKey sandbox:eyJxxxxaaaa...bbbbbbbb
 
 # Set environment
-nvm config set environment sandbox
+nevermined config set environment sandbox
 
 # Set active profile
-nvm config set activeProfile production
+nevermined config set activeProfile production
 ```
 
 ### Configuration File Structure
@@ -114,7 +114,7 @@ Facilitator commands are used by agent owners to verify and settle permissions (
 Verify that a subscriber has permission to use credits from a payment plan. This simulates credit usage without actually burning credits:
 
 ```bash
-nvm facilitator verify-permissions \
+nevermined facilitator verify-permissions \
   --params verify.json
 ```
 
@@ -133,7 +133,7 @@ nvm facilitator verify-permissions \
 Settle (burn) credits from a subscriber's payment plan. This executes the actual credit consumption:
 
 ```bash
-nvm facilitator settle-permissions \
+nevermined facilitator settle-permissions \
   --params settle.json
 ```
 
@@ -156,16 +156,16 @@ Manage organization members and settings.
 View all members in your organization:
 
 ```bash
-nvm organizations get-members
+nevermined organizations get-members
 
 # Filter by role
-nvm organizations get-members --role admin
+nevermined organizations get-members --role admin
 
 # Filter active members
-nvm organizations get-members --is-active true
+nevermined organizations get-members --is-active true
 
 # Pagination
-nvm organizations get-members --page 1 --offset 10
+nevermined organizations get-members --page 1 --offset 10
 ```
 
 ### Create Member
@@ -173,10 +173,10 @@ nvm organizations get-members --page 1 --offset 10
 Add a new member to your organization:
 
 ```bash
-nvm organizations create-member <user-id>
+nevermined organizations create-member <user-id>
 
 # With email and role
-nvm organizations create-member <user-id> --user-email "john@example.com" --user-role "developer"
+nevermined organizations create-member <user-id> --user-email "john@example.com" --user-role "developer"
 ```
 
 Flags:
@@ -188,7 +188,7 @@ Flags:
 Connect a user with Stripe for fiat payments:
 
 ```bash
-nvm organizations connect-stripe-account \
+nevermined organizations connect-stripe-account \
   --user-email "john@example.com" \
   --user-country-code "US" \
   --return-url "https://yourapp.com/stripe-callback"
@@ -206,13 +206,13 @@ All flags are required:
 Generate an access token for a plan with delegated permissions:
 
 ```bash
-nvm x402token get-x402-access-token <plan-id>
+nevermined x402token get-x402-access-token <plan-id>
 ```
 
 Example:
 
 ```bash
-nvm x402token get-x402-access-token "did:nvm:abc123"
+nevermined x402token get-x402-access-token "did:nvm:abc123"
 ```
 
 Optional flags:
@@ -224,7 +224,7 @@ Optional flags:
 Example with options:
 
 ```bash
-nvm x402token get-x402-access-token "did:nvm:abc123" \
+nevermined x402token get-x402-access-token "did:nvm:abc123" \
   --agent-id "did:nvm:agent456" \
   --redemption-limit 100 \
   --expiration 3600
@@ -244,7 +244,7 @@ Save token for later use:
 
 ```bash
 # Save to environment variable
-export X402_TOKEN=$(nvm x402token get-x402-access-token "did:nvm:abc123" \
+export X402_TOKEN=$(nevermined x402token get-x402-access-token "did:nvm:abc123" \
   --format json | jq -r '.token')
 
 # Use token in requests
@@ -261,13 +261,13 @@ Control output format:
 
 ```bash
 # Table output (default)
-nvm plans get-plans
+nevermined plans get-plans
 
 # JSON output
-nvm plans get-plans --format json
+nevermined plans get-plans --format json
 
 # Quiet output (minimal)
-nvm plans get-plans --format quiet
+nevermined plans get-plans --format quiet
 ```
 
 ### Profile Flag
@@ -276,10 +276,10 @@ Use a specific configuration profile:
 
 ```bash
 # Use production profile
-nvm --profile production plans get-plans
+nevermined --profile production plans get-plans
 
 # Use staging profile
-nvm --profile staging agents get-agent <agent-id>
+nevermined --profile staging agents get-agent <agent-id>
 ```
 
 ### Verbose Flag
@@ -287,7 +287,7 @@ nvm --profile staging agents get-agent <agent-id>
 Enable verbose output with detailed logging:
 
 ```bash
-nvm plans order-plan "did:nvm:abc123" --verbose
+nevermined plans order-plan "did:nvm:abc123" --verbose
 ```
 
 Output includes:
@@ -302,7 +302,7 @@ Output includes:
 Check CLI version:
 
 ```bash
-nvm --version
+nevermined --version
 ```
 
 ### Help
@@ -311,16 +311,16 @@ Get help for commands:
 
 ```bash
 # General help
-nvm --help
+nevermined --help
 
 # Topic help
-nvm plans --help
-nvm agents --help
-nvm config --help
+nevermined plans --help
+nevermined agents --help
+nevermined config --help
 
 # Command help
-nvm plans get-plan --help
-nvm agents register-agent --help
+nevermined plans get-plan --help
+nevermined agents register-agent --help
 ```
 
 ## Scripting Examples
@@ -333,11 +333,11 @@ Switch between environments easily:
 #!/bin/bash
 case $1 in
   production)
-    nvm config set activeProfile production
+    nevermined config set activeProfile production
     echo "Switched to production environment"
     ;;
   sandbox)
-    nvm config set activeProfile default
+    nevermined config set activeProfile default
     echo "Switched to sandbox environment"
     ;;
   *)
@@ -346,7 +346,7 @@ case $1 in
     ;;
 esac
 
-nvm config show
+nevermined config show
 ```
 
 ### Multi-Profile Operations
@@ -360,7 +360,7 @@ COMMAND="$@"
 
 for PROFILE in "${PROFILES[@]}"; do
   echo "Profile: $PROFILE"
-  nvm --profile $PROFILE $COMMAND
+  nevermined --profile $PROFILE $COMMAND
   echo ""
 done
 ```
@@ -397,12 +397,12 @@ jobs:
 
       - name: Configure CLI
         run: |
-          nvm config set nvmApiKey ${{ secrets.NVM_API_KEY }}
-          nvm config set environment live
+          nevermined config set nvmApiKey ${{ secrets.NVM_API_KEY }}
+          nevermined config set environment live
 
       - name: Register Agent
         run: |
-          nvm agents register-agent \
+          nevermined agents register-agent \
             --agent-metadata agent.json \
             --agent-api "https://api.example.com" \
             --payment-plans "${{ secrets.PLAN_ID }}"
@@ -415,9 +415,9 @@ jobs:
 Initialize configuration:
 
 ```bash
-nvm login
+nevermined login
 # or
-nvm config init
+nevermined config init
 ```
 
 ### "Invalid profile"
@@ -425,7 +425,7 @@ nvm config init
 Check available profiles:
 
 ```bash
-nvm config show --all
+nevermined config show --all
 ```
 
 ### "Permission denied"

--- a/cli/docs/plans.md
+++ b/cli/docs/plans.md
@@ -21,13 +21,13 @@ View all available payment plans:
 
 ```bash
 # Table output (default)
-nvm plans get-plans
+nevermined plans get-plans
 
 # JSON output for scripting
-nvm plans get-plans --format json
+nevermined plans get-plans --format json
 
 # With pagination and sorting
-nvm plans get-plans --page 1 --offset 10 --sort-by name --sort-order asc
+nevermined plans get-plans --page 1 --offset 10 --sort-by name --sort-order asc
 ```
 
 ## Getting Plan Details
@@ -35,13 +35,13 @@ nvm plans get-plans --page 1 --offset 10 --sort-by name --sort-order asc
 Retrieve detailed information about a specific plan:
 
 ```bash
-nvm plans get-plan <plan-id>
+nevermined plans get-plan <plan-id>
 ```
 
 Example:
 
 ```bash
-nvm plans get-plan "did:nvm:abc123"
+nevermined plans get-plan "did:nvm:abc123"
 ```
 
 Output includes:
@@ -56,10 +56,10 @@ Check your credit balance for a plan:
 
 ```bash
 # Your balance
-nvm plans get-plan-balance <plan-id>
+nevermined plans get-plan-balance <plan-id>
 
 # Check balance for specific address
-nvm plans get-plan-balance <plan-id> --account-address "0x1234..."
+nevermined plans get-plan-balance <plan-id> --account-address "0x1234..."
 ```
 
 ## Getting Agents for a Plan
@@ -67,10 +67,10 @@ nvm plans get-plan-balance <plan-id> --account-address "0x1234..."
 List all agents accessible through a specific plan:
 
 ```bash
-nvm plans get-agents-associated-to-a-plan <plan-id>
+nevermined plans get-agents-associated-to-a-plan <plan-id>
 
 # With pagination
-nvm plans get-agents-associated-to-a-plan <plan-id> --pagination '{"page": 1, "offset": 10}'
+nevermined plans get-agents-associated-to-a-plan <plan-id> --pagination '{"page": 1, "offset": 10}'
 ```
 
 ## Creating Plans
@@ -80,7 +80,7 @@ nvm plans get-agents-associated-to-a-plan <plan-id> --pagination '{"page": 1, "o
 Register a plan with full control over price and credits/duration configuration:
 
 ```bash
-nvm plans register-plan \
+nevermined plans register-plan \
   --plan-metadata plan-metadata.json \
   --price-config price-config.json \
   --credits-config credits-config.json
@@ -95,7 +95,7 @@ Optional flags:
 Create a pay-per-use plan with credits:
 
 ```bash
-nvm plans register-credits-plan \
+nevermined plans register-credits-plan \
   --plan-metadata plan-metadata.json \
   --price-config price-config.json \
   --credits-config credits-config.json
@@ -114,7 +114,7 @@ nvm plans register-credits-plan \
 }
 ```
 
-**price-config.json** (`PlanPriceConfig`) — charge a fixed crypto price; `amounts` is in the token's smallest unit (e.g. `1000000` = 1 USDC at 6 decimals) and `receivers` collects it (this is what `nvm plans get-erc20-price-config` / `get-native-token-price-config` emit):
+**price-config.json** (`PlanPriceConfig`) — charge a fixed crypto price; `amounts` is in the token's smallest unit (e.g. `1000000` = 1 USDC at 6 decimals) and `receivers` collects it (this is what `nevermined plans get-erc20-price-config` / `get-native-token-price-config` emit):
 
 ```json
 {
@@ -129,7 +129,7 @@ nvm plans register-credits-plan \
 }
 ```
 
-**credits-config.json** (`PlanCreditsConfig`) — grant 100 credits, burn 1 per request (what `nvm plans get-fixed-credits-config` emits):
+**credits-config.json** (`PlanCreditsConfig`) — grant 100 credits, burn 1 per request (what `nevermined plans get-fixed-credits-config` emits):
 
 ```json
 {
@@ -148,13 +148,13 @@ nvm plans register-credits-plan \
 Create a subscription plan with time-limited access:
 
 ```bash
-nvm plans register-time-plan \
+nevermined plans register-time-plan \
   --plan-metadata plan-metadata.json \
   --price-config price-config.json \
   --credits-config credits-config.json
 ```
 
-**credits-config.json** (for time plan) (`PlanCreditsConfig`) — a time-limited plan sets `durationSecs > 0` (what `nvm plans get-expirable-duration-config` emits):
+**credits-config.json** (for time plan) (`PlanCreditsConfig`) — a time-limited plan sets `durationSecs > 0` (what `nevermined plans get-expirable-duration-config` emits):
 
 ```json
 {
@@ -177,7 +177,7 @@ Trial plans can only be purchased once per user and are useful for letting users
 **Credits trial** (limited by credits):
 
 ```bash
-nvm plans register-credits-trial-plan \
+nevermined plans register-credits-trial-plan \
   --plan-metadata plan-metadata.json \
   --price-config price-config.json \
   --credits-config credits-config.json
@@ -186,7 +186,7 @@ nvm plans register-credits-trial-plan \
 **Time trial** (limited by duration):
 
 ```bash
-nvm plans register-time-trial-plan \
+nevermined plans register-time-trial-plan \
   --plan-metadata plan-metadata.json \
   --price-config price-config.json \
   --credits-config credits-config.json
@@ -199,7 +199,7 @@ nvm plans register-time-trial-plan \
 Purchase a plan with cryptocurrency:
 
 ```bash
-nvm plans order-plan <plan-id>
+nevermined plans order-plan <plan-id>
 ```
 
 ### Fiat Payment
@@ -207,7 +207,7 @@ nvm plans order-plan <plan-id>
 Initiate a plan purchase with fiat payment. Returns a URL where the user can complete the payment:
 
 ```bash
-nvm plans order-fiat-plan <plan-id>
+nevermined plans order-fiat-plan <plan-id>
 ```
 
 ## Minting Credits
@@ -217,7 +217,7 @@ nvm plans order-fiat-plan <plan-id>
 Add credits to a plan and transfer them to a receiver (plan owner only):
 
 ```bash
-nvm plans mint-plan-credits <plan-id> \
+nevermined plans mint-plan-credits <plan-id> \
   --credits-amount 1000 \
   --credits-receiver "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb"
 ```
@@ -227,7 +227,7 @@ nvm plans mint-plan-credits <plan-id> \
 Add time-limited credits:
 
 ```bash
-nvm plans mint-plan-expirable <plan-id> \
+nevermined plans mint-plan-expirable <plan-id> \
   --credits-amount 1000 \
   --credits-receiver "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb" \
   --credits-duration 2592000
@@ -237,12 +237,12 @@ The `--credits-duration` flag is optional and specifies duration in seconds.
 
 ## Redeeming Credits
 
-Credit redemption (burning credits after a paid request) is performed via the x402 facilitator, not via a dedicated `plans` command. The legacy `nvm plans redeem-credits` command was removed because the backend exposes no direct redeem endpoint — the only burn path is `POST /api/v1/x402/settle`.
+Credit redemption (burning credits after a paid request) is performed via the x402 facilitator, not via a dedicated `plans` command. The legacy `nevermined plans redeem-credits` command was removed because the backend exposes no direct redeem endpoint — the only burn path is `POST /api/v1/x402/settle`.
 
 Migration (subscriber side — get an access token):
 
 ```bash
-nvm x402token get-x402-access-token <plan-id> --format json
+nevermined x402token get-x402-access-token <plan-id> --format json
 # → { "accessToken": "eyJ4NDAyVm..." }
 ```
 
@@ -269,8 +269,8 @@ cat > /tmp/settle-params.json <<EOF
 }
 EOF
 
-nvm facilitator verify-permissions --params "$(cat /tmp/settle-params.json)" --format json
-nvm facilitator settle-permissions --params "$(cat /tmp/settle-params.json)" --format json
+nevermined facilitator verify-permissions --params "$(cat /tmp/settle-params.json)" --format json
+nevermined facilitator settle-permissions --params "$(cat /tmp/settle-params.json)" --format json
 # → { "success": true, "creditsRedeemed": "5", "remainingBalance": "...", ... }
 ```
 
@@ -282,28 +282,28 @@ The CLI provides helper commands to build price configuration objects:
 
 ```bash
 # Free (no payment required)
-nvm plans get-free-price-config
+nevermined plans get-free-price-config
 
 # Fiat price
-nvm plans get-fiat-price-config --amount 1000 --receiver "0x123..."
+nevermined plans get-fiat-price-config --amount 1000 --receiver "0x123..."
 
 # Crypto price
-nvm plans get-crypto-price-config --amount 1000 --receiver "0x123..."
+nevermined plans get-crypto-price-config --amount 1000 --receiver "0x123..."
 
 # Crypto with specific token
-nvm plans get-crypto-price-config --amount 1000 --receiver "0x123..." --token-address "0xToken..."
+nevermined plans get-crypto-price-config --amount 1000 --receiver "0x123..." --token-address "0xToken..."
 
 # Native token price
-nvm plans get-native-token-price-config --amount 1000 --receiver "0x123..."
+nevermined plans get-native-token-price-config --amount 1000 --receiver "0x123..."
 
 # ERC20 token price
-nvm plans get-erc20-price-config --amount 1000 --receiver "0x123..." --token-address "0xToken..."
+nevermined plans get-erc20-price-config --amount 1000 --receiver "0x123..." --token-address "0xToken..."
 
 # EURC (Euro stablecoin) price
-nvm plans get-eurc-price-config --amount 1000 --receiver "0x123..."
+nevermined plans get-eurc-price-config --amount 1000 --receiver "0x123..."
 
 # Pay-as-you-go price
-nvm plans get-pay-as-you-go-price-config --amount 1000 --receiver "0x123..."
+nevermined plans get-pay-as-you-go-price-config --amount 1000 --receiver "0x123..."
 ```
 
 ## Credits Configuration Helpers
@@ -312,20 +312,20 @@ Helper commands to build credits configuration objects:
 
 ```bash
 # Fixed credits (same amount per request)
-nvm plans get-fixed-credits-config --credits-granted 100 --credits-per-request 1
+nevermined plans get-fixed-credits-config --credits-granted 100 --credits-per-request 1
 
 # Dynamic credits (range per request)
-nvm plans get-dynamic-credits-config --credits-granted 100 \
+nevermined plans get-dynamic-credits-config --credits-granted 100 \
   --min-credits-per-request 1 --max-credits-per-request 10
 
 # Pay-as-you-go credits
-nvm plans get-pay-as-you-go-credits-config
+nevermined plans get-pay-as-you-go-credits-config
 
 # Expirable duration
-nvm plans get-expirable-duration-config --duration-of-plan 2592000
+nevermined plans get-expirable-duration-config --duration-of-plan 2592000
 
 # Non-expirable
-nvm plans get-non-expirable-duration-config
+nevermined plans get-non-expirable-duration-config
 ```
 
 ## Advanced Operations
@@ -335,7 +335,7 @@ nvm plans get-non-expirable-duration-config
 Mark whether burns of these credits are mirrored on-chain:
 
 ```bash
-nvm plans set-onchain-mirror \
+nevermined plans set-onchain-mirror \
   --credits-config credits-config.json \
   --onchain-mirror
 ```
@@ -345,7 +345,7 @@ nvm plans set-onchain-mirror \
 Set the redemption type in a credits configuration:
 
 ```bash
-nvm plans set-redemption-type \
+nevermined plans set-redemption-type \
   --credits-config credits-config.json \
   --redemption-type "fixed"
 ```
@@ -356,7 +356,7 @@ Use `--format json` for machine-readable output:
 
 ```bash
 # Get plan details as JSON
-PLAN_DATA=$(nvm plans get-plan "did:nvm:abc123" --format json)
+PLAN_DATA=$(nevermined plans get-plan "did:nvm:abc123" --format json)
 
 # Extract specific field with jq
 PLAN_NAME=$(echo $PLAN_DATA | jq -r '.name')
@@ -406,7 +406,7 @@ cat > credits.json << EOF
 EOF
 
 # 4. Register the plan
-nvm plans register-credits-plan \
+nevermined plans register-credits-plan \
   --plan-metadata plan.json \
   --price-config price.json \
   --credits-config credits.json
@@ -419,7 +419,7 @@ nvm plans register-credits-plan \
 PLAN_ID="did:nvm:abc123"
 MIN_CREDITS=10
 
-BALANCE=$(nvm plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
+BALANCE=$(nevermined plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
 
 if [ "$BALANCE" -lt "$MIN_CREDITS" ]; then
   echo "Low balance: $BALANCE credits remaining"
@@ -459,13 +459,13 @@ Always test new plans in sandbox before going live:
 
 ```bash
 # Test in sandbox
-nvm --profile sandbox plans register-credits-plan \
+nevermined --profile sandbox plans register-credits-plan \
   --plan-metadata metadata.json \
   --price-config price.json \
   --credits-config credits.json
 
 # Verify it works
-nvm --profile sandbox plans get-plan <plan-id>
+nevermined --profile sandbox plans get-plan <plan-id>
 ```
 
 ## Common Issues
@@ -480,10 +480,10 @@ Ensure you're using the correct environment and plan ID:
 
 ```bash
 # Check which environment you're using
-nvm config show
+nevermined config show
 
 # Try the correct profile
-nvm --profile sandbox plans get-plan <plan-id>
+nevermined --profile sandbox plans get-plan <plan-id>
 ```
 
 ## Next Steps

--- a/cli/docs/purchases.md
+++ b/cli/docs/purchases.md
@@ -19,13 +19,13 @@ Purchasing a payment plan gives you access to AI agents and services. Once you o
 Purchase a payment plan with cryptocurrency:
 
 ```bash
-nvm plans order-plan <plan-id>
+nevermined plans order-plan <plan-id>
 ```
 
 Example:
 
 ```bash
-nvm plans order-plan "did:nvm:abc123"
+nevermined plans order-plan "did:nvm:abc123"
 ```
 
 Output:
@@ -43,13 +43,13 @@ Status: Confirmed
 Initiate a plan purchase with fiat. This returns a URL where you can complete the payment:
 
 ```bash
-nvm plans order-fiat-plan <plan-id>
+nevermined plans order-fiat-plan <plan-id>
 ```
 
 Example:
 
 ```bash
-nvm plans order-fiat-plan "did:nvm:abc123"
+nevermined plans order-fiat-plan "did:nvm:abc123"
 ```
 
 ## Checking Your Credits
@@ -60,10 +60,10 @@ Check how many credits you have remaining:
 
 ```bash
 # Your balance
-nvm plans get-plan-balance <plan-id>
+nevermined plans get-plan-balance <plan-id>
 
 # Balance for specific address
-nvm plans get-plan-balance <plan-id> --account-address "0x123..."
+nevermined plans get-plan-balance <plan-id> --account-address "0x123..."
 ```
 
 Example output:
@@ -84,7 +84,7 @@ PLANS=("did:nvm:plan1" "did:nvm:plan2" "did:nvm:plan3")
 
 for PLAN in "${PLANS[@]}"; do
   echo "Checking balance for $PLAN..."
-  nvm plans get-plan-balance $PLAN
+  nevermined plans get-plan-balance $PLAN
   echo ""
 done
 ```
@@ -96,7 +96,7 @@ done
 Re-order a plan to add more credits to your existing balance:
 
 ```bash
-nvm plans order-plan <plan-id>
+nevermined plans order-plan <plan-id>
 ```
 
 ### Bulk Credit Purchase
@@ -109,7 +109,7 @@ PLANS=("did:nvm:plan1" "did:nvm:plan2")
 
 for PLAN in "${PLANS[@]}"; do
   echo "Ordering $PLAN..."
-  nvm plans order-plan $PLAN
+  nevermined plans order-plan $PLAN
 done
 ```
 
@@ -124,7 +124,7 @@ Create a script to alert when credits run low:
 PLAN_ID="did:nvm:abc123"
 MIN_CREDITS=10
 
-BALANCE=$(nvm plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
+BALANCE=$(nevermined plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
 
 if [ "$BALANCE" -lt "$MIN_CREDITS" ]; then
   echo "LOW CREDITS ALERT"
@@ -144,14 +144,14 @@ Automatically refill credits when low:
 PLAN_ID="did:nvm:abc123"
 MIN_CREDITS=20
 
-BALANCE=$(nvm plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
+BALANCE=$(nevermined plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
 
 if [ "$BALANCE" -lt "$MIN_CREDITS" ]; then
   echo "$(date): Credits low ($BALANCE), ordering more..."
-  nvm plans order-plan $PLAN_ID
+  nevermined plans order-plan $PLAN_ID
 
   if [ $? -eq 0 ]; then
-    NEW_BALANCE=$(nvm plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
+    NEW_BALANCE=$(nevermined plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
     echo "$(date): New balance: $NEW_BALANCE credits"
   else
     echo "$(date): ERROR - Failed to order credits"
@@ -170,27 +170,27 @@ fi
 
 # 1. Browse available plans
 echo "Available Plans:"
-nvm plans get-plans
+nevermined plans get-plans
 
 # 2. Get details about a specific plan
 PLAN_ID="did:nvm:abc123"
-nvm plans get-plan $PLAN_ID
+nevermined plans get-plan $PLAN_ID
 
 # 3. Check current balance
 echo "Current balance:"
-nvm plans get-plan-balance $PLAN_ID
+nevermined plans get-plan-balance $PLAN_ID
 
 # 4. Purchase the plan
 echo "Purchasing plan..."
-nvm plans order-plan $PLAN_ID
+nevermined plans order-plan $PLAN_ID
 
 # 5. Verify purchase
 echo "New balance:"
-nvm plans get-plan-balance $PLAN_ID
+nevermined plans get-plan-balance $PLAN_ID
 
 # 6. Get access token for using the service
 echo "Getting access token..."
-nvm x402token get-x402-access-token $PLAN_ID
+nevermined x402token get-x402-access-token $PLAN_ID
 ```
 
 ### Example 2: Team Credit Management
@@ -202,13 +202,13 @@ TEAM_PLANS=("did:nvm:plan1" "did:nvm:plan2" "did:nvm:plan3")
 # Purchase for entire team
 for PLAN in "${TEAM_PLANS[@]}"; do
   echo "Ordering $PLAN for team..."
-  nvm plans order-plan $PLAN
+  nevermined plans order-plan $PLAN
 done
 
 # Generate team usage report
 echo "Team Balances:"
 for PLAN in "${TEAM_PLANS[@]}"; do
-  nvm plans get-plan-balance $PLAN --format json | jq '{plan: .planId, remaining: .balance}'
+  nevermined plans get-plan-balance $PLAN --format json | jq '{plan: .planId, remaining: .balance}'
 done
 ```
 
@@ -241,7 +241,7 @@ Implement auto-refill to ensure continuous service:
 Always use `--format json` in scripts:
 
 ```bash
-BALANCE=$(nvm plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
+BALANCE=$(nevermined plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
 ```
 
 ## Common Issues
@@ -256,10 +256,10 @@ The plan may be sold out or no longer active:
 
 ```bash
 # Verify plan status
-nvm plans get-plan <plan-id>
+nevermined plans get-plan <plan-id>
 
 # Look for alternative plans
-nvm plans get-plans
+nevermined plans get-plans
 ```
 
 ## Next Steps

--- a/cli/docs/querying.md
+++ b/cli/docs/querying.md
@@ -19,13 +19,13 @@ After purchasing a payment plan, you can query AI agents using X402 access token
 Get an access token for a purchased plan:
 
 ```bash
-nvm x402token get-x402-access-token <plan-id>
+nevermined x402token get-x402-access-token <plan-id>
 ```
 
 Example:
 
 ```bash
-nvm x402token get-x402-access-token "did:nvm:abc123"
+nevermined x402token get-x402-access-token "did:nvm:abc123"
 ```
 
 Optional flags:
@@ -37,7 +37,7 @@ Optional flags:
 Example with options:
 
 ```bash
-nvm x402token get-x402-access-token "did:nvm:abc123" \
+nevermined x402token get-x402-access-token "did:nvm:abc123" \
   --agent-id "did:nvm:agent456" \
   --redemption-limit 100 \
   --expiration 3600
@@ -68,7 +68,7 @@ Store the token for multiple requests:
 
 ```bash
 # Get token and save to file
-TOKEN=$(nvm x402token get-x402-access-token "did:nvm:abc123" --format json | jq -r '.token')
+TOKEN=$(nevermined x402token get-x402-access-token "did:nvm:abc123" --format json | jq -r '.token')
 echo $TOKEN > ~/.nvm-token
 
 # Use token from file
@@ -83,7 +83,7 @@ Query an agent using curl:
 
 ```bash
 # Get access token
-TOKEN=$(nvm x402token get-x402-access-token "did:nvm:abc123" --format json | jq -r '.token')
+TOKEN=$(nevermined x402token get-x402-access-token "did:nvm:abc123" --format json | jq -r '.token')
 
 # Make request with payment-signature header
 curl -X POST https://agent-api.example.com/v1/chat \
@@ -102,7 +102,7 @@ curl -X POST https://agent-api.example.com/v1/chat \
 const { execSync } = require('child_process')
 
 const planId = 'did:nvm:abc123'
-const tokenCmd = `nvm x402token get-x402-access-token ${planId} --format json`
+const tokenCmd = `nevermined x402token get-x402-access-token ${planId} --format json`
 const result = JSON.parse(execSync(tokenCmd).toString())
 const token = result.token
 
@@ -132,7 +132,7 @@ import requests
 
 # Get token from CLI
 plan_id = 'did:nvm:abc123'
-cmd = f'nvm x402token get-x402-access-token {plan_id} --format json'
+cmd = f'nevermined x402token get-x402-access-token {plan_id} --format json'
 result = subprocess.run(cmd.split(), capture_output=True, text=True)
 token_data = json.loads(result.stdout)
 token = token_data['token']
@@ -160,7 +160,7 @@ print(response.json())
 Verify that a request is valid before processing (for agent owners):
 
 ```bash
-nvm facilitator verify-permissions \
+nevermined facilitator verify-permissions \
   --params verify.json
 ```
 
@@ -213,7 +213,7 @@ if (!verification.isValid) {
 After processing a request, burn the credits (agent owners):
 
 ```bash
-nvm facilitator settle-permissions \
+nevermined facilitator settle-permissions \
   --params settle.json
 ```
 
@@ -255,16 +255,16 @@ AGENT_API="https://agent-api.example.com/v1/chat"
 
 # 1. Purchase plan if needed
 echo "Checking balance..."
-BALANCE=$(nvm plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
+BALANCE=$(nevermined plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
 
 if [ "$BALANCE" -lt "10" ]; then
   echo "Low balance, purchasing plan..."
-  nvm plans order-plan $PLAN_ID
+  nevermined plans order-plan $PLAN_ID
 fi
 
 # 2. Get X402 access token
 echo "Getting access token..."
-TOKEN=$(nvm x402token get-x402-access-token $PLAN_ID --format json | jq -r '.token')
+TOKEN=$(nevermined x402token get-x402-access-token $PLAN_ID --format json | jq -r '.token')
 
 # 3. Query the agent
 echo "Querying agent..."
@@ -281,7 +281,7 @@ echo $RESPONSE | jq '.'
 
 # 4. Check updated balance
 echo "Updated balance:"
-nvm plans get-plan-balance $PLAN_ID
+nevermined plans get-plan-balance $PLAN_ID
 ```
 
 ## Advanced Usage
@@ -298,7 +298,7 @@ PLAN_ID="did:nvm:abc123"
 AGENT_API="https://agent-api.example.com/v1/chat"
 
 # Get token once
-TOKEN=$(nvm x402token get-x402-access-token $PLAN_ID --format json | jq -r '.token')
+TOKEN=$(nevermined x402token get-x402-access-token $PLAN_ID --format json | jq -r '.token')
 
 # Array of questions
 QUESTIONS=(
@@ -322,7 +322,7 @@ for QUESTION in "${QUESTIONS[@]}"; do
 done
 
 # Check final balance
-nvm plans get-plan-balance $PLAN_ID
+nevermined plans get-plan-balance $PLAN_ID
 ```
 
 ### Rate-Limited Queries
@@ -338,7 +338,7 @@ AGENT_API="https://agent-api.example.com/v1/chat"
 RATE_LIMIT=10  # requests per minute
 DELAY=$(echo "60 / $RATE_LIMIT" | bc -l)
 
-TOKEN=$(nvm x402token get-x402-access-token $PLAN_ID --format json | jq -r '.token')
+TOKEN=$(nevermined x402token get-x402-access-token $PLAN_ID --format json | jq -r '.token')
 
 for i in {1..50}; do
   echo "Request $i..."
@@ -369,7 +369,7 @@ query_agent() {
 
   while [ $retry_count -lt $max_retries ]; do
     # Get fresh token
-    TOKEN=$(nvm x402token get-x402-access-token $plan_id --format json 2>&1)
+    TOKEN=$(nevermined x402token get-x402-access-token $plan_id --format json 2>&1)
 
     if [ $? -ne 0 ]; then
       echo "Error getting token: $TOKEN"
@@ -395,7 +395,7 @@ query_agent() {
         ;;
       402)
         echo "Insufficient credits. Purchasing more..."
-        nvm plans order-plan $plan_id
+        nevermined plans order-plan $plan_id
         ;;
       429)
         echo "Rate limit exceeded. Waiting..."
@@ -432,16 +432,16 @@ PLAN_ID="did:nvm:abc123"
 LOG_FILE="credit-usage.log"
 
 # Get initial balance
-INITIAL=$(nvm plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
+INITIAL=$(nevermined plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
 
 # Make query
-TOKEN=$(nvm x402token get-x402-access-token $PLAN_ID --format json | jq -r '.token')
+TOKEN=$(nevermined x402token get-x402-access-token $PLAN_ID --format json | jq -r '.token')
 RESPONSE=$(curl -s -X POST https://agent-api.example.com/v1/chat \
   -H "payment-signature: $TOKEN" \
   -d '{"message": "test query"}')
 
 # Get new balance
-FINAL=$(nvm plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
+FINAL=$(nevermined plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
 
 # Calculate usage
 USED=$((INITIAL - FINAL))
@@ -486,7 +486,7 @@ Tokens may expire, always get fresh tokens for new sessions:
 
 ```bash
 # Don't reuse old tokens
-TOKEN=$(nvm x402token get-x402-access-token $PLAN_ID --format json | jq -r '.token')
+TOKEN=$(nevermined x402token get-x402-access-token $PLAN_ID --format json | jq -r '.token')
 ```
 
 ### 2. Credit Management
@@ -494,10 +494,10 @@ TOKEN=$(nvm x402token get-x402-access-token $PLAN_ID --format json | jq -r '.tok
 Monitor balance before queries:
 
 ```bash
-BALANCE=$(nvm plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
+BALANCE=$(nevermined plans get-plan-balance $PLAN_ID --format json | jq -r '.balance')
 if [ "$BALANCE" -lt "10" ]; then
   echo "Low credits, refilling..."
-  nvm plans order-plan $PLAN_ID
+  nevermined plans order-plan $PLAN_ID
 fi
 ```
 
@@ -532,7 +532,7 @@ Never commit tokens to version control:
 
 ```bash
 # Use environment variables
-export X402_TOKEN=$(nvm x402token get-x402-access-token $PLAN_ID --format json | jq -r '.token')
+export X402_TOKEN=$(nevermined x402token get-x402-access-token $PLAN_ID --format json | jq -r '.token')
 
 # Or secure file storage
 chmod 600 ~/.nvm-token
@@ -555,7 +555,7 @@ Token may be expired or malformed:
 
 ```bash
 # Get a fresh token
-nvm x402token get-x402-access-token $PLAN_ID
+nevermined x402token get-x402-access-token $PLAN_ID
 ```
 
 ### "Insufficient credits"
@@ -564,10 +564,10 @@ Your balance is too low:
 
 ```bash
 # Check balance
-nvm plans get-plan-balance $PLAN_ID
+nevermined plans get-plan-balance $PLAN_ID
 
 # Purchase more
-nvm plans order-plan $PLAN_ID
+nevermined plans order-plan $PLAN_ID
 ```
 
 ### "402 Payment Required"

--- a/cli/package.json
+++ b/cli/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "bin": {
-    "nvm": "./bin/run.js"
+    "nevermined": "./bin/run.js"
   },
   "main": "dist/index.js",
   "files": [
@@ -66,7 +66,7 @@
     "node": ">=18.0.0"
   },
   "oclif": {
-    "bin": "nvm",
+    "bin": "nevermined",
     "dirname": "nvm",
     "commands": "./dist/commands",
     "plugins": [

--- a/cli/src/base-command.ts
+++ b/cli/src/base-command.ts
@@ -71,7 +71,7 @@ export abstract class BaseCommand extends Command {
 
     if (!nvmApiKey) {
       this.error(
-        'NVM API Key not found. Set NVM_API_KEY environment variable, run: nvm login, or run: nvm config init',
+        'NVM API Key not found. Set NVM_API_KEY environment variable, run: nevermined login, or run: nevermined config init',
         { exit: 1 }
       )
     }
@@ -86,7 +86,7 @@ export abstract class BaseCommand extends Command {
       environment: environment as EnvironmentName,
     })
     // Expose for subclasses that need to talk to backend endpoints the
-    // SDK does not yet wrap — see `nvm cards setup/enroll/delegate`.
+    // SDK does not yet wrap — see `nevermined cards setup/enroll/delegate`.
     this.resolvedEnvironment = environment as EnvironmentName
     this.resolvedNvmApiKey = nvmApiKey
 
@@ -110,7 +110,7 @@ export abstract class BaseCommand extends Command {
     if (errorMessage.includes('API Key') || errorMessage.includes('apiKey')) {
       this.formatter.error('API Key Error: ' + errorMessage)
       this.formatter.info('\n💡 Helpful tip:')
-      this.formatter.info('   Run: nvm login (or nvm config init)')
+      this.formatter.info('   Run: nevermined login (or nevermined config init)')
       this.formatter.info('   Or set: export NVM_API_KEY=your-key-here')
     } else if (errorMessage.includes('network') || errorMessage.includes('ECONNREFUSED')) {
       this.formatter.error('Network Error: ' + errorMessage)
@@ -126,7 +126,7 @@ export abstract class BaseCommand extends Command {
       this.formatter.error('Authentication Error: ' + errorMessage)
       this.formatter.info('\n💡 Helpful tip:')
       this.formatter.info('   Your API key may be invalid or expired')
-      this.formatter.info('   Run: nvm login (or nvm config init)')
+      this.formatter.info('   Run: nevermined login (or nevermined config init)')
     } else if (errorMessage.includes('JSON') || errorMessage.includes('parse')) {
       this.formatter.error('Invalid JSON: ' + errorMessage)
       this.formatter.info('\n💡 Helpful tip:')

--- a/cli/src/commands/agents/add-plan-to-agent.ts
+++ b/cli/src/commands/agents/add-plan-to-agent.ts
@@ -8,7 +8,7 @@ export default class AddPlanToAgent extends BaseCommand {
   static override description = "Adds an existing Payment Plan to an AI Agent. After this operation, users with access to the Payment Plan will be able to access the AI Agent."
 
   static override examples = [
-    '$ nvm agents add-plan-to-agent <planId>'
+    '$ nevermined agents add-plan-to-agent <planId>'
   ]
 
   static override flags = {

--- a/cli/src/commands/agents/get-agent-plans.ts
+++ b/cli/src/commands/agents/get-agent-plans.ts
@@ -8,7 +8,7 @@ export default class GetAgentPlans extends BaseCommand {
   static override description = "Gets the list of plans that can be ordered to get access to an agent."
 
   static override examples = [
-    '$ nvm agents get-agent-plans <agentId>'
+    '$ nevermined agents get-agent-plans <agentId>'
   ]
 
   static override flags = {

--- a/cli/src/commands/agents/get-agent.ts
+++ b/cli/src/commands/agents/get-agent.ts
@@ -8,7 +8,7 @@ export default class GetAgent extends BaseCommand {
   static override description = "Gets the metadata for a given Agent identifier."
 
   static override examples = [
-    '$ nvm agents get-agent <agentId>'
+    '$ nevermined agents get-agent <agentId>'
   ]
 
   static override flags = {

--- a/cli/src/commands/agents/get-agents.ts
+++ b/cli/src/commands/agents/get-agents.ts
@@ -8,7 +8,7 @@ export default class GetAgents extends BaseCommand {
   static override description = "Lists the AI agents **you** published (the authenticated caller's own agents). This is account management, not a marketplace search — it never returns other users' agents."
 
   static override examples = [
-    '$ nvm agents get-agents <orgId>'
+    '$ nevermined agents get-agents <orgId>'
   ]
 
   static override flags = {

--- a/cli/src/commands/agents/register-agent-and-plan.ts
+++ b/cli/src/commands/agents/register-agent-and-plan.ts
@@ -8,7 +8,7 @@ export default class RegisterAgentAndPlan extends BaseCommand {
   static override description = "It registers a new AI Agent and a Payment Plan associated to this new agent. Depending on the Payment Plan and the configuration of the agent, the usage of the agent/service will consume credits. When the plan expires (because the time is over or the credits are consumed), the user needs to renew the plan to continue using the agent."
 
   static override examples = [
-    '$ nvm agents register-agent-and-plan'
+    '$ nevermined agents register-agent-and-plan'
   ]
 
   static override flags = {

--- a/cli/src/commands/agents/register-agent.ts
+++ b/cli/src/commands/agents/register-agent.ts
@@ -8,7 +8,7 @@ export default class RegisterAgent extends BaseCommand {
   static override description = "It registers a new AI Agent on Nevermined. The agent must be associated to one or multiple Payment Plans. Users that are subscribers of a payment plan can query the agent. Depending on the Payment Plan and the configuration of the agent, the usage of the agent/service will consume credits. When the plan expires (because the time is over or the credits are consumed), the user needs to renew the plan to continue using the agent."
 
   static override examples = [
-    '$ nvm agents register-agent'
+    '$ nevermined agents register-agent'
   ]
 
   static override flags = {

--- a/cli/src/commands/agents/remove-plan-from-agent.ts
+++ b/cli/src/commands/agents/remove-plan-from-agent.ts
@@ -8,7 +8,7 @@ export default class RemovePlanFromAgent extends BaseCommand {
   static override description = "Removes a Payment Plan from an AI Agent. After this operation, users with access to the Payment Plan will no longer be able to access the AI Agent."
 
   static override examples = [
-    '$ nvm agents remove-plan-from-agent <planId>'
+    '$ nevermined agents remove-plan-from-agent <planId>'
   ]
 
   static override flags = {

--- a/cli/src/commands/agents/update-agent-metadata.ts
+++ b/cli/src/commands/agents/update-agent-metadata.ts
@@ -8,7 +8,7 @@ export default class UpdateAgentMetadata extends BaseCommand {
   static override description = "Updates the metadata and API attributes of an existing AI Agent."
 
   static override examples = [
-    '$ nvm agents update-agent-metadata <agentId>'
+    '$ nevermined agents update-agent-metadata <agentId>'
   ]
 
   static override flags = {

--- a/cli/src/commands/cards/delegate.ts
+++ b/cli/src/commands/cards/delegate.ts
@@ -16,7 +16,7 @@ import {
  * the resulting `delegationId` is redirected back to a localhost
  * callback.
  *
- * The combined `nvm cards setup` flow is preferred for first-time
+ * The combined `nevermined cards setup` flow is preferred for first-time
  * card setup; use this when the card already exists and only the
  * delegation needs to be (re-)created.
  */

--- a/cli/src/commands/cards/enroll.ts
+++ b/cli/src/commands/cards/enroll.ts
@@ -16,7 +16,7 @@ import {
  * resulting `paymentMethodId` back to a localhost callback.
  *
  * For the common case of "add a card AND a delegation in one flow",
- * use `nvm cards setup` instead — the combined command emits both IDs
+ * use `nevermined cards setup` instead — the combined command emits both IDs
  * in a single callback.
  */
 export default class CardsEnroll extends BaseCommand {

--- a/cli/src/commands/cards/setup.ts
+++ b/cli/src/commands/cards/setup.ts
@@ -16,10 +16,10 @@ import {
  * receives `paymentMethodId` + `delegationId` back at a localhost
  * callback the CLI starts for the duration of the flow.
  *
- * Mirrors the `nvm login` UX: ephemeral HTTP server on a random port,
+ * Mirrors the `nevermined login` UX: ephemeral HTTP server on a random port,
  * URL printed (or browser opened), 5-minute timeout, single-use
  * `state` echo for CSRF binding. The user must already be authenticated
- * (`nvm login`) and must be a member of at least one organisation —
+ * (`nevermined login`) and must be a member of at least one organisation —
  * the widgets feature is organisation-scoped (see issue #1671).
  */
 export default class CardsSetup extends BaseCommand {

--- a/cli/src/commands/config/init.ts
+++ b/cli/src/commands/config/init.ts
@@ -81,7 +81,7 @@ export default class ConfigInit extends BaseCommand {
           `  Environment: ${environment}`
       )
 
-      this.formatter.info('You can now use the CLI with: nvm plans get-plans')
+      this.formatter.info('You can now use the CLI with: nevermined plans get-plans')
     } catch (error: any) {
       this.handleError(error)
     }

--- a/cli/src/commands/config/show.ts
+++ b/cli/src/commands/config/show.ts
@@ -26,7 +26,7 @@ export default class ConfigShow extends BaseCommand {
       const config = await this.configManager.load()
 
       if (!config) {
-        this.formatter.warning('No configuration found. Run: nvm config init')
+        this.formatter.warning('No configuration found. Run: nevermined config init')
         return
       }
 

--- a/cli/src/commands/delegation/list-payment-methods.ts
+++ b/cli/src/commands/delegation/list-payment-methods.ts
@@ -7,8 +7,8 @@ export default class ListPaymentMethods extends BaseCommand {
   static override description = 'List enrolled credit/debit cards available for card-delegation (fiat) payments.'
 
   static override examples = [
-    '$ nvm delegation list-payment-methods',
-    '$ nvm delegation list-payment-methods --format json',
+    '$ nevermined delegation list-payment-methods',
+    '$ nevermined delegation list-payment-methods --format json',
   ]
 
   static override flags = {

--- a/cli/src/commands/facilitator/settle-permissions.ts
+++ b/cli/src/commands/facilitator/settle-permissions.ts
@@ -8,7 +8,7 @@ export default class SettlePermissions extends BaseCommand {
   static override description = "Settle (burn) credits from a subscriber's payment plan. This method executes the actual credit consumption, burning the specified number of credits from the subscriber's balance. If the subscriber doesn't have enough credits, it will attempt to order more before settling. The planId and subscriberAddress are extracted from the x402AccessToken."
 
   static override examples = [
-    '$ nvm facilitator settle-permissions'
+    '$ nevermined facilitator settle-permissions'
   ]
 
   static override flags = {

--- a/cli/src/commands/facilitator/verify-permissions.ts
+++ b/cli/src/commands/facilitator/verify-permissions.ts
@@ -8,7 +8,7 @@ export default class VerifyPermissions extends BaseCommand {
   static override description = "Verify if a subscriber has permission to use credits from a payment plan. This method simulates the credit usage without actually burning credits, checking if the subscriber has sufficient balance and permissions. The planId and subscriberAddress are extracted from the x402AccessToken."
 
   static override examples = [
-    '$ nvm facilitator verify-permissions'
+    '$ nevermined facilitator verify-permissions'
   ]
 
   static override flags = {

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -134,7 +134,7 @@ export default class Login extends BaseCommand {
           `  Environment: ${environment}\n` +
           `  Config file: ${this.configManager.getDefaultConfigPath()}`
       )
-      this.formatter.info('\nYou can now use the CLI. Try: nvm plans get-plans')
+      this.formatter.info('\nYou can now use the CLI. Try: nevermined plans get-plans')
     } catch (error) {
       this.handleError(error)
     }

--- a/cli/src/commands/logout.ts
+++ b/cli/src/commands/logout.ts
@@ -49,7 +49,7 @@ export default class Logout extends BaseCommand {
         )
       }
 
-      this.formatter.info('\nTo authenticate again, run: nvm login')
+      this.formatter.info('\nTo authenticate again, run: nevermined login')
     } catch (error) {
       this.handleError(error)
     }

--- a/cli/src/commands/organizations/connect-stripe-account.ts
+++ b/cli/src/commands/organizations/connect-stripe-account.ts
@@ -8,7 +8,7 @@ export default class ConnectStripeAccount extends BaseCommand {
   static override description = "Connect user with Stripe"
 
   static override examples = [
-    '$ nvm organizations connect-stripe-account'
+    '$ nevermined organizations connect-stripe-account'
   ]
 
   static override flags = {

--- a/cli/src/commands/organizations/create-member.ts
+++ b/cli/src/commands/organizations/create-member.ts
@@ -8,7 +8,7 @@ export default class CreateMember extends BaseCommand {
   static override description = "Create a new member in the organization"
 
   static override examples = [
-    '$ nvm organizations create-member <userId>'
+    '$ nevermined organizations create-member <userId>'
   ]
 
   static override flags = {

--- a/cli/src/commands/organizations/get-members.ts
+++ b/cli/src/commands/organizations/get-members.ts
@@ -8,7 +8,7 @@ export default class GetMembers extends BaseCommand {
   static override description = "OrganizationsAPI getMembers"
 
   static override examples = [
-    '$ nvm organizations get-members'
+    '$ nevermined organizations get-members'
   ]
 
   static override flags = {

--- a/cli/src/commands/organizations/get-my-memberships.ts
+++ b/cli/src/commands/organizations/get-my-memberships.ts
@@ -8,7 +8,7 @@ export default class GetMyMemberships extends BaseCommand {
   static override description = "Lists every organization the authenticated user is an active member of, with their role and the organization's tier. Powers workspace pickers in third-party tools built on the SDK, and the \"where will this publish?\" UX when a user belongs to multiple orgs."
 
   static override examples = [
-    '$ nvm organizations get-my-memberships'
+    '$ nevermined organizations get-my-memberships'
   ]
 
   static override flags = {

--- a/cli/src/commands/organizations/get-organization-activity.ts
+++ b/cli/src/commands/organizations/get-organization-activity.ts
@@ -8,7 +8,7 @@ export default class GetOrganizationActivity extends BaseCommand {
   static override description = "Lists events emitted into the activity feed of an organization the caller is an active member of (member invites, customer events, subscription transitions, webhook deliveries, …). Requires the caller to be a Member or Admin of `orgId`; the backend returns 403 otherwise. Premium+ entitlement is enforced server-side."
 
   static override examples = [
-    '$ nvm organizations get-organization-activity <orgId>'
+    '$ nevermined organizations get-organization-activity <orgId>'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/get-agents-associated-to-a-plan.ts
+++ b/cli/src/commands/plans/get-agents-associated-to-a-plan.ts
@@ -8,7 +8,7 @@ export default class GetAgentsAssociatedToAPlan extends BaseCommand {
   static override description = "Gets the list of Agents that have associated a specific Payment Plan. All the agents returned can be accessed by the users that are subscribed to the Payment Plan."
 
   static override examples = [
-    '$ nvm plans get-agents-associated-to-a-plan <planId>'
+    '$ nevermined plans get-agents-associated-to-a-plan <planId>'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/get-crypto-price-config.ts
+++ b/cli/src/commands/plans/get-crypto-price-config.ts
@@ -8,7 +8,7 @@ export default class GetCryptoPriceConfig extends BaseCommand {
   static override description = "Builds a crypto price configuration for a plan."
 
   static override examples = [
-    '$ nvm plans get-crypto-price-config'
+    '$ nevermined plans get-crypto-price-config'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/get-dynamic-credits-config.ts
+++ b/cli/src/commands/plans/get-dynamic-credits-config.ts
@@ -8,7 +8,7 @@ export default class GetDynamicCreditsConfig extends BaseCommand {
   static override description = "Builds a DYNAMIC credits configuration (range-limited per request)."
 
   static override examples = [
-    '$ nvm plans get-dynamic-credits-config'
+    '$ nevermined plans get-dynamic-credits-config'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/get-erc20-price-config.ts
+++ b/cli/src/commands/plans/get-erc20-price-config.ts
@@ -8,7 +8,7 @@ export default class GetERC20PriceConfig extends BaseCommand {
   static override description = "Builds an ERC20 price configuration for a plan."
 
   static override examples = [
-    '$ nvm plans get-erc20-price-config'
+    '$ nevermined plans get-erc20-price-config'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/get-eurc-price-config.ts
+++ b/cli/src/commands/plans/get-eurc-price-config.ts
@@ -8,7 +8,7 @@ export default class GetEURCPriceConfig extends BaseCommand {
   static override description = "Builds an EURC (Euro stablecoin) price configuration for a plan."
 
   static override examples = [
-    '$ nvm plans get-eurc-price-config'
+    '$ nevermined plans get-eurc-price-config'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/get-expirable-duration-config.ts
+++ b/cli/src/commands/plans/get-expirable-duration-config.ts
@@ -8,7 +8,7 @@ export default class GetExpirableDurationConfig extends BaseCommand {
   static override description = "Credits helpers"
 
   static override examples = [
-    '$ nvm plans get-expirable-duration-config'
+    '$ nevermined plans get-expirable-duration-config'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/get-fiat-price-config.ts
+++ b/cli/src/commands/plans/get-fiat-price-config.ts
@@ -8,7 +8,7 @@ export default class GetFiatPriceConfig extends BaseCommand {
   static override description = "Price helpers"
 
   static override examples = [
-    '$ nvm plans get-fiat-price-config'
+    '$ nevermined plans get-fiat-price-config'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/get-fixed-credits-config.ts
+++ b/cli/src/commands/plans/get-fixed-credits-config.ts
@@ -8,7 +8,7 @@ export default class GetFixedCreditsConfig extends BaseCommand {
   static override description = "Builds a FIXED credits configuration."
 
   static override examples = [
-    '$ nvm plans get-fixed-credits-config'
+    '$ nevermined plans get-fixed-credits-config'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/get-free-price-config.ts
+++ b/cli/src/commands/plans/get-free-price-config.ts
@@ -8,7 +8,7 @@ export default class GetFreePriceConfig extends BaseCommand {
   static override description = "Builds a FREE price configuration (no payment required)."
 
   static override examples = [
-    '$ nvm plans get-free-price-config'
+    '$ nevermined plans get-free-price-config'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/get-native-token-price-config.ts
+++ b/cli/src/commands/plans/get-native-token-price-config.ts
@@ -8,7 +8,7 @@ export default class GetNativeTokenPriceConfig extends BaseCommand {
   static override description = "Builds a native token price configuration for a plan."
 
   static override examples = [
-    '$ nvm plans get-native-token-price-config'
+    '$ nevermined plans get-native-token-price-config'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/get-non-expirable-duration-config.ts
+++ b/cli/src/commands/plans/get-non-expirable-duration-config.ts
@@ -8,7 +8,7 @@ export default class GetNonExpirableDurationConfig extends BaseCommand {
   static override description = "Builds a NON-EXPIRABLE credits configuration (no expiration)."
 
   static override examples = [
-    '$ nvm plans get-non-expirable-duration-config'
+    '$ nevermined plans get-non-expirable-duration-config'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/get-pay-as-you-go-credits-config.ts
+++ b/cli/src/commands/plans/get-pay-as-you-go-credits-config.ts
@@ -8,7 +8,7 @@ export default class GetPayAsYouGoCreditsConfig extends BaseCommand {
   static override description = "Builds a Pay-As-You-Go credits configuration."
 
   static override examples = [
-    '$ nvm plans get-pay-as-you-go-credits-config'
+    '$ nevermined plans get-pay-as-you-go-credits-config'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/get-pay-as-you-go-price-config.ts
+++ b/cli/src/commands/plans/get-pay-as-you-go-price-config.ts
@@ -8,7 +8,7 @@ export default class GetPayAsYouGoPriceConfig extends BaseCommand {
   static override description = "Builds a Pay-As-You-Go price configuration using the template address from the API."
 
   static override examples = [
-    '$ nvm plans get-pay-as-you-go-price-config'
+    '$ nevermined plans get-pay-as-you-go-price-config'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/get-plan-balance.ts
+++ b/cli/src/commands/plans/get-plan-balance.ts
@@ -8,7 +8,7 @@ export default class GetPlanBalance extends BaseCommand {
   static override description = "Gets the balance of an account for a Payment Plan."
 
   static override examples = [
-    '$ nvm plans get-plan-balance <planId>'
+    '$ nevermined plans get-plan-balance <planId>'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/get-plan.ts
+++ b/cli/src/commands/plans/get-plan.ts
@@ -8,7 +8,7 @@ export default class GetPlan extends BaseCommand {
   static override description = "Gets the information about a Payment Plan by its identifier."
 
   static override examples = [
-    '$ nvm plans get-plan <planId>'
+    '$ nevermined plans get-plan <planId>'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/get-plans.ts
+++ b/cli/src/commands/plans/get-plans.ts
@@ -8,7 +8,7 @@ export default class GetPlans extends BaseCommand {
   static override description = "Lists the payment plans **you** published (the authenticated caller's own plans). This is account management, not a marketplace search — it never returns other users' plans."
 
   static override examples = [
-    '$ nvm plans get-plans <orgId>'
+    '$ nevermined plans get-plans <orgId>'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/mint-plan-credits.ts
+++ b/cli/src/commands/plans/mint-plan-credits.ts
@@ -8,7 +8,7 @@ export default class MintPlanCredits extends BaseCommand {
   static override description = "Mints credits for a given Payment Plan and transfers them to a receiver."
 
   static override examples = [
-    '$ nvm plans mint-plan-credits <planId>'
+    '$ nevermined plans mint-plan-credits <planId>'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/mint-plan-expirable.ts
+++ b/cli/src/commands/plans/mint-plan-expirable.ts
@@ -8,7 +8,7 @@ export default class MintPlanExpirable extends BaseCommand {
   static override description = "Mints expirable credits for a given Payment Plan and transfers them to a receiver."
 
   static override examples = [
-    '$ nvm plans mint-plan-expirable <planId>'
+    '$ nevermined plans mint-plan-expirable <planId>'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/order-fiat-plan.ts
+++ b/cli/src/commands/plans/order-fiat-plan.ts
@@ -8,7 +8,7 @@ export default class OrderFiatPlan extends BaseCommand {
   static override description = "Initiates the purchase of a Plan requiring the payment in Fiat. This method will return a URL where the user can complete the payment."
 
   static override examples = [
-    '$ nvm plans order-fiat-plan <planId>'
+    '$ nevermined plans order-fiat-plan <planId>'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/order-plan.ts
+++ b/cli/src/commands/plans/order-plan.ts
@@ -8,7 +8,7 @@ export default class OrderPlan extends BaseCommand {
   static override description = "Orders a Payment Plan requiring the payment in crypto. The user must have enough balance in the selected token."
 
   static override examples = [
-    '$ nvm plans order-plan <planId>'
+    '$ nevermined plans order-plan <planId>'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/register-credits-plan.ts
+++ b/cli/src/commands/plans/register-credits-plan.ts
@@ -8,7 +8,7 @@ export default class RegisterCreditsPlan extends BaseCommand {
   static override description = "It allows to an AI Builder to create a Payment Plan on Nevermined based on Credits. A Nevermined Credits Plan limits the access by the access/usage of the Plan. With them, AI Builders control the number of requests that can be made to an agent or service. Every time a user accesses any resouce associated to the Payment Plan, the usage consumes from a capped amount of credits. When the user consumes all the credits, the plan automatically expires and the user needs to top up to continue using the service."
 
   static override examples = [
-    '$ nvm plans register-credits-plan'
+    '$ nevermined plans register-credits-plan'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/register-credits-trial-plan.ts
+++ b/cli/src/commands/plans/register-credits-trial-plan.ts
@@ -8,7 +8,7 @@ export default class RegisterCreditsTrialPlan extends BaseCommand {
   static override description = "It allows to an AI Builder to create a Trial Payment Plan on Nevermined limited by duration. A Nevermined Trial Plan allow subscribers of that plan to test the Agents associated to it. A Trial plan is a plan that only can be purchased once by a user. Trial plans, as regular plans, can be limited by duration (i.e 1 week of usage) or by credits (i.e 100 credits to use the agent)."
 
   static override examples = [
-    '$ nvm plans register-credits-trial-plan'
+    '$ nevermined plans register-credits-trial-plan'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/register-plan.ts
+++ b/cli/src/commands/plans/register-plan.ts
@@ -8,7 +8,7 @@ export default class RegisterPlan extends BaseCommand {
   static override description = "It allows to an AI Builder to register a Payment Plan on Nevermined in a flexible manner. A Payment Plan defines 2 main aspects: 1. What a subscriber needs to pay to get the plan (i.e. 100 USDC, 5 USD, etc). 2. What the subscriber gets in return to access the AI agents associated to the plan (i.e. 100 credits, 1 week of usage, etc). With Payment Plans, AI Builders control the usage to their AI Agents. Every time a user accesses an AI Agent to the Payment Plan, the usage consumes from a capped amount of credits (or when the plan duration expires). When the user consumes all the credits, the plan automatically expires and the user needs to top up to continue using the service."
 
   static override examples = [
-    '$ nvm plans register-plan'
+    '$ nevermined plans register-plan'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/register-time-plan.ts
+++ b/cli/src/commands/plans/register-time-plan.ts
@@ -8,7 +8,7 @@ export default class RegisterTimePlan extends BaseCommand {
   static override description = "It allows to an AI Builder to create a Payment Plan on Nevermined limited by duration. A Nevermined Credits Plan limits the access by the access/usage of the Plan. With them, AI Builders control the number of requests that can be made to an agent or service. Every time a user accesses any resouce associated to the Payment Plan, the usage consumes from a capped amount of credits. When the user consumes all the credits, the plan automatically expires and the user needs to top up to continue using the service."
 
   static override examples = [
-    '$ nvm plans register-time-plan'
+    '$ nevermined plans register-time-plan'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/register-time-trial-plan.ts
+++ b/cli/src/commands/plans/register-time-trial-plan.ts
@@ -8,7 +8,7 @@ export default class RegisterTimeTrialPlan extends BaseCommand {
   static override description = "It allows to an AI Builder to create a Trial Payment Plan on Nevermined limited by duration. A Nevermined Trial Plan allow subscribers of that plan to test the Agents associated to it. A Trial plan is a plan that only can be purchased once by a user. Trial plans, as regular plans, can be limited by duration (i.e 1 week of usage) or by credits (i.e 100 credits to use the agent)."
 
   static override examples = [
-    '$ nvm plans register-time-trial-plan'
+    '$ nevermined plans register-time-trial-plan'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/set-onchain-mirror.ts
+++ b/cli/src/commands/plans/set-onchain-mirror.ts
@@ -8,7 +8,7 @@ export default class SetOnchainMirror extends BaseCommand {
   static override description = "Marks whether burns of these credits are mirrored on-chain."
 
   static override examples = [
-    '$ nvm plans set-onchain-mirror'
+    '$ nevermined plans set-onchain-mirror'
   ]
 
   static override flags = {

--- a/cli/src/commands/plans/set-redemption-type.ts
+++ b/cli/src/commands/plans/set-redemption-type.ts
@@ -8,7 +8,7 @@ export default class SetRedemptionType extends BaseCommand {
   static override description = "Sets the redemption type in a credits configuration."
 
   static override examples = [
-    '$ nvm plans set-redemption-type'
+    '$ nevermined plans set-redemption-type'
   ]
 
   static override flags = {

--- a/cli/src/commands/x402token/get-x402-access-token.ts
+++ b/cli/src/commands/x402token/get-x402-access-token.ts
@@ -10,11 +10,11 @@ export default class GetX402AccessToken extends BaseCommand {
   static override description = "Create a delegation and get an X402 access token for the given plan. Supports both crypto (erc4337) and fiat (card-delegation) payment schemes."
 
   static override examples = [
-    '$ nvm x402token get-x402-access-token <planId>',
-    '$ nvm x402token get-x402-access-token <planId> --payment-type fiat',
-    '$ nvm x402token get-x402-access-token <planId> --payment-type fiat --payment-method-id pm_1AbCdEfGhIjKlM --spending-limit-cents 5000',
-    '$ nvm x402token get-x402-access-token <planId> --spending-limit-cents 100000 --delegation-duration-secs 604800',
-    '$ nvm x402token get-x402-access-token <planId> --auto-resolve-scheme',
+    '$ nevermined x402token get-x402-access-token <planId>',
+    '$ nevermined x402token get-x402-access-token <planId> --payment-type fiat',
+    '$ nevermined x402token get-x402-access-token <planId> --payment-type fiat --payment-method-id pm_1AbCdEfGhIjKlM --spending-limit-cents 5000',
+    '$ nevermined x402token get-x402-access-token <planId> --spending-limit-cents 100000 --delegation-duration-secs 604800',
+    '$ nevermined x402token get-x402-access-token <planId> --auto-resolve-scheme',
   ]
 
   static override flags = {

--- a/cli/src/generator/command-generator.ts
+++ b/cli/src/generator/command-generator.ts
@@ -292,7 +292,7 @@ ${runMethod}
       const idParam = method.parameters.find(p => p.name.toLowerCase().includes('id'))
       const idExample = idParam ? `<${idParam.name}>` : ''
 
-      examples.push(`$ nvm ${topic} ${commandName} ${idExample}`.trim())
+      examples.push(`$ nevermined ${topic} ${commandName} ${idExample}`.trim())
     }
 
     return examples.map(ex => `    '${ex.replace(/'/g, "\\'")}'`).join(',\n')

--- a/cli/src/generator/generate.ts
+++ b/cli/src/generator/generate.ts
@@ -74,7 +74,7 @@ async function main() {
   console.log('\n✨ Next steps:')
   console.log('   1. Review generated commands in src/commands/')
   console.log('   2. Run: pnpm build:manifest')
-  console.log('   3. Test commands: nvm <topic> <command> --help')
+  console.log('   3. Test commands: nevermined <topic> <command> --help')
   console.log('   4. Run tests: pnpm test')
 
   console.log('\n🎉 Done!\n')

--- a/cli/src/utils/browser.ts
+++ b/cli/src/utils/browser.ts
@@ -2,7 +2,7 @@ import { execFile } from 'child_process'
 
 /**
  * Open the user's default browser at `url`. Cross-platform wrapper used
- * by `nvm login` and `nvm cards setup/enroll/delegate`.
+ * by `nevermined login` and `nevermined cards setup/enroll/delegate`.
  *
  * On Windows we deliberately avoid `cmd /c start <url>`: cmd parses `&`
  * inside the URL as a command separator, which truncates any URL that

--- a/cli/src/utils/widget-redirect-flow.ts
+++ b/cli/src/utils/widget-redirect-flow.ts
@@ -49,7 +49,7 @@ const SELF_MINT_FETCH_TIMEOUT_MS = 15_000
 
 /**
  * Default timeout for a redirect-mode CLI flow. Mirrors the existing
- * `nvm login` callback timeout — 5 minutes is enough for the user to
+ * `nevermined login` callback timeout — 5 minutes is enough for the user to
  * tab into the browser, complete a card enrolment + delegation, and
  * land back at the CLI.
  */

--- a/markdown/cli-card-setup.md
+++ b/markdown/cli-card-setup.md
@@ -11,9 +11,9 @@ Nevermined ships a standalone embed app (served at `embed.<tier>` — e.g. `embe
 1. Enrolling a credit / debit card (via Stripe Elements — sensitive data never touches your servers).
 2. Creating a spending delegation against that card (a per-card budget the user pre-authorises for agent spend).
 
-This guide explains how a **CLI or any other non-iframe integrator** can drive that page in a top-level browser tab and receive `paymentMethodId` + `delegationId` back at a localhost HTTP callback. The pattern mirrors `nvm login`: print a URL, the user clicks it, the browser redirects back to a one-shot port on the user's machine, your process resolves with the result.
+This guide explains how a **CLI or any other non-iframe integrator** can drive that page in a top-level browser tab and receive `paymentMethodId` + `delegationId` back at a localhost HTTP callback. The pattern mirrors `nevermined login`: print a URL, the user clicks it, the browser redirects back to a one-shot port on the user's machine, your process resolves with the result.
 
-The official `nvm` CLI ships three commands implementing this flow out of the box — see [`nvm cards setup`](#using-the-nvm-cli) below. If you are building your own CLI or backend integration, the rest of this guide is the contract you need to honour.
+The official `nevermined` CLI ships three commands implementing this flow out of the box — see [`nevermined cards setup`](#using-the-nevermined-cli) below. If you are building your own CLI or backend integration, the rest of this guide is the contract you need to honour.
 
 ## When to Use This Flow
 
@@ -28,7 +28,7 @@ For the classic iframe integration (a website embedding `/cards/enroll` etc. ins
 | Path | Who uses it | Authentication |
 |------|-------------|---------------|
 | **Widget-key** | A third-party (website backend, CLI) acting on behalf of an organisation's own end-users. The end-users do not necessarily have their own Nevermined accounts. | Server signs an init-token with the organisation's widget-key secret and exchanges it at `POST /widgets/session` for a session token. |
-| **Self-mint** | A user with their own NVM API key (typically after running `nvm login`) who wants to attach a card to their *own* Nevermined identity. | `POST /widgets/session/self` with `Authorization: Bearer <nvmApiKey>`. |
+| **Self-mint** | A user with their own NVM API key (typically after running `nevermined login`) who wants to attach a card to their *own* Nevermined identity. | `POST /widgets/session/self` with `Authorization: Bearer <nvmApiKey>`. |
 
 Both paths produce the same response shape (`WidgetSessionResponse`); the embed routes don't branch on which one was used.
 
@@ -89,21 +89,21 @@ Card setup is **organization-scoped**. Self-mint callers must be members of at l
 
 The browser ends up on a friendly "All done — close this tab" page so the user knows the flow finished; your CLI prints the IDs and exits.
 
-## Using the `nvm` CLI
+## Using the `nevermined` CLI
 
 Three commands are available out of the box:
 
 ```bash
 # Combined: enroll a card AND create a delegation in one flow.
 # Returns both paymentMethodId and delegationId.
-nvm cards setup
+nevermined cards setup
 
 # Single-purpose: only enroll a card. Returns paymentMethodId.
-nvm cards enroll
+nevermined cards enroll
 
 # Single-purpose: only create a delegation against an already-enrolled card.
 # Returns delegationId.
-nvm cards delegate --card pm_1234
+nevermined cards delegate --card pm_1234
 ```
 
 All three accept:
@@ -111,10 +111,10 @@ All three accept:
 - `--no-browser` — Print the URL instead of opening the browser automatically (useful over SSH or in CI).
 - `--provider stripe|braintree|visa` — Tokenization provider for the enrolment step. Defaults to `stripe`.
 
-Pre-requisite: run `nvm login` first to authenticate against the target environment.
+Pre-requisite: run `nevermined login` first to authenticate against the target environment.
 
 ```bash
-$ nvm cards setup
+$ nevermined cards setup
 ℹ Using organization: Acme AI (org-abc-123)
 Opening browser...
 Waiting for completion...
@@ -195,12 +195,12 @@ Three other routes exist if you only need one step of the flow:
 
 The browser redirects to `<returnUrl>?paymentMethodId=…&delegationId=…&state=<echo>` on success. Your local server should:
 
-1. Verify the `state` query parameter matches the one you issued. Use a constant-time string comparison (the `nvm` CLI uses `crypto.timingSafeEqual`).
+1. Verify the `state` query parameter matches the one you issued. Use a constant-time string comparison (the `nevermined` CLI uses `crypto.timingSafeEqual`).
 2. Extract `paymentMethodId` and `delegationId` (or just one, depending on which embed route you opened).
 3. Respond `200 OK` with a friendly "you can close this tab" HTML page.
 4. Close the server.
 
-Recommended timeout: **5 minutes**. Match the `nvm login` flow so users have time to switch contexts in their browser.
+Recommended timeout: **5 minutes**. Match the `nevermined login` flow so users have time to switch contexts in their browser.
 
 ### Pseudocode
 
@@ -298,6 +298,6 @@ Rules:
 
 ## See Also
 
-- [`nvm login`](./installation.md) — the equivalent flow for authentication.
+- [`nevermined login`](./installation.md) — the equivalent flow for authentication.
 - [Payment Plans](./payment-plans.md) — once a card is delegated, you can use it to subscribe to plans.
 - [Initialising the Library](./initializing-the-library.md) — bootstrap the SDK.

--- a/markdown/payments-and-balance.md
+++ b/markdown/payments-and-balance.md
@@ -110,7 +110,7 @@ if (fiatResult.checkoutUrl) {
 
 ```bash
 # Order a fiat plan (returns a Stripe checkout URL)
-nvm plans order-fiat-plan <plan-id>
+nevermined plans order-fiat-plan <plan-id>
 ```
 
 > **Note**: When using X402 card-delegation tokens (`nvm:card-delegation` scheme), the payment is handled automatically through the delegated card — no separate checkout URL is needed. See [Querying an Agent](./querying-an-agent) for details on card-delegation tokens.

--- a/markdown/querying-an-agent.md
+++ b/markdown/querying-an-agent.md
@@ -131,22 +131,22 @@ const { accessToken } = await subscriberPayments.x402.getX402AccessToken(
 
 ```bash
 # Crypto (default)
-nvm x402token get-x402-access-token <planId>
+nevermined x402token get-x402-access-token <planId>
 
 # Fiat with auto-selected card
-nvm x402token get-x402-access-token <planId> --payment-type fiat
+nevermined x402token get-x402-access-token <planId> --payment-type fiat
 
 # Fiat with specific card and limits
-nvm x402token get-x402-access-token <planId> --payment-type fiat \
+nevermined x402token get-x402-access-token <planId> --payment-type fiat \
     --payment-method-id pm_1AbCdEfGhIjKlM \
     --spending-limit-cents 5000 \
     --delegation-duration-secs 7200
 
 # Auto-detect scheme from plan metadata
-nvm x402token get-x402-access-token <planId> --auto-resolve-scheme
+nevermined x402token get-x402-access-token <planId> --auto-resolve-scheme
 
 # List enrolled payment methods
-nvm delegation list-payment-methods
+nevermined delegation list-payment-methods
 ```
 
 ### Basic Example


### PR DESCRIPTION
## Summary

Renames the CLI binary from `nvm` to `nevermined`. The old name collided with [Node Version Manager](https://github.com/nvm-sh/nvm) — by far the most common `nvm` on developer machines — which shadowed the Nevermined CLI depending on shell/PATH setup (#388).

Per the team RFC decision (issue #388):
- **Name:** `nevermined`
- **Transition:** clean rename, no deprecated `nvm` alias
- **Config dir:** `oclif.dirname` stays `nvm`, so existing `~/.config/nvm` config is **not** orphaned (no migration needed)

## Changes

- `cli/package.json`: `bin` key and oclif `bin` → `nevermined`; `dirname: "nvm"` kept intentionally
- All command examples (`$ nevermined ...`), help text and the command generator updated
- CLI `README.md` / guides and published `markdown/` docs updated (incl. internal anchor in `cli-card-setup.md`)
- Migration note added to `getting-started.md`

**Left untouched on purpose:** `nvmApiKey` / `NVM_*` env vars, protocol schemes (`nvm:erc4337`, `nvm:card-delegation`), `did:nvm:` DIDs, the `~/.config/nvm` config dir, and `CHANGELOG.md` history.

## Breaking change

Hard rename: scripts invoking `nvm <command>` must switch to `nevermined <command>`.

## Validation

- `pnpm test:unit` (CLI) passes 10/10
- `pnpm build` failures present locally are pre-existing SDK type drift (`node_modules` ships published SDK 1.3.2); CI builds against the local SDK via symlink

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)