### PR TITLE
docs: retire docs.nevermined.app references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Every HTTP call to the Nevermined backend carries a `Nevermined-Version` header 
 
 **Override path**: per `Payments` instance via the existing `options.version` (e.g. `Payments.getInstance({ ..., version: '1.0' })`). There is intentionally **no per-request override** — `Nevermined-Version` is not in the `ALLOWED_EXTRA_HEADERS` allowlist, so `extraHeaders` cannot clobber it.
 
-See https://docs.nevermined.app/api-reference/versioning and nvm-monorepo#1535/#1938.
+See https://nevermined.ai/docs/development-guide/api-versioning and nvm-monorepo#1535/#1938.
 
 ### x402 Protocol and Documentation Standards
 

--- a/openclaw/skills/nevermined/SKILL.md
+++ b/openclaw/skills/nevermined/SKILL.md
@@ -67,7 +67,7 @@ Log out from Nevermined and remove the stored API key.
 
 Every Nevermined-backend call this plugin makes goes through the `@nevermined-io/payments` SDK, which **pins the backend API version** (the platform `MAJOR.MINOR`) via the `Nevermined-Version` header automatically — so OpenClaw-orchestrated agents keep getting a stable wire shape across platform releases without any per-call work. The pinned version is the one the bundled SDK release was built and tested against; it moves only when the plugin upgrades its SDK dependency.
 
-If an agent makes a **direct** REST call to the Nevermined API (outside these tools), send `Nevermined-Version: <MAJOR.MINOR>`, default it to the `current` from `GET /api/v1/meta/versions`, and never silently change a key's stored pin. See <https://docs.nevermined.app/docs/development-guide/api-versioning>.
+If an agent makes a **direct** REST call to the Nevermined API (outside these tools), send `Nevermined-Version: <MAJOR.MINOR>`, default it to the `current` from `GET /api/v1/meta/versions`, and never silently change a key's stored pin. See <https://nevermined.ai/docs/development-guide/api-versioning>.
 
 ## Subscriber Tools
 

--- a/src/common/api-version.ts
+++ b/src/common/api-version.ts
@@ -12,7 +12,7 @@
  * Callers can override the pin per `Payments` instance via
  * `options.version`.
  *
- * @see https://docs.nevermined.app/api-reference/versioning
+ * @see https://nevermined.ai/docs/development-guide/api-versioning
  */
 export const LOCKED_API_VERSION = '1.1'
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -50,7 +50,7 @@ export interface PaymentOptions {
    * built and tested against. Override only to deliberately target a
    * different backend contract.
    *
-   * @see https://docs.nevermined.app/api-reference/versioning
+   * @see https://nevermined.ai/docs/development-guide/api-versioning
    */
   version?: string
 


### PR DESCRIPTION
Payments-repo slice of the cross-repo sweep tracked in [nevermined-io/nevermined.ai-website#233](https://github.com/nevermined-io/nevermined.ai-website/issues/233).

## What changed

This repo had four source references to `docs.nevermined.app`, and all four hit the same dead path — `/api-reference/versioning` 404s on the old host *and* on `nevermined.ai/docs`. So this is issue case #2 (dead link, not just a stale host): a plain host substitution would have produced a working URL to a 404.

Repointed all four at the live page, `https://nevermined.ai/docs/development-guide/api-versioning` (verified 200):

| File | Context |
| --- | --- |
| `src/common/api-version.ts:15` | `@see` on `LOCKED_API_VERSION` |
| `src/common/types.ts:53` | `@see` on `PaymentOptions.version` |
| `CLAUDE.md:92` | API Version Pinning section |
| `openclaw/skills/nevermined/SKILL.md:70` | already used the correct `development-guide/api-versioning` path — only the host was stale |

## Deliberately not touched

`docs/interfaces/PaymentOptions.html` and `docs/variables/LOCKED_API_VERSION.html` are TypeDoc build output, not source — the false-positive category the issue calls out. They pick up the new URL on the next `pnpm doc`.

## Verification

```
$ grep -rn "docs\.nevermined\.app" CLAUDE.md src openclaw
(no matches)
```

`pnpm build` currently fails on `src/x402/langchain/agent.ts` with `TS2307: Cannot find module '@langchain/langgraph/prebuilt'`. That failure reproduces on a clean tree at `main` and is unrelated to this diff, which touches only doc comments and markdown.

Refs nevermined-io/nevermined.ai-website#233

🤖 Generated with [Claude Code](https://claude.com/claude-code)