### PR TITLE
fix(organizations): onboardCustomer returns the Bearer (hash), not the encrypted blob

### DIFF
--- a/src/api/organizations-api/organizations-api.ts
+++ b/src/api/organizations-api/organizations-api.ts
@@ -91,17 +91,20 @@ export class OrganizationsAPI extends BasePaymentsAPI {
     if (response.status === 202 || wallet.consentRequired) {
       return { consentRequired: true }
     }
-    // New account or the org's returning customer: a usable key MUST be present.
-    // A 2xx without one means a partial/unexpected payload — fail loudly rather
-    // than hand back a "success" carrying undefined credentials.
-    if (!wallet.nvmApiKey) {
+    // New account or the org's returning customer: the Bearer MUST be present.
+    // The backend returns the usable credential as `walletResult.hash`
+    // (`<env>:<JWT>`) — the sibling `nvmApiKey` is the encrypted server-side
+    // blob and is NOT a valid Bearer. Surface `hash` as `nvmApiKey`, exactly as
+    // createMember does. A 2xx without a hash means a partial/unexpected payload
+    // — fail loudly rather than hand back a "success" carrying no credential.
+    if (!wallet.hash) {
       throw PaymentsError.internal(
         'Customer onboarding did not return an API key (unexpected backend response)',
       )
     }
     return {
       consentRequired: false,
-      nvmApiKey: wallet.nvmApiKey,
+      nvmApiKey: wallet.hash,
       userId: wallet.userId,
       userWallet: wallet.userWallet,
       isCustomer: wallet.isCustomer,

--- a/src/api/organizations-api/organizations-api.ts
+++ b/src/api/organizations-api/organizations-api.ts
@@ -109,6 +109,7 @@ export class OrganizationsAPI extends BasePaymentsAPI {
       userWallet: wallet.userWallet,
       isCustomer: wallet.isCustomer,
       customerRecorded: wallet.customerRecorded,
+      expiresAt: wallet.expiresAt,
     }
   }
 

--- a/src/api/organizations-api/types.ts
+++ b/src/api/organizations-api/types.ts
@@ -55,6 +55,12 @@ export type CustomerOnboardingResponse =
       isCustomer: boolean
       /** Whether the customer was written to the org's Customers list (best-effort). */
       customerRecorded: boolean
+      /**
+       * ISO-8601 expiry of the credential (#2924). Track it and re-onboard to
+       * refresh before it lapses. Optional: returned for the credential outcome,
+       * but an older backend may omit it.
+       */
+      expiresAt?: string
     }
 
 /**

--- a/tests/unit/organizations-api.test.ts
+++ b/tests/unit/organizations-api.test.ts
@@ -315,7 +315,7 @@ describe('OrganizationsAPI — workspace surface', () => {
   })
 
   describe('onboardCustomer (#2418)', () => {
-    test('new/returning customer: sends as=customer and returns the REAL nvmApiKey', async () => {
+    test('new/returning customer: sends as=customer and returns hash as the Bearer', async () => {
       const payments = makePayments()
       const calls = installFetchStub(() => ({
         ok: true,
@@ -324,10 +324,14 @@ describe('OrganizationsAPI — workspace surface', () => {
           success: true,
           message: 'Customer onboarded',
           walletResult: {
-            hash: 'lookup-hash',
+            // `hash` is the Bearer credential (`<env>:<JWT>`) — the backend
+            // documents this as the value to send as `Authorization: Bearer …`.
+            hash: 'sandbox:jwt-bearer-token',
             userId: 'us-123',
             userWallet: '0xabc',
-            nvmApiKey: 'nvm-real-usable-key',
+            // `nvmApiKey` is the encrypted server-side blob — explicitly NOT a
+            // Bearer; sending it as a header does not authenticate.
+            nvmApiKey: 'encrypted-blob-not-a-bearer',
             isCustomer: true,
             customerRecorded: true,
             alreadyMember: false,
@@ -344,10 +348,11 @@ describe('OrganizationsAPI — workspace surface', () => {
         email: 'customer@example.com',
         as: 'customer',
       })
-      // The USABLE key is returned — not the (non-usable) lookup hash.
+      // The USABLE Bearer is surfaced as `nvmApiKey` (mirroring createMember) —
+      // the raw `nvmApiKey` blob must never leak through as a credential.
       expect(result).toEqual({
         consentRequired: false,
-        nvmApiKey: 'nvm-real-usable-key',
+        nvmApiKey: 'sandbox:jwt-bearer-token',
         userId: 'us-123',
         userWallet: '0xabc',
         isCustomer: true,
@@ -390,7 +395,7 @@ describe('OrganizationsAPI — workspace surface', () => {
       installFetchStub(() => ({
         ok: true,
         status: 201,
-        // Partial/regressed payload: not consent-pending, yet no nvmApiKey.
+        // Partial/regressed payload: not consent-pending, yet no `hash` (the Bearer).
         body: { success: true, walletResult: { userId: 'us-1', isCustomer: true } },
       }))
 

--- a/tests/unit/organizations-api.test.ts
+++ b/tests/unit/organizations-api.test.ts
@@ -334,6 +334,7 @@ describe('OrganizationsAPI — workspace surface', () => {
             nvmApiKey: 'encrypted-blob-not-a-bearer',
             isCustomer: true,
             customerRecorded: true,
+            expiresAt: '2026-09-27T12:00:00.000Z',
             alreadyMember: false,
           },
         },
@@ -357,6 +358,8 @@ describe('OrganizationsAPI — workspace surface', () => {
         userWallet: '0xabc',
         isCustomer: true,
         customerRecorded: true,
+        // The credential expiry the paired docs tell integrators to track.
+        expiresAt: '2026-09-27T12:00:00.000Z',
       })
     })
 


### PR DESCRIPTION
## Why this matters

White-label customer onboarding through the SDK is currently broken: `onboardCustomer` hands callers a credential that cannot authenticate. Any integrator following our docs — initialize a client with the returned key and act for the customer — gets `401`s, because the value we return is an encrypted internal blob, not a usable Bearer token. This fixes the SDK so the documented flow actually works, and unblocks the docs PR that surfaced it ([docs#301](https://github.com/nevermined-io/docs/pull/301)).

## The bug

`onboardCustomer` returned `walletResult.nvmApiKey` — which the backend documents (for the `as=customer` outcome, #2924) as *"the encrypted SDK/server-side blob — NOT a Bearer; do not send it as a header. To authenticate an HTTP request use `hash`."* The usable credential is `walletResult.hash` (`<env>:<JWT>`).

The sibling `createMember` already does the right thing:

```ts
return { ...data.walletResult, nvmApiKey: data.walletResult.hash }
```

`onboardCustomer` simply never got that mapping, so it leaked the raw blob through as `nvmApiKey`. Following it produced `Authorization: Bearer <encrypted blob>`.

## The fix

- Return `wallet.hash` as `nvmApiKey` (mirroring `createMember`).
- Guard on `wallet.hash` (the field we now return) instead of the blob, so a partial payload still fails loudly.

## Alternatives considered

- **Document the current behavior instead** (have docs tell REST callers to use `hash` and demote the SDK path). Rejected: the SDK genuinely can't produce a working customer client today — `CustomerOnboardingResponse` exposes no `hash` — so that path is a real defect, not a doc gap. Fixing the SDK makes the whole flow correct rather than papering over it.

## Test plan

- Corrected the unit test, which had encoded the inverted premise (it called `hash` a "lookup hash" and asserted the raw blob was returned). It now asserts `hash` is surfaced as the Bearer and the blob never leaks.
- `pnpm jest tests/unit/organizations-api.test.ts` → 20/20 pass.
- `pnpm build` (tsc) clean; `pnpm lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZ3y8ptZEYfscAKfhyfs1h