### PR TITLE
fix(mcp): build a fresh transport per request so spec-compliant MCP clients work

### DIFF
--- a/src/mcp/http/session-manager.ts
+++ b/src/mcp/http/session-manager.ts
@@ -107,15 +107,19 @@ export class SessionManager {
 
   /**
    * Get or create a transport for a session.
+   *
+   * Always builds a FRESH transport, even when a transport is already cached for
+   * this session id. The transports are created in stateless mode
+   * (`sessionIdGenerator: undefined`), and the SDK's stateless transport is
+   * single-request by design — reusing a cached one yields an empty-body HTTP 500
+   * on the second request. Spec-compliant clients (Claude, Cursor, the official
+   * SDK) echo the `Mcp-Session-Id` we return on `initialize` back on every
+   * subsequent request, which used to route them straight into that broken reuse
+   * path. Rebuilding per request keeps the echoed-id path working exactly like the
+   * no-header path. The cached entry is only retained so GET (SSE) / DELETE can
+   * still resolve the latest transport for a session id.
    */
   async getOrCreateSession(sessionId: string): Promise<any> {
-    if (this.sessions.has(sessionId)) {
-      const existingSession = this.sessions.get(sessionId)
-      if (existingSession) {
-        return existingSession
-      }
-    }
-
     if (!this.mcpServer) {
       throw new Error('MCP server not set. Call setMcpServer() first.')
     }

--- a/src/mcp/http/session-manager.ts
+++ b/src/mcp/http/session-manager.ts
@@ -116,8 +116,17 @@ export class SessionManager {
    * SDK) echo the `Mcp-Session-Id` we return on `initialize` back on every
    * subsequent request, which used to route them straight into that broken reuse
    * path. Rebuilding per request keeps the echoed-id path working exactly like the
-   * no-header path. The cached entry is only retained so GET (SSE) / DELETE can
-   * still resolve the latest transport for a session id.
+   * no-header path.
+   *
+   * The session map still records the latest transport per id so DELETE can
+   * terminate it and requests for an unknown id can be rejected. This managed
+   * server runs in stateless JSON-response mode (`enableJsonResponse: true`) and
+   * does NOT support standalone GET/SSE streams — the stateless transport rejects
+   * them — so there is no long-lived stream for a later POST to disrupt.
+   *
+   * ponytail: one shared McpServer that every request `close()`s and reconnects —
+   * two in-flight requests still race (tracked in #424). Per-session server+transport
+   * pairs are the upgrade if concurrency ever matters.
    */
   async getOrCreateSession(sessionId: string): Promise<any> {
     if (!this.mcpServer) {

--- a/tests/integration/mcp/mcp_session_reuse_regression.test.ts
+++ b/tests/integration/mcp/mcp_session_reuse_regression.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Regression test for the "empty 500 after initialize when the client echoes
+ * Mcp-Session-Id" bug (gist mqklin/8e2d10156f94bee42f6b226d7beb099c).
+ *
+ * A spec-compliant MCP client echoes the `Mcp-Session-Id` returned on
+ * `initialize` back on every subsequent request. The managed server used to
+ * return a cached single-use stateless transport for that echoed id, which the
+ * SDK answers with an empty-body HTTP 500. This test drives the real
+ * mcp-handler + session-manager over HTTP and asserts the echoed-id path works.
+ */
+import express from 'express'
+import type { Server } from 'http'
+import type { AddressInfo } from 'net'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { SessionManager } from '../../../src/mcp/http/session-manager.js'
+import { mountMcpHandlers } from '../../../src/mcp/http/mcp-handler.js'
+
+describe('MCP Session - transport reuse regression', () => {
+  let server: Server
+  let mcpServer: McpServer
+  let baseUrl: string
+
+  beforeAll(async () => {
+    mcpServer = new McpServer({ name: 'repro', version: '1.0.0' })
+    mcpServer.registerTool('ping', { description: 'ping' }, async () => ({
+      content: [{ type: 'text', text: 'pong' }],
+    }))
+
+    const sessionManager = new SessionManager()
+    sessionManager.setMcpServer(mcpServer)
+
+    const app = express()
+    app.use(express.json())
+    mountMcpHandlers(app as any, { sessionManager, requireAuth: false })
+
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => resolve())
+    })
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}/mcp`
+  })
+
+  afterAll(async () => {
+    await mcpServer?.close().catch(() => {})
+    await new Promise<void>((resolve) => server?.close(() => resolve()))
+  })
+
+  const post = (body: object, sessionId?: string) =>
+    fetch(baseUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        ...(sessionId ? { 'mcp-session-id': sessionId } : {}),
+      },
+      body: JSON.stringify(body),
+    })
+
+  const initialize = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'r', version: '0' },
+    },
+  }
+  const toolsList = { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }
+
+  test('tools/list succeeds when the client echoes the Mcp-Session-Id (compliant client)', async () => {
+    const initRes = await post(initialize)
+    expect(initRes.status).toBe(200)
+    const sessionId = initRes.headers.get('mcp-session-id')
+    expect(sessionId).toBeTruthy()
+
+    // Compliant clients echo the session id back — this used to yield an empty 500.
+    const listRes = await post(toolsList, sessionId!)
+    expect(listRes.status).toBe(200)
+    const body = await listRes.json()
+    expect(body.result.tools.map((t: any) => t.name)).toContain('ping')
+  })
+
+  test('tools/list still succeeds without the session header (non-compliant path)', async () => {
+    const listRes = await post(toolsList)
+    expect(listRes.status).toBe(200)
+    const body = await listRes.json()
+    expect(body.result.tools.map((t: any) => t.name)).toContain('ping')
+  })
+})

--- a/tests/integration/mcp/mcp_session_reuse_regression.test.ts
+++ b/tests/integration/mcp/mcp_session_reuse_regression.test.ts
@@ -86,4 +86,25 @@ describe('MCP Session - transport reuse regression', () => {
     const body = await listRes.json()
     expect(body.result.tools.map((t: any) => t.name)).toContain('ping')
   })
+
+  test('standalone GET/SSE is unsupported in stateless mode, so a later POST tears down nothing', async () => {
+    // Review question on #423: does rebuilding a transport on POST close a live
+    // GET/SSE stream on the same session? In this stateless config
+    // (sessionIdGenerator: undefined, enableJsonResponse) the SDK rejects the
+    // standalone SSE stream outright — it never establishes, so there is no
+    // long-lived stream for the subsequent POST to disrupt.
+    const initRes = await post(initialize)
+    const sessionId = initRes.headers.get('mcp-session-id')!
+
+    const sse = await fetch(baseUrl, {
+      method: 'GET',
+      headers: { Accept: 'text/event-stream', 'mcp-session-id': sessionId },
+    })
+    expect(sse.status).not.toBe(200)
+    await sse.body?.cancel()
+
+    // The session id is still usable for JSON-RPC POSTs afterwards.
+    const listRes = await post(toolsList, sessionId)
+    expect(listRes.status).toBe(200)
+  })
 })


### PR DESCRIPTION
## Why this matters

A user reported that AI agents built on our managed MCP server can't be reached by the tools people actually use — Claude, Cursor, and the official MCP SDK client all fail to connect out of the box, getting a blank HTTP 500 error right after connecting. This makes `payments.mcp.start()` servers effectively unusable for real customers, even though quick test scripts appeared to work. This PR fixes that so any spec-compliant MCP client connects and calls tools normally.

## Description

The managed MCP server handed the client an `Mcp-Session-Id` on `initialize`, then failed with an empty-body **HTTP 500** on every subsequent request that carried that header back. Per the MCP streamable-HTTP spec, every compliant client echoes the session id, so `client.connect()` failed at the `notifications/initialized`/`tools/list` step. Requests **without** the header succeeded, which is why simple scripts didn't surface the bug.

**Root cause:** `SessionManager.getOrCreateSession()` cached the stateless `StreamableHTTPServerTransport` (`sessionIdGenerator: undefined`) per session id and reused it. The SDK's stateless transport is single-request by design, so reuse writes an empty 500 on the second request. Because `mcp-handler.ts` sets `Mcp-Session-Id` on every response, compliant clients were steered straight into that broken reuse path.

**Fix:** `getOrCreateSession()` now always builds a **fresh** transport instead of returning the cached one — the echoed-session-id path behaves exactly like the no-header path that already worked. The existing `mcpServer.close()` before each connect already reaps the previous transport (via `onclose`), so the session map stays bounded. The cached entry is kept only so GET (SSE) / DELETE can resolve the latest transport for a session id.

**Alternatives considered:**
- *Stop emitting `Mcp-Session-Id`.* Makes compliant clients stop echoing, but is fragile (a proxy or reconnect can still send the header) and doesn't fix the root cause — reuse would still 500.
- *Implement real stateful sessions* (`sessionIdGenerator` set, multi-request transports). Requires a separate `McpServer` per session; the current architecture shares one server and closes/reconnects it per request. Much larger change for no additional user-visible benefit given the stateless design.
- *Chosen:* rebuild a fresh transport per request — smallest diff, fixes the root cause, keeps both the compliant and the direct-JSON-RPC paths working.

## Is this PR related with an open issue?

Fixes #422

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [ ] Documentation

**Test plan:**
- New `tests/integration/mcp/mcp_session_reuse_regression.test.ts` drives `initialize → tools/list` through the real handler + session manager over HTTP, asserting **200** both when the client echoes `Mcp-Session-Id` (the regression) and when it omits it. Verified RED before the fix (echoed id → 500), GREEN after.
- `pnpm build && pnpm lint` clean (only pre-existing warnings in untouched files).
- `pnpm test:unit` (570 passed) and `pnpm test:integration` (54 passed) green.

#### Funny gif

![](https://media.giphy.com/media/13HgwGsXF0aiGY/giphy.gif)
