### PR TITLE
feat(orders): OrdersAPI client for browser-fiat Orders (createOrder / getOrder)

### DIFF
--- a/markdown/README.md
+++ b/markdown/README.md
@@ -17,6 +17,7 @@ This directory contains the markdown documentation for the Nevermined Payments T
 11. **x402.md** - X402 payment protocol specification
 12. **mpp-integration.md** - Machine Payments Protocol (MPP) integration
 13. **cli-card-setup.md** - White-labeled card enrolment + delegation for CLI / top-level integrators
+14. **orders.md** - Browser-fiat Orders: arbitrary-amount card charges without a payment plan
 
 ## Automation Workflows
 

--- a/markdown/orders.md
+++ b/markdown/orders.md
@@ -30,11 +30,11 @@ const payments = Payments.getInstance({
 })
 
 const { orderId, status, clientSecret } = await payments.orders.createOrder({
-  amountMinor: 3437, // USD cents: $34.37 ($1.00 - $999,999.99)
+  amountMinor: 3437, // USD cents: $34.37
   description: 'Cart checkout - 3 items',
   buyerRef: 'merchant-order-4821',
   idempotencyKey: 'merchant-order-4821',
-  lineItems: [{ sku: 'PRO-PLAN', quantity: 1, amountMinor: 3437 }],
+  lineItems: [{ sku: 'PRO-PLAN', quantity: 1, unit_price: 3437 }],
   metadata: { channel: 'web' },
 })
 
@@ -45,13 +45,13 @@ console.log(clientSecret) // hand this to the browser (Stripe.js confirm)
 
 | Option | Type | Description |
 |---|---|---|
-| `amountMinor` | `number` | Charge amount in USD cents, `100` to `99_999_999`. |
+| `amountMinor` | `number` | Charge amount in USD cents (at least `100`, i.e. $1.00). The API validates the upper bound (`BCK.ORDER.0001`); a deployment may enforce a lower per-order cap (`BCK.ORDER.0003`). |
 | `currency` | `'usd'` | ISO currency, lower-cased. Default and only value in Phase 1. |
 | `description` | `string` | Optional. Human-readable description (max 1024 chars). |
 | `buyerRef` | `string` | Optional. Your own reference for the buyer or cart (max 255 chars). |
 | `idempotencyKey` | `string` | Optional. A retried create with the same key returns the same Order and `clientSecret`; a conflicting body is refused with `BCK.ORDER.0007`. |
-| `lineItems` | `Record<string, unknown>[]` | Optional. Recorded verbatim, opaque to the API. |
-| `metadata` | `Record<string, unknown>` | Optional. Recorded verbatim, opaque to the API. |
+| `lineItems` | `Record<string, unknown>[]` | Optional. Merchant-defined structure, recorded verbatim (keys are not transformed), opaque to the API. |
+| `metadata` | `Record<string, unknown>` | Optional. Merchant-defined structure, recorded verbatim (keys are not transformed), opaque to the API. |
 | `captureMode` | `'automatic'` | Optional. The only value in Phase 1. |
 | `paymentProvider` | `'stripe'` | Optional. The only value in Phase 1. |
 

--- a/markdown/orders.md
+++ b/markdown/orders.md
@@ -1,0 +1,110 @@
+---
+title: "Orders"
+description: "Charge an arbitrary amount by card without a payment plan: create a browser-fiat Order and read its status"
+icon: "cart-shopping"
+---
+
+# Orders
+
+This guide covers browser-fiat **Orders**: a merchant-initiated, off-plan charge for an arbitrary amount (the Stripe PaymentIntent analog) that the buyer's browser confirms client-side. No payment plan, no buyer Nevermined account, no delegation.
+
+## Overview
+
+1. `payments.orders.createOrder(...)` — the merchant creates the Order server-side and receives a Stripe `clientSecret`.
+2. The merchant hands the `clientSecret` to its checkout page, which confirms the payment with Stripe.js.
+3. `payments.orders.getOrder(orderId)` — anyone holding the unguessable `orderId` reads the buyer-safe status. No API key is sent on the wire.
+
+## Requirements
+
+`createOrder` needs an **organization-scoped** NVM API key: the API resolves the merchant organization from the key's own org tag. A personal key is refused with `BCK.ORDER.0003`, and `payments.setOrganizationId(...)` does not substitute for an org-scoped key. The organization must be active and have a Stripe Connect account able to receive card payments.
+
+## Create an Order
+
+```typescript
+import { Payments, EnvironmentName } from '@nevermined-io/payments'
+
+// Initialize with the merchant's organization-scoped API key
+const payments = Payments.getInstance({
+  nvmApiKey: process.env.NVM_API_KEY!,
+  environment: 'sandbox' as EnvironmentName,
+})
+
+const { orderId, status, clientSecret } = await payments.orders.createOrder({
+  amountMinor: 3437, // USD cents: $34.37 ($1.00 - $999,999.99)
+  description: 'Cart checkout - 3 items',
+  buyerRef: 'merchant-order-4821',
+  idempotencyKey: 'merchant-order-4821',
+  lineItems: [{ sku: 'PRO-PLAN', quantity: 1, amountMinor: 3437 }],
+  metadata: { channel: 'web' },
+})
+
+console.log(orderId) // ord_... - the buyer-facing access control
+console.log(status) // 'requires_payment'
+console.log(clientSecret) // hand this to the browser (Stripe.js confirm)
+```
+
+| Option | Type | Description |
+|---|---|---|
+| `amountMinor` | `number` | Charge amount in USD cents, `100` to `99_999_999`. |
+| `currency` | `'usd'` | ISO currency, lower-cased. Default and only value in Phase 1. |
+| `description` | `string` | Optional. Human-readable description (max 1024 chars). |
+| `buyerRef` | `string` | Optional. Your own reference for the buyer or cart (max 255 chars). |
+| `idempotencyKey` | `string` | Optional. A retried create with the same key returns the same Order and `clientSecret`; a conflicting body is refused with `BCK.ORDER.0007`. |
+| `lineItems` | `Record<string, unknown>[]` | Optional. Recorded verbatim, opaque to the API. |
+| `metadata` | `Record<string, unknown>` | Optional. Recorded verbatim, opaque to the API. |
+| `captureMode` | `'automatic'` | Optional. The only value in Phase 1. |
+| `paymentProvider` | `'stripe'` | Optional. The only value in Phase 1. |
+
+## Read an Order
+
+```typescript
+const order = await payments.orders.getOrder(orderId)
+
+console.log(order.status) // 'requires_payment' | 'paid' | 'refunded' | 'partially_refunded' | 'disputed' | 'failed'
+console.log(order.amountMinor) // 3437
+console.log(order.amountRefundedMinor) // 0
+console.log(order.clientSecret) // present only while the Order is payable
+
+if (order.status === 'paid') {
+  // fulfil the order
+}
+```
+
+The read is anonymous on the wire (the unguessable id is the access control) and returns a buyer-safe projection: it never includes the merchant identity, the Connect account or the fee.
+
+## Order lifecycle
+
+| Status | Meaning |
+|---|---|
+| `requires_payment` | Created; the browser has not confirmed yet. `clientSecret` is available. |
+| `paid` | Payment succeeded. |
+| `failed` | Payment failed, or the PaymentIntent could not be created. No money moved. |
+| `refunded` / `partially_refunded` | Refunded in full / in part (see `amountRefundedMinor`). |
+| `disputed` | A chargeback is open. |
+
+## Error codes
+
+Errors throw `PaymentsError` with `code` set to the backend catalogue code:
+
+| Code | HTTP | Meaning |
+|---|---|---|
+| `BCK.ORDER.0001` | 400 | Invalid request (amount out of range, unsupported currency / capture mode / provider). |
+| `BCK.ORDER.0002` | 404 | No Order with this id. |
+| `BCK.ORDER.0003` | 403 | The key is not an active organization, or the amount exceeds the per-order cap. |
+| `BCK.ORDER.0004` | 500 | The merchant has no Connect account able to receive card payments. |
+| `BCK.ORDER.0005` | 500 | The PaymentIntent could not be created; the Order is `failed`, no money moved. |
+| `BCK.ORDER.0007` | 409 | Idempotency-key conflict. |
+| `BCK.ORDER.0010` | 429 | Velocity cap exceeded. Retry after backoff. |
+
+```typescript
+import { PaymentsError } from '@nevermined-io/payments'
+
+try {
+  await payments.orders.createOrder({ amountMinor: 3437 })
+} catch (error) {
+  if (error instanceof PaymentsError && error.code === 'BCK.ORDER.0010') {
+    // back off and retry
+  }
+  throw error
+}
+```

--- a/markdown/orders.md
+++ b/markdown/orders.md
@@ -49,7 +49,7 @@ console.log(clientSecret) // hand this to the browser (Stripe.js confirm)
 | `currency` | `'usd'` | ISO currency, lower-cased. Default and only value in Phase 1. |
 | `description` | `string` | Optional. Human-readable description (max 1024 chars). |
 | `buyerRef` | `string` | Optional. Your own reference for the buyer or cart (max 255 chars). |
-| `idempotencyKey` | `string` | Optional. A retried create with the same key returns the same Order and `clientSecret`; a conflicting body is refused with `BCK.ORDER.0007`. |
+| `idempotencyKey` | `string` | Optional. A retry with the same key returns the original Order unchanged (and its `clientSecret` while the Order is still payable); the other fields of the retry are ignored, not merged. A retry with a different `amountMinor` or `currency` is refused with `BCK.ORDER.0007`. |
 | `lineItems` | `Record<string, unknown>[]` | Optional. Merchant-defined structure, recorded verbatim (keys are not transformed), opaque to the API. |
 | `metadata` | `Record<string, unknown>` | Optional. Merchant-defined structure, recorded verbatim (keys are not transformed), opaque to the API. |
 | `captureMode` | `'automatic'` | Optional. The only value in Phase 1. |
@@ -95,7 +95,7 @@ Errors throw `PaymentsError` with `code` set to the backend catalogue code:
 | `BCK.ORDER.0003` | 403 | The key is not an active organization, or the amount exceeds the per-order cap. |
 | `BCK.ORDER.0004` | 500 | The merchant has no Connect account able to receive card payments. |
 | `BCK.ORDER.0005` | 500 | The PaymentIntent could not be created; the Order is `failed`, no money moved. |
-| `BCK.ORDER.0007` | 409 | Idempotency-key conflict. |
+| `BCK.ORDER.0007` | 409 | Idempotency key reused with a different `amountMinor` or `currency`. |
 | `BCK.ORDER.0010` | 429 | Velocity cap exceeded on `createOrder`. Retry after backoff. |
 | `http_429` | 429 | The `getOrder` read throttle (no catalogue code). Back off and retry. |
 

--- a/markdown/orders.md
+++ b/markdown/orders.md
@@ -72,15 +72,17 @@ if (order.status === 'paid') {
 
 The read is anonymous on the wire (the unguessable id is the access control) and returns a buyer-safe projection: it never includes the merchant identity, the Connect account or the fee.
 
+The read endpoint is rate-limited: all anonymous callers behind one IP share a bucket of 60 requests per minute. A throttled call throws `PaymentsError` with code `http_429` and no catalogue code (this is not the create-side `BCK.ORDER.0010`). Poll sparingly and back off on `http_429`.
+
 ## Order lifecycle
 
 | Status | Meaning |
 |---|---|
 | `requires_payment` | Created; the browser has not confirmed yet. `clientSecret` is available. |
-| `paid` | Payment succeeded. |
+| `paid` | Payment succeeded. Also the state after a **won** dispute. |
 | `failed` | Payment failed, or the PaymentIntent could not be created. No money moved. |
 | `refunded` / `partially_refunded` | Refunded in full / in part (see `amountRefundedMinor`). |
-| `disputed` | A chargeback is open. |
+| `disputed` | A chargeback is open, or was lost. A won dispute returns the Order to `paid`. |
 
 ## Error codes
 
@@ -94,7 +96,10 @@ Errors throw `PaymentsError` with `code` set to the backend catalogue code:
 | `BCK.ORDER.0004` | 500 | The merchant has no Connect account able to receive card payments. |
 | `BCK.ORDER.0005` | 500 | The PaymentIntent could not be created; the Order is `failed`, no money moved. |
 | `BCK.ORDER.0007` | 409 | Idempotency-key conflict. |
-| `BCK.ORDER.0010` | 429 | Velocity cap exceeded. Retry after backoff. |
+| `BCK.ORDER.0010` | 429 | Velocity cap exceeded on `createOrder`. Retry after backoff. |
+| `http_429` | 429 | The `getOrder` read throttle (no catalogue code). Back off and retry. |
+
+A refusal that carries no catalogue code (a throttle or gateway response) surfaces with code `http_<status>`.
 
 ```typescript
 import { PaymentsError } from '@nevermined-io/payments'

--- a/src/api/nvm-api.ts
+++ b/src/api/nvm-api.ts
@@ -40,6 +40,10 @@ export const API_URL_GET_MEMBERS = '/api/v1/organizations/members'
 export const API_URL_MY_MEMBERSHIPS = '/api/v1/organizations/my-memberships'
 export const API_URL_ORG_ACTIVITY = '/api/v1/organizations/:orgId/activity'
 export const API_URL_CONNECT_STRIPE_ACCOUNT = '/api/v1/fiat/stripe/account'
+// Browser-fiat Orders (nvm-monorepo epic #3238). POST is merchant-authenticated
+// (org-scoped NVM API key); GET is anonymous — the unguessable id is the access control.
+export const API_URL_CREATE_ORDER = '/api/v1/orders'
+export const API_URL_GET_ORDER = '/api/v1/orders/:orderId'
 
 export interface BackendApiOptions {
   /**

--- a/src/api/orders-api.ts
+++ b/src/api/orders-api.ts
@@ -117,7 +117,9 @@ export class OrdersAPI extends BasePaymentsAPI {
    *   (invalid request), `BCK.ORDER.0003` (not an active organization / over the
    *   per-order cap), `BCK.ORDER.0007` (idempotency-key conflict),
    *   `BCK.ORDER.0010` (velocity cap — retryable), `BCK.ORDER.0004`/`0005`
-   *   (Connect account / PaymentIntent failure, no money moved).
+   *   (Connect account / PaymentIntent failure, no money moved). A refusal
+   *   without a catalogue code (e.g. a gateway or throttle response) carries
+   *   `http_<status>` instead.
    * @example
    * ```
    *  const { orderId, clientSecret } = await payments.orders.createOrder({
@@ -132,7 +134,7 @@ export class OrdersAPI extends BasePaymentsAPI {
     const url = new URL(API_URL_CREATE_ORDER, this.environment.backend)
     const response = await fetch(url, this.getBackendHTTPOptions('POST', body))
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Unable to create order', await safeParseJson(response))
+      throw PaymentsError.fromBackend('Unable to create order', await backendError(response))
     }
     return response.json()
   }
@@ -149,6 +151,11 @@ export class OrdersAPI extends BasePaymentsAPI {
    * @param orderId - The unguessable Order id returned by {@link createOrder}.
    * @returns @see {@link Order}
    * @throws PaymentsError with code `BCK.ORDER.0002` when no Order has this id.
+   *   The read endpoint is rate-limited — all anonymous callers behind one IP
+   *   share a bucket of 60 requests per minute — and a throttled call carries
+   *   no catalogue code, so it surfaces as code `http_429`. That is distinct
+   *   from the create-side velocity cap `BCK.ORDER.0010`; poll sparingly and
+   *   back off on `http_429`.
    * @example
    * ```
    *  const order = await payments.orders.getOrder(orderId)
@@ -156,12 +163,24 @@ export class OrdersAPI extends BasePaymentsAPI {
    * ```
    */
   public async getOrder(orderId: string): Promise<Order> {
-    const query = API_URL_GET_ORDER.replace(':orderId', orderId)
+    const query = API_URL_GET_ORDER.replace(':orderId', encodeURIComponent(orderId))
     const url = new URL(query, this.environment.backend)
     const response = await fetch(url, this.getPublicHTTPOptions('GET'))
     if (!response.ok) {
-      throw PaymentsError.fromBackend('Unable to get order', await safeParseJson(response))
+      throw PaymentsError.fromBackend('Unable to get order', await backendError(response))
     }
     return response.json()
   }
+}
+
+/**
+ * Backend error envelope with an `http_<status>` fallback `code`, so a refusal
+ * that is not an `NVMException` (the read endpoint's throttle is a Nest
+ * `ThrottlerException` with no `code`) is still branchable by callers instead
+ * of collapsing to the generic `payments_error`. A catalogue `code` in the body
+ * always wins. Same convention as the Python SDK's `PaymentsError.from_response`.
+ */
+async function backendError(response: Response): Promise<Record<string, unknown>> {
+  const body = (await safeParseJson(response)) as Record<string, unknown>
+  return { code: `http_${response.status}`, ...body }
 }

--- a/src/api/orders-api.ts
+++ b/src/api/orders-api.ts
@@ -87,6 +87,11 @@ export interface Order {
  * refused with `BCK.ORDER.0003`. `Payments.setOrganizationId` (the
  * `X-Current-Org-Id` header) does not substitute for an org-scoped key.
  *
+ * This client is the merchant's: a `Payments` instance is always constructed
+ * with an NVM API key. The buyer never needs one — the buyer's browser confirms
+ * the `clientSecret` with Stripe.js and can poll `GET /api/v1/orders/:id`
+ * directly, which is why {@link OrdersAPI.getOrder} sends no key on that call.
+ *
  * @see nvm-monorepo `apps/api/src/orders/README.md` (epic #3238)
  */
 export class OrdersAPI extends BasePaymentsAPI {
@@ -133,8 +138,9 @@ export class OrdersAPI extends BasePaymentsAPI {
    *
    * @remarks
    * The endpoint is anonymous — the unguessable id is the sole access control —
-   * so no API key is sent. The response never includes the merchant identity
-   * or the fee, and carries `clientSecret` only while the Order is payable.
+   * so this call sends no API key (the `Payments` instance still needs one to
+   * be constructed). The response never includes the merchant identity or the
+   * fee, and carries `clientSecret` only while the Order is payable.
    *
    * @param orderId - The unguessable Order id returned by {@link createOrder}.
    * @returns @see {@link Order}

--- a/src/api/orders-api.ts
+++ b/src/api/orders-api.ts
@@ -1,0 +1,157 @@
+import { safeParseJson } from '../common/helper.js'
+import { PaymentsError } from '../common/payments.error.js'
+import { PaymentOptions } from '../common/types.js'
+import { BasePaymentsAPI } from './base-payments.js'
+import { API_URL_CREATE_ORDER, API_URL_GET_ORDER } from './nvm-api.js'
+
+/**
+ * Buyer-facing lifecycle status of an Order, as published on the wire by the
+ * Nevermined API (`WireOrderStatus` in nvm-monorepo
+ * `apps/api/src/orders/order-status.ts`).
+ */
+export type OrderStatus =
+  | 'requires_payment'
+  | 'paid'
+  | 'refunded'
+  | 'partially_refunded'
+  | 'disputed'
+  | 'failed'
+
+/**
+ * Body of `POST /api/v1/orders` (`RegisterOrderDto`). The authenticated
+ * merchant key sets the price; the seller's Stripe Connect account is
+ * resolved server-side and is deliberately NOT part of this contract.
+ */
+export interface CreateOrderOptions {
+  /** Charge amount in USD cents: $1.00 – $999,999.99 (`100` – `99_999_999`). */
+  amountMinor: number
+  /** ISO currency, lower-cased. Phase 1 is USD-only; defaults to `'usd'`. */
+  currency?: 'usd'
+  /** Human-readable description of the charge (max 1024 chars). */
+  description?: string
+  /** Opaque merchant-supplied buyer reference, e.g. the merchant's own order id (max 255 chars). */
+  buyerRef?: string
+  /** A retried create with the same key returns the same Order + `clientSecret` (max 255 chars). */
+  idempotencyKey?: string
+  /** Cart line items, recorded verbatim and opaque to the API. */
+  lineItems?: Array<Record<string, unknown>>
+  /** Opaque merchant metadata, recorded verbatim. */
+  metadata?: Record<string, unknown>
+  /** Stripe capture mode. Phase 1 supports `'automatic'` only (the default). */
+  captureMode?: 'automatic'
+  /** Payment Service Provider that settles the Order. Phase 1 implements `'stripe'` only (the default). */
+  paymentProvider?: 'stripe'
+}
+
+/** Response of `POST /api/v1/orders` (`CreateOrderResponseDto`). */
+export interface CreateOrderResult {
+  /** Unguessable Order id — the buyer-facing access control for {@link OrdersAPI.getOrder}. */
+  orderId: string
+  status: OrderStatus
+  /** Stripe PaymentIntent client secret the browser confirms against. Present only while the Order is payable. */
+  clientSecret?: string
+}
+
+/**
+ * Buyer-safe view of an Order (`OrderResponseDto`). It never carries the
+ * merchant identity, the Connect account or the fee breakdown.
+ */
+export interface Order {
+  /** Unguessable Order id. */
+  id: string
+  /** Charge amount in USD cents. */
+  amountMinor: number
+  currency: string
+  status: OrderStatus
+  /** Total refunded so far, in cents. */
+  amountRefundedMinor: number
+  description: string | null
+  buyerRef: string | null
+  /** The Stripe PaymentIntent backing this Order; `null` until it is created. */
+  paymentIntentId: string | null
+  /** ISO-8601 instant when the Order stops being payable; `null` if it never expires. */
+  expiresAt: string | null
+  /** Present only while the Order is payable. */
+  clientSecret?: string
+}
+
+/**
+ * The OrdersAPI class wraps the browser-fiat Orders endpoints. An Order is a
+ * merchant-initiated, off-plan charge for an arbitrary amount (the Stripe
+ * PaymentIntent analog) that the buyer's browser confirms client-side — no
+ * plan, no buyer Nevermined account, no delegation.
+ *
+ * @remarks
+ * `createOrder` requires an **organization-scoped** NVM API key: the API reads
+ * the merchant organization from the key's own org tag, so a personal key is
+ * refused with `BCK.ORDER.0003`. `Payments.setOrganizationId` (the
+ * `X-Current-Org-Id` header) does not substitute for an org-scoped key.
+ *
+ * @see nvm-monorepo `apps/api/src/orders/README.md` (epic #3238)
+ */
+export class OrdersAPI extends BasePaymentsAPI {
+  static getInstance(options: PaymentOptions): OrdersAPI {
+    return new OrdersAPI(options)
+  }
+
+  /**
+   * Creates an Order and its PaymentIntent, returning the `clientSecret` a
+   * browser confirms against (`POST /api/v1/orders`).
+   *
+   * @remarks
+   * This method is oriented to merchants. The NVM API Key must be scoped to an
+   * active organization whose Stripe Connect account can receive card payments.
+   *
+   * @param options - @see {@link CreateOrderOptions}. `currency` defaults to `'usd'`.
+   * @returns The new Order id, its status and — while payable — the `clientSecret`.
+   * @throws PaymentsError carrying the backend catalogue code: `BCK.ORDER.0001`
+   *   (invalid request), `BCK.ORDER.0003` (not an active organization / over the
+   *   per-order cap), `BCK.ORDER.0007` (idempotency-key conflict),
+   *   `BCK.ORDER.0010` (velocity cap — retryable), `BCK.ORDER.0004`/`0005`
+   *   (Connect account / PaymentIntent failure, no money moved).
+   * @example
+   * ```
+   *  const { orderId, clientSecret } = await payments.orders.createOrder({
+   *    amountMinor: 3437, // $34.37
+   *    description: 'Cart checkout — 3 items',
+   *    idempotencyKey: 'merchant-order-4821',
+   *  })
+   * ```
+   */
+  public async createOrder(options: CreateOrderOptions): Promise<CreateOrderResult> {
+    const body = { ...options, currency: options.currency ?? 'usd' }
+    const url = new URL(API_URL_CREATE_ORDER, this.environment.backend)
+    const response = await fetch(url, this.getBackendHTTPOptions('POST', body))
+    if (!response.ok) {
+      throw PaymentsError.fromBackend('Unable to create order', await safeParseJson(response))
+    }
+    return response.json()
+  }
+
+  /**
+   * Reads the buyer-safe view of an Order by id (`GET /api/v1/orders/:id`).
+   *
+   * @remarks
+   * The endpoint is anonymous — the unguessable id is the sole access control —
+   * so no API key is sent. The response never includes the merchant identity
+   * or the fee, and carries `clientSecret` only while the Order is payable.
+   *
+   * @param orderId - The unguessable Order id returned by {@link createOrder}.
+   * @returns @see {@link Order}
+   * @throws PaymentsError with code `BCK.ORDER.0002` when no Order has this id.
+   * @example
+   * ```
+   *  const order = await payments.orders.getOrder(orderId)
+   *  if (order.status === 'paid') fulfil(order)
+   * ```
+   */
+  public async getOrder(orderId: string): Promise<Order> {
+    const query = API_URL_GET_ORDER.replace(':orderId', orderId)
+    const url = new URL(query, this.environment.backend)
+    const response = await fetch(url, this.getPublicHTTPOptions('GET'))
+    if (!response.ok) {
+      throw PaymentsError.fromBackend('Unable to get order', await safeParseJson(response))
+    }
+    return response.json()
+  }
+}

--- a/src/api/orders-api.ts
+++ b/src/api/orders-api.ts
@@ -35,7 +35,12 @@ export interface CreateOrderOptions {
   description?: string
   /** Opaque merchant-supplied buyer reference, e.g. the merchant's own order id (max 255 chars). */
   buyerRef?: string
-  /** A retried create with the same key returns the same Order + `clientSecret` (max 255 chars). */
+  /**
+   * Idempotency key (max 255 chars). A retry with the same key returns the
+   * original Order unchanged (and its `clientSecret` while the Order is still
+   * payable); the other fields of the retry are ignored, not merged. A retry
+   * with a different `amountMinor` or `currency` is refused with `BCK.ORDER.0007`.
+   */
   idempotencyKey?: string
   /** Cart line items — merchant-defined structure, recorded verbatim (keys are not transformed), opaque to the API. */
   lineItems?: Array<Record<string, unknown>>

--- a/src/api/orders-api.ts
+++ b/src/api/orders-api.ts
@@ -23,7 +23,11 @@ export type OrderStatus =
  * resolved server-side and is deliberately NOT part of this contract.
  */
 export interface CreateOrderOptions {
-  /** Charge amount in USD cents: $1.00 – $999,999.99 (`100` – `99_999_999`). */
+  /**
+   * Charge amount in USD cents (at least `100`, i.e. $1.00). The API validates
+   * the upper bound (`BCK.ORDER.0001`); a deployment may enforce a lower
+   * per-order cap (`BCK.ORDER.0003`).
+   */
   amountMinor: number
   /** ISO currency, lower-cased. Phase 1 is USD-only; defaults to `'usd'`. */
   currency?: 'usd'
@@ -33,9 +37,9 @@ export interface CreateOrderOptions {
   buyerRef?: string
   /** A retried create with the same key returns the same Order + `clientSecret` (max 255 chars). */
   idempotencyKey?: string
-  /** Cart line items, recorded verbatim and opaque to the API. */
+  /** Cart line items — merchant-defined structure, recorded verbatim (keys are not transformed), opaque to the API. */
   lineItems?: Array<Record<string, unknown>>
-  /** Opaque merchant metadata, recorded verbatim. */
+  /** Merchant-defined metadata, recorded verbatim (keys are not transformed), opaque to the API. */
   metadata?: Record<string, unknown>
   /** Stripe capture mode. Phase 1 supports `'automatic'` only (the default). */
   captureMode?: 'automatic'

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ export { ContractsAPI } from './api/contracts-api.js'
 export { CURRENT_ORG_ID_HEADER } from './api/base-payments.js'
 export type { PublicationOptions } from './api/base-payments.js'
 export { OrganizationsAPI } from './api/organizations-api/organizations-api.js'
+export { OrdersAPI } from './api/orders-api.js'
+export type { CreateOrderOptions, CreateOrderResult, Order, OrderStatus } from './api/orders-api.js'
 export {
   OrganizationMemberRole,
   OrganizationType,

--- a/src/payments.ts
+++ b/src/payments.ts
@@ -13,6 +13,7 @@ import { PaymentsA2AServer } from './a2a/server.js'
 import { buildPaymentAgentCard } from './a2a/agent-card.js'
 import * as mcpModule from './mcp/index.js'
 import { OrganizationsAPI } from './api/organizations-api/organizations-api.js'
+import { OrdersAPI } from './api/orders-api.js'
 import { FacilitatorAPI } from './x402/facilitator-api.js'
 import { X402TokenAPI } from './x402/token.js'
 import { DelegationAPI } from './x402/delegation-api.js'
@@ -27,6 +28,7 @@ import { MppAPI } from './mpp/mpp-api.js'
  *
  * Each of these functionalities is encapsulated in its own API class:
  * - `plans`: Manages AI Plans, including registration and ordering and retrieving plan details.
+ * - `orders`: Browser-fiat Orders — merchant-initiated, off-plan charges for an arbitrary amount.
  * - `agents`: Handles AI Agents, including registration of AI Agents and access token generation.
  * - `requests`: Manages requests received by AI Agents, including validation and tracking.
  * - `observability`: Provides observability and logging utilities for AI Agents with Helicone integration
@@ -38,6 +40,7 @@ export class Payments extends BasePaymentsAPI {
   public requests!: AgentRequestsAPI
   public observability!: ObservabilityAPI
   public organizations!: OrganizationsAPI
+  public orders!: OrdersAPI
   public contracts!: ContractsAPI
   public facilitator!: FacilitatorAPI
   public x402!: X402TokenAPI
@@ -210,6 +213,7 @@ export class Payments extends BasePaymentsAPI {
     this.requests = AgentRequestsAPI.getInstance(options)
     this.observability = ObservabilityAPI.getInstance(options)
     this.organizations = OrganizationsAPI.getInstance(options)
+    this.orders = OrdersAPI.getInstance(options)
     this.query = AIQueryApi.getInstance()
     this.contracts = new ContractsAPI(options)
     this.facilitator = FacilitatorAPI.getInstance(options)
@@ -276,6 +280,7 @@ export class Payments extends BasePaymentsAPI {
     this.requests?.setOrganizationId(organizationId)
     this.observability?.setOrganizationId(organizationId)
     this.organizations?.setOrganizationId(organizationId)
+    this.orders?.setOrganizationId(organizationId)
     this.contracts?.setOrganizationId(organizationId)
     this.facilitator?.setOrganizationId(organizationId)
     this.x402?.setOrganizationId(organizationId)

--- a/tests/unit/orders-api.test.ts
+++ b/tests/unit/orders-api.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for `payments.orders` (OrdersAPI) — the SDK client for the
+ * browser-fiat Orders endpoints (nvm-monorepo epic #3238, task #3250):
+ *
+ * - `POST /api/v1/orders` — merchant, server-to-server, authenticated with an
+ *   org-scoped NVM API key.
+ * - `GET /api/v1/orders/:id` — anonymous; the unguessable id is the access
+ *   control, so the SDK sends NO Authorization header.
+ *
+ * `fetch` is replaced with a recording stub so we can assert on URLs, headers
+ * and bodies without hitting the network. The mock NVM API key is the same
+ * fixture used in `payments.test.ts`.
+ */
+
+import { Payments } from '../../src/payments.js'
+import { API_VERSION_HEADER, LOCKED_API_VERSION } from '../../src/common/api-version.js'
+import type { CreateOrderResult, Order } from '../../src/api/orders-api.js'
+
+const TEST_API_KEY =
+  'sandbox-staging:eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweDU4MzhCNTUxMmNGOWYxMkZFOWYyYmVjY0IyMGViNDcyMTFGOUIwYmMiLCJzdWIiOiIweDIxRjc5ZjlkM2I2ZDUyZUY4Y2M4QjFhN0YyNjFCY2Y1ZjJFRjM1NGEiLCJqdGkiOiIweGUxMjIwMmRkMzZlZmQ4N2FkMjE1MmRlMjlkM2MwNmE5ZDU5N2M4NWJhOGMxOTQ1YjQ5MjlkYTYyYTRiZjQ1NGYiLCJleHAiOjE3OTEwNDc0OTcsIm8xMXkiOiJzay1oZWxpY29uZS13amUzYXdpLW5ud2V5M2EtdzdndnY3YS1oYmh3bm1pIn0.JI14qfSWHCWRvHOK9TAg3HEXWX7oKEI6fU6gaaWlyDl5btBWLh8FQo1ZnuzixPmgsUR3gc4oRlenLPUuTy-mORw'
+
+type RecordedCall = { url: URL; init: any }
+
+const originalFetch = globalThis.fetch
+
+function installFetchStub(
+  responder: (call: RecordedCall) => { ok: boolean; status?: number; body: any },
+): RecordedCall[] {
+  const calls: RecordedCall[] = []
+  globalThis.fetch = (async (input: any, init?: any) => {
+    const url = input instanceof URL ? input : new URL(String(input))
+    const call: RecordedCall = { url, init: init ?? {} }
+    calls.push(call)
+    const { ok, status = ok ? 200 : 500, body } = responder(call)
+    return {
+      ok,
+      status,
+      headers: { get: () => 'application/json' },
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    } as any
+  }) as any
+  return calls
+}
+
+function restoreFetch() {
+  globalThis.fetch = originalFetch
+}
+
+function makePayments() {
+  return Payments.getInstance({ nvmApiKey: TEST_API_KEY, environment: 'staging_sandbox' })
+}
+
+describe('OrdersAPI — payments.orders', () => {
+  afterEach(() => {
+    restoreFetch()
+  })
+
+  test('is wired into Payments and follows the instance org pin', () => {
+    const payments = makePayments()
+    expect(payments.orders).toBeDefined()
+    payments.setOrganizationId('org-abc')
+    expect(payments.orders.getOrganizationId()).toBe('org-abc')
+  })
+
+  describe('createOrder', () => {
+    const created: CreateOrderResult = {
+      orderId: 'ord_9f2c1a7e-3b4d-4c8a-9e21-0a5b6c7d8e9f',
+      status: 'requires_payment',
+      clientSecret: 'pi_3PGh9k_secret_9x8y7z',
+    }
+
+    test('POSTs to /api/v1/orders with the merchant key and returns the result', async () => {
+      const calls = installFetchStub(() => ({ ok: true, status: 201, body: created }))
+      const payments = makePayments()
+
+      const result = await payments.orders.createOrder({
+        amountMinor: 3437,
+        description: 'Cart checkout — 3 items',
+        idempotencyKey: 'idem-8f2c1a',
+        // Opaque merchant data must reach the wire verbatim (no key rewriting).
+        metadata: { channel: 'web', unit_price: 3437 },
+        lineItems: [{ sku: 'PRO-PLAN', unit_price: 3437, quantity: 1 }],
+      })
+
+      expect(result).toEqual(created)
+      expect(calls).toHaveLength(1)
+      const [{ url, init }] = calls
+      expect(url.pathname).toBe('/api/v1/orders')
+      expect(init.method).toBe('POST')
+      expect(init.headers.Authorization).toBe(`Bearer ${TEST_API_KEY}`)
+      expect(init.headers[API_VERSION_HEADER]).toBe(LOCKED_API_VERSION)
+      expect(JSON.parse(init.body)).toEqual({
+        amountMinor: 3437,
+        currency: 'usd',
+        description: 'Cart checkout — 3 items',
+        idempotencyKey: 'idem-8f2c1a',
+        metadata: { channel: 'web', unit_price: 3437 },
+        lineItems: [{ sku: 'PRO-PLAN', unit_price: 3437, quantity: 1 }],
+      })
+    })
+
+    test('sends only the fields the caller set (no undefined placeholders)', async () => {
+      const calls = installFetchStub(() => ({ ok: true, status: 201, body: created }))
+      await makePayments().orders.createOrder({ amountMinor: 100, currency: 'usd' })
+      expect(JSON.parse(calls[0].init.body)).toEqual({ amountMinor: 100, currency: 'usd' })
+    })
+
+    test('surfaces the backend catalogue code on refusal (BCK.ORDER.0003)', async () => {
+      installFetchStub(() => ({
+        ok: false,
+        status: 403,
+        body: { code: 'BCK.ORDER.0003', message: 'Order not initiated by an active organization' },
+      }))
+      await expect(makePayments().orders.createOrder({ amountMinor: 3437 })).rejects.toMatchObject({
+        name: 'PaymentsError',
+        code: 'BCK.ORDER.0003',
+        message: expect.stringContaining('active organization'),
+      })
+    })
+  })
+
+  describe('getOrder', () => {
+    const order: Order = {
+      id: 'ord_9f2c1a7e-3b4d-4c8a-9e21-0a5b6c7d8e9f',
+      amountMinor: 3437,
+      currency: 'usd',
+      status: 'requires_payment',
+      amountRefundedMinor: 0,
+      description: 'Cart checkout — 3 items',
+      buyerRef: null,
+      paymentIntentId: 'pi_3PGh9k',
+      expiresAt: null,
+      clientSecret: 'pi_3PGh9k_secret_9x8y7z',
+    }
+
+    test('GETs /api/v1/orders/:id anonymously and returns the buyer-safe view', async () => {
+      const calls = installFetchStub(() => ({ ok: true, body: order }))
+      const result = await makePayments().orders.getOrder(order.id)
+
+      expect(result).toEqual(order)
+      const [{ url, init }] = calls
+      expect(url.pathname).toBe(`/api/v1/orders/${order.id}`)
+      expect(init.method).toBe('GET')
+      // The id IS the access control — never leak the merchant key on the read.
+      expect(init.headers.Authorization).toBeUndefined()
+      expect(init.headers[API_VERSION_HEADER]).toBe(LOCKED_API_VERSION)
+    })
+
+    test('surfaces BCK.ORDER.0002 on a miss', async () => {
+      installFetchStub(() => ({
+        ok: false,
+        status: 404,
+        body: { code: 'BCK.ORDER.0002', message: 'No order exists with this id' },
+      }))
+      await expect(makePayments().orders.getOrder('ord_missing')).rejects.toMatchObject({
+        name: 'PaymentsError',
+        code: 'BCK.ORDER.0002',
+      })
+    })
+  })
+})

--- a/tests/unit/orders-api.test.ts
+++ b/tests/unit/orders-api.test.ts
@@ -14,6 +14,7 @@
 
 import { Payments } from '../../src/payments.js'
 import { API_VERSION_HEADER, LOCKED_API_VERSION } from '../../src/common/api-version.js'
+import { CURRENT_ORG_ID_HEADER } from '../../src/api/base-payments.js'
 import type { CreateOrderResult, Order } from '../../src/api/orders-api.js'
 
 const TEST_API_KEY =
@@ -56,11 +57,19 @@ describe('OrdersAPI — payments.orders', () => {
     restoreFetch()
   })
 
-  test('is wired into Payments and follows the instance org pin', () => {
+  test('is wired into Payments and forwards the instance org pin to the wire', async () => {
+    const calls = installFetchStub(() => ({
+      ok: true,
+      status: 201,
+      body: { orderId: 'ord_1', status: 'requires_payment' },
+    }))
     const payments = makePayments()
     expect(payments.orders).toBeDefined()
+
     payments.setOrganizationId('org-abc')
-    expect(payments.orders.getOrganizationId()).toBe('org-abc')
+    await payments.orders.createOrder({ amountMinor: 100 })
+
+    expect(calls[0].init.headers[CURRENT_ORG_ID_HEADER]).toBe('org-abc')
   })
 
   describe('createOrder', () => {

--- a/tests/unit/orders-api.test.ts
+++ b/tests/unit/orders-api.test.ts
@@ -156,6 +156,27 @@ describe('OrdersAPI — payments.orders', () => {
       expect(init.headers[API_VERSION_HEADER]).toBe(LOCKED_API_VERSION)
     })
 
+    test('URL-encodes the order id so a stray character cannot retarget the request', async () => {
+      const calls = installFetchStub(() => ({ ok: true, body: order }))
+      await makePayments().orders.getOrder('ord_x?foo=1')
+      expect(calls[0].url.pathname).toBe('/api/v1/orders/ord_x%3Ffoo%3D1')
+      expect(calls[0].url.search).toBe('')
+    })
+
+    test('surfaces the read throttle (no catalogue code) as http_429', async () => {
+      // Nest ThrottlerException body: no `code`, unlike NVMException envelopes.
+      installFetchStub(() => ({
+        ok: false,
+        status: 429,
+        body: { statusCode: 429, message: 'ThrottlerException: Too Many Requests' },
+      }))
+      await expect(makePayments().orders.getOrder('ord_1')).rejects.toMatchObject({
+        name: 'PaymentsError',
+        code: 'http_429',
+        message: expect.stringContaining('Too Many Requests'),
+      })
+    })
+
     test('surfaces BCK.ORDER.0002 on a miss', async () => {
       installFetchStub(() => ({
         ok: false,


### PR DESCRIPTION
## Why this matters

Merchants can now charge a customer an arbitrary amount by card straight from the Nevermined SDK, without first publishing a payment plan or asking the buyer to create a Nevermined account. One call creates the order and returns the Stripe client secret the checkout page needs; a second call reads the order's status so the merchant can fulfil once it is paid. This delivers the TypeScript half of nvm-monorepo#3250 (P1.8) for the "dynamic pricing: goods & services" epic (#3238).

## Description

### What

`payments.orders` (new `OrdersAPI`) wrapping the Orders endpoints shipped in nvm-monorepo#3311:

- `createOrder(options)` → `POST /api/v1/orders` (merchant, authenticated). Returns `{ orderId, status, clientSecret? }`.
- `getOrder(orderId)` → `GET /api/v1/orders/:id` (anonymous, public HTTP options — the unguessable id is the access control). Returns the buyer-safe `Order` projection.

Modelled on `PlansAPI`: same `BasePaymentsAPI` request layer (`getBackendHTTPOptions` / `getPublicHTTPOptions`), same `Bearer` + `Nevermined-Version` headers, errors surfaced via `PaymentsError.fromBackend(...)` so `err.code` is the catalogue code (`BCK.ORDER.0001..0011`). No new error types, no hand-rolled HTTP, no server changes.

### Decisions (left to the implementer by #3250)

- **Typed options object, not positionals.** `createOrder` has 1 required + 7 optional fields; positionals would be unusable (the same pain `registerPlan`'s six positionals already cause). `OrganizationsAPI.getOrganizationActivity(orgId, filters)` already takes an options object, so this is in-convention. `getOrder(orderId)` stays positional like `getPlan(planId)`.
- **`currency` defaults to `'usd'`.** The wire requires it but Phase 1 accepts only `usd`; defaulting removes boilerplate without hiding anything. Typed as the literal `'usd'` so a later currency is an additive union change.
- **Full response typing.** `CreateOrderResult` and `Order` mirror `CreateOrderResponseDto` / `OrderResponseDto` field-for-field, preserving optional-vs-nullable (`clientSecret?` is absent when withheld; `description` / `buyerRef` / `paymentIntentId` / `expiresAt` are `string | null`). No merchant-identity or fee fields are modelled, per the buyer-safe contract. `OrderStatus` is the six-value wire union.
- **No client-side range validation.** The server owns the bounds (`BCK.ORDER.0001`; the max is env-configurable via `ORDER_MAX_AMOUNT_MINOR`), so duplicating them in the SDK would only drift.
- **Tests: unit, fetch-stub style** (same pattern as `organizations-api.test.ts`): URL, method, headers (Bearer present on create, absent on get, `X-Current-Org-Id` forwarded from the instance pin), the exact JSON body including verbatim opaque `metadata` / `lineItems`, and catalogue-code propagation for `BCK.ORDER.0003` / `0002`. No e2e: creating an order on staging needs an org-scoped key with an active org and a Connect account, which the CI test keys are not, and staging may not carry #3311 yet (argocd#611).

### Escalations (per the #3250 brief) — @aaitor

1. **No release / publish.** This PR stops at merge; no version bump. Cutting `@nevermined-io/payments` with this needs your explicit go-ahead.
2. **Org-scoped API key.** The API derives the merchant organization from the key's own org tag (`req.apiKeyOrgId`, set by `NvmApiHashKeyGuard`), not from the `X-Current-Org-Id` header. The SDK's key model is "any NVM API key string", so an org-scoped key is expressible today with no change: the merchant constructs `Payments` with it. What does **not** work is `setOrganizationId()` on a personal key — that only sets the header, which the org gate (#3317) ignores, so the call is refused with `BCK.ORDER.0003`. Documented in the class TSDoc; no workaround attempted. Flagging so "get an org-scoped key" lands in the merchant onboarding docs.

## Is this PR related with an open issue?

Related to nevermined-io/nvm-monorepo#3250 (P1.8 — SDK OrdersAPI), epic nevermined-io/nvm-monorepo#3238.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation — `markdown/orders.md` guide page + `markdown/README.md` index entry; TSDoc on `OrdersAPI` and its types

### Test plan

- [x] `pnpm build` — exit 0
- [x] `pnpm lint` — 0 errors (3 pre-existing warnings in untouched files)
- [x] `pnpm test:unit` — 44 suites, 576 passed
- [x] Deep pre-PR review — 0 blockers; 2 should-fix addressed in the second commit, re-run clean (0/0/0)
- [ ] CI green: `lint_build`, `cli_sync_check`, `openclaw_check`, `unit_integration`, `e2e`
- [x] `./scripts/generate-docs.sh` — exit 0

Refs nevermined-io/nvm-monorepo#3250 · epic #3238 · server contract nvm-monorepo#3311 · org gate #3317. Companion PR: nevermined-io/payments-py#270 (Python SDK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSHvoA2jHxfARTVwEmrR33
