### PR TITLE
feat(x402): surface billingModel so a pay-as-you-go settle can be read as paid

### DIFF
--- a/markdown/mcp-integration.md
+++ b/markdown/mcp-integration.md
@@ -458,6 +458,7 @@ On a successful paid call, the SDK injects the settlement receipt under `_meta["
     'nevermined/credits': {
       success: true,
       txHash: '0xabc...',
+      billingModel: 'credits',
       creditsRedeemed: '5',
       planId: 'plan-123',
       subscriberAddress: '0x123...',
@@ -472,9 +473,9 @@ Free / no-credit calls omit the `x402/payment-response` key (no settlement occur
 > credit balance — each call is charged directly — so both credit fields read `'0'` even though the
 > buyer *was* charged. Read `billingModel` off `_meta["x402/payment-response"]` to tell the two apart:
 > `'pay-as-you-go'` means the charge is referenced by `orderTx` (fiat rails) or `transaction` (crypto
-> rails), and `creditsRedeemed` carries no information. The whole settle receipt is passed through
-> under that key, so `billingModel` and `orderTx` are both available there; the condensed
-> `nevermined/credits` key does not carry them. See
+> rails), and `creditsRedeemed` carries no information. Both keys carry the discriminator: the whole
+> settle receipt is passed through under `x402/payment-response`, and `nevermined/credits` carries
+> `billingModel` and `orderTx` alongside its condensed fields. See
 > [Was the buyer charged?](./validation-of-requests#was-the-buyer-charged).
 
 ### Payment required

--- a/markdown/mcp-integration.md
+++ b/markdown/mcp-integration.md
@@ -450,6 +450,7 @@ On a successful paid call, the SDK injects the settlement receipt under `_meta["
       transaction: '0xabc...',
       network: 'eip155:84532',
       payer: '0x123...',
+      billingModel: 'credits',
       creditsRedeemed: '5',
       remainingBalance: '95',
     },
@@ -466,6 +467,15 @@ On a successful paid call, the SDK injects the settlement receipt under `_meta["
 ```
 
 Free / no-credit calls omit the `x402/payment-response` key (no settlement occurred); `nevermined/credits` is still attached with `creditsRedeemed: '0'`.
+
+> **On a pay-as-you-go plan, a paid call also reports `creditsRedeemed: '0'`.** Those plans hold no
+> credit balance — each call is charged directly — so both credit fields read `'0'` even though the
+> buyer *was* charged. Read `billingModel` off `_meta["x402/payment-response"]` to tell the two apart:
+> `'pay-as-you-go'` means the charge is referenced by `orderTx` (fiat rails) or `transaction` (crypto
+> rails), and `creditsRedeemed` carries no information. The whole settle receipt is passed through
+> under that key, so `billingModel` and `orderTx` are both available there; the condensed
+> `nevermined/credits` key does not carry them. See
+> [Was the buyer charged?](./validation-of-requests#was-the-buyer-charged).
 
 ### Payment required
 

--- a/markdown/validation-of-requests.md
+++ b/markdown/validation-of-requests.md
@@ -148,12 +148,15 @@ app.post('/api/v1/tasks', async (req, res) => {
       maxAmount: 1n,  // Credits to burn
     })
 
-    // Return success with payment metadata
+    // Return success with payment metadata. Pass `billingModel` through — it is
+    // what tells the caller how to read the credit fields (see below).
     return res.json({
       result,
       transaction: settlement.transaction,
+      billingModel: settlement.billingModel,
       creditsUsed: settlement.creditsRedeemed,
       remainingBalance: settlement.remainingBalance,
+      orderTx: settlement.orderTx,
     })
 
   } catch (error) {
@@ -161,6 +164,30 @@ app.post('/api/v1/tasks', async (req, res) => {
   }
 })
 ```
+
+### Was the buyer charged?
+
+`settlement.success` tells you the settle worked. What to check **in addition** depends
+on `settlement.billingModel`:
+
+| `billingModel` | Success criterion | Credit fields |
+| -------------- | ----------------- | ------------- |
+| `credits` | `success === true && Number(creditsRedeemed) > 0` | `creditsRedeemed` is the amount burned, `remainingBalance` what is left |
+| `pay-as-you-go` | `success === true` **and** a non-empty `orderTx` (fiat rails) / `transaction` (crypto rails) | always the string `'0'` — no balance exists on this plan shape |
+
+```typescript
+const settled =
+  settlement.success &&
+  (settlement.billingModel === 'pay-as-you-go'
+    ? Boolean(settlement.orderTx || settlement.transaction)
+    : Number(settlement.creditsRedeemed ?? '0') > 0)
+```
+
+Do not gate on `creditsRedeemed` without reading `billingModel` first: a pay-as-you-go plan
+holds no credit balance, so `creditsRedeemed > 0` can never hold there and a real charge
+reads as a decline. On a card rail that invites a retry of a payment that already succeeded,
+and repeated attempts feed issuer fraud scoring. Note also that these fields are **strings** —
+`'0'` is truthy while `Number('0') > 0` is false.
 
 ## Return 402 Payment Required
 
@@ -270,7 +297,9 @@ app.post('/api/v1/tasks', async (req, res) => {
       success: settlement.success,
       network: settlement.network,
       transaction: settlement.transaction,
+      billingModel: settlement.billingModel,
       creditsRedeemed: settlement.creditsRedeemed,
+      orderTx: settlement.orderTx,
     }
 
     res.writeHead(200, {
@@ -394,6 +423,8 @@ const settlement = await agentPayments.facilitator.settlePermissions({
 5. **Log Transactions**: Record transaction hashes for audit trails
 6. **Dynamic Pricing**: Calculate credits based on actual resource usage
 7. **Token Validation**: Never skip verification even if token looks valid
+8. **Branch on `billingModel`**: Never decide "was the buyer charged?" from
+   `creditsRedeemed` alone — see [Was the buyer charged?](#was-the-buyer-charged) above
 
 ## Related Documentation
 

--- a/markdown/validation-of-requests.md
+++ b/markdown/validation-of-requests.md
@@ -175,6 +175,11 @@ on `settlement.billingModel`:
 | `credits` | `success === true && Number(creditsRedeemed) > 0` | `creditsRedeemed` is the amount burned, `remainingBalance` what is left |
 | `pay-as-you-go` | `success === true` **and** a non-empty `orderTx` (fiat rails) / `transaction` (crypto rails) | always the string `'0'` — no balance exists on this plan shape |
 
+**No `billingModel` in the response?** You are talking to a Nevermined API that predates the
+discriminator. Apply the **credits** rule — never read a missing discriminator as pay-as-you-go.
+All three fields are optional; if `creditsRedeemed` is absent too there is no balance information
+to check, and `success === true` is the whole answer.
+
 ```typescript
 const settled =
   settlement.success &&

--- a/markdown/validation-of-requests.md
+++ b/markdown/validation-of-requests.md
@@ -177,8 +177,6 @@ on `settlement.billingModel`:
 
 **No `billingModel` in the response?** You are talking to a Nevermined API that predates the
 discriminator. Apply the **credits** rule — never read a missing discriminator as pay-as-you-go.
-All three fields are optional; if `creditsRedeemed` is absent too there is no balance information
-to check, and `success === true` is the whole answer.
 
 ```typescript
 const settled =

--- a/markdown/x402.md
+++ b/markdown/x402.md
@@ -554,6 +554,11 @@ interface SettlePermissionsResult {
 | `credits` | `success === true && Number(creditsRedeemed) > 0` | `creditsRedeemed` is the amount burned, `remainingBalance` what is left |
 | `pay-as-you-go` | `success === true` **and** a non-empty `orderTx` (fiat rails) / `transaction` (crypto rails) | always the string `'0'` — no balance exists on this plan shape |
 
+**No `billingModel` in the response?** You are talking to a Nevermined API that predates the
+discriminator. Apply the **credits** rule — never read a missing discriminator as pay-as-you-go.
+All three fields are optional; if `creditsRedeemed` is absent too there is no balance information
+to check, and `success === true` is the whole answer.
+
 ```typescript
 const settled =
   settlement.success &&

--- a/markdown/x402.md
+++ b/markdown/x402.md
@@ -556,8 +556,6 @@ interface SettlePermissionsResult {
 
 **No `billingModel` in the response?** You are talking to a Nevermined API that predates the
 discriminator. Apply the **credits** rule — never read a missing discriminator as pay-as-you-go.
-All three fields are optional; if `creditsRedeemed` is absent too there is no balance information
-to check, and `success === true` is the whole answer.
 
 ```typescript
 const settled =

--- a/markdown/x402.md
+++ b/markdown/x402.md
@@ -516,21 +516,60 @@ const settlement = await agentPayments.facilitator.settlePermissions({
 
 console.log(`✓ Settlement successful`)
 console.log(`Transaction: ${settlement.transaction}`)
-console.log(`Credits burned: ${settlement.creditsRedeemed}`)
-console.log(`Remaining balance: ${settlement.remainingBalance}`)
+
+// Read `billingModel` before the credit fields — see "Was the buyer charged?" below
+if (settlement.billingModel === 'pay-as-you-go') {
+  console.log(`Charged, reference: ${settlement.orderTx || settlement.transaction}`)
+} else {
+  console.log(`Credits burned: ${settlement.creditsRedeemed}`)
+  console.log(`Remaining balance: ${settlement.remainingBalance}`)
+}
 ```
 
 ### Settlement Response
 
 ```typescript
+type X402BillingModel = 'credits' | 'pay-as-you-go'
+
 interface SettlePermissionsResult {
-  success: boolean          // True if settlement succeeded
-  transaction: string       // Blockchain transaction hash
-  creditsRedeemed: string   // Credits burned
-  remainingBalance: string  // Subscriber's remaining credits
-  network: string          // Blockchain network
+  success: boolean               // True if settlement succeeded
+  errorReason?: string           // Only present when success is false
+  payer?: string                 // Payer's wallet address
+  transaction: string            // Blockchain transaction hash
+  network: string                // Rail: CAIP-2 chain id, or the fiat PSP ('stripe', …)
+  billingModel?: X402BillingModel // How this request was priced
+  creditsRedeemed?: string       // Credits burned — always '0' on pay-as-you-go
+  remainingBalance?: string      // Remaining credits — always '0' on pay-as-you-go
+  orderTx?: string               // Order / per-request charge reference
 }
 ```
+
+### Was the buyer charged?
+
+`success` alone tells you the settle worked. What to check **in addition** depends on
+`billingModel`:
+
+| `billingModel` | Success criterion | Credit fields |
+| -------------- | ----------------- | ------------- |
+| `credits` | `success === true && Number(creditsRedeemed) > 0` | `creditsRedeemed` is the amount burned, `remainingBalance` what is left |
+| `pay-as-you-go` | `success === true` **and** a non-empty `orderTx` (fiat rails) / `transaction` (crypto rails) | always the string `'0'` — no balance exists on this plan shape |
+
+```typescript
+const settled =
+  settlement.success &&
+  (settlement.billingModel === 'pay-as-you-go'
+    ? Boolean(settlement.orderTx || settlement.transaction)
+    : Number(settlement.creditsRedeemed ?? '0') > 0)
+```
+
+Two things make this easy to get wrong:
+
+- **Do not gate on `creditsRedeemed` without reading `billingModel` first.** A pay-as-you-go
+  plan holds no credit balance, so `creditsRedeemed > 0` can never hold there — a real charge
+  reads as a decline. On a card rail that invites a retry of a payment that already succeeded,
+  and repeated attempts feed issuer fraud scoring.
+- **These fields are strings.** `'0'` is truthy while `Number('0') > 0` is false, so two
+  plausible-looking checks disagree. Compare numerically, and only on `credits` plans.
 
 ## HTTP Headers (X402 v2)
 
@@ -623,17 +662,35 @@ PAYMENT-RESPONSE: eyJzdWNjZXNzIjp0cnVlLCJ0cmFuc2FjdGlvbiI6IjB4Li4uIn0=
 {"result": "Task completed"}
 ```
 
-The header contains base64-encoded settlement details:
+The header contains base64-encoded settlement details. On a `credits` plan:
 
 ```json
 {
   "success": true,
   "network": "eip155:84532",
   "transaction": "0x...",
+  "billingModel": "credits",
   "creditsRedeemed": "2",
   "remainingBalance": "98"
 }
 ```
+
+The same successful settle on a **pay-as-you-go** plan reports the charge in `orderTx`
+(fiat rails) or `transaction` (crypto rails), and reads `"0"` for both credit fields:
+
+```json
+{
+  "success": true,
+  "network": "stripe",
+  "transaction": "pi_3U6tgrBYvSRKcV421ehH4bnX",
+  "billingModel": "pay-as-you-go",
+  "creditsRedeemed": "0",
+  "remainingBalance": "0",
+  "orderTx": "pi_3U6tgrBYvSRKcV421ehH4bnX"
+}
+```
+
+See [Was the buyer charged?](#was-the-buyer-charged) for the check to apply to each.
 
 ## Complete X402 Flow
 
@@ -747,12 +804,16 @@ app.post('/api/v1/tasks', async (req, res) => {
       maxAmount: 2n,
     })
 
-    // 6. Return response with PAYMENT-RESPONSE header
+    // 6. Return response with PAYMENT-RESPONSE header. Pass `billingModel` through —
+    //    without it the client cannot tell a pay-as-you-go charge (creditsRedeemed
+    //    always "0") from a credits settle that burned nothing.
     const paymentResponse = {
       success: settlement.success,
       network: settlement.network,
       transaction: settlement.transaction,
+      billingModel: settlement.billingModel,
       creditsRedeemed: settlement.creditsRedeemed,
+      orderTx: settlement.orderTx,
     }
 
     return res

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export type {
   VerifyPermissionsResult,
   SettlePermissionsParams,
   SettlePermissionsResult,
+  X402BillingModel,
 } from './x402/facilitator-api.js'
 
 // MPP (Machine Payments Protocol) public surface

--- a/src/mcp/core/paywall.ts
+++ b/src/mcp/core/paywall.ts
@@ -237,10 +237,16 @@ export class PaywallDecorator {
           ...(creditsResult && { [X402_PAYMENT_RESPONSE_META_KEY]: creditsResult }),
           [NEVERMINED_CREDITS_META_KEY]: {
             ...(creditsResult?.transaction && { txHash: creditsResult.transaction }),
+            // `creditsRedeemed` is meaningless without this: a pay-as-you-go plan
+            // holds no balance, so it reads '0' on a settle that DID charge the
+            // buyer. Omitted (not '') when the settle carried no discriminator,
+            // so a consumer can tell "absent" from "present and empty".
+            ...(creditsResult?.billingModel && { billingModel: creditsResult.billingModel }),
             creditsRedeemed: creditsResult?.success
               ? (creditsResult.creditsRedeemed ?? credits.toString())
               : '0',
             remainingBalance: creditsResult?.remainingBalance,
+            ...(creditsResult?.orderTx && { orderTx: creditsResult.orderTx }),
             planId: authResult.planId,
             subscriberAddress: authResult.subscriberAddress,
             success: creditsResult ? creditsResult.success : true,
@@ -396,10 +402,14 @@ function wrapAsyncIterable<T>(
         // Nevermined-namespaced observability (NOT part of the x402 spec).
         [NEVERMINED_CREDITS_META_KEY]: {
           ...(settlement?.transaction && { txHash: settlement.transaction }),
+          // See the non-streaming site: without `billingModel`, `creditsRedeemed`
+          // cannot be read — it is '0' on a pay-as-you-go settle that charged.
+          ...(settlement?.billingModel && { billingModel: settlement.billingModel }),
           creditsRedeemed: settlement?.success
             ? (settlement.creditsRedeemed ?? credits.toString())
             : '0',
           remainingBalance: settlement?.remainingBalance,
+          ...(settlement?.orderTx && { orderTx: settlement.orderTx }),
           planId,
           subscriberAddress,
           success: settlement ? settlement.success : true,

--- a/src/x402/facilitator-api.ts
+++ b/src/x402/facilitator-api.ts
@@ -219,6 +219,12 @@ export type X402BillingModel = 'credits' | 'pay-as-you-go'
  * Mind the type as well: these fields are **strings**. `'0'` is truthy while
  * `Number('0') > 0` is false, so two plausible-looking checks disagree.
  *
+ * If `billingModel` is **absent**, you are talking to a Nevermined API that
+ * predates the discriminator: apply the `credits` rule, and never read a missing
+ * discriminator as pay-as-you-go. All three fields are optional; if
+ * `creditsRedeemed` is absent too there is no balance information to check, and
+ * `success === true` is the whole answer.
+ *
  * @example
  * ```typescript
  * const settled =
@@ -250,9 +256,11 @@ export interface SettlePermissionsResult {
   /**
    * Which billing model this settle was priced under (Nevermined extension).
    *
-   * Present regardless of `success` — check `success` before treating it as
-   * evidence of a charge. Read it before `creditsRedeemed` / `remainingBalance`:
-   * see the interface docs above for the per-model success criterion.
+   * Reported whether or not the settle succeeded — so check `success` before
+   * treating it as evidence of a charge. It is absent entirely against a
+   * Nevermined API that predates the discriminator, which is why it is optional;
+   * treat that case as `credits`. Read it before `creditsRedeemed` /
+   * `remainingBalance`: see the interface docs above for the per-model criterion.
    */
   billingModel?: X402BillingModel
   /**

--- a/src/x402/facilitator-api.ts
+++ b/src/x402/facilitator-api.ts
@@ -221,9 +221,7 @@ export type X402BillingModel = 'credits' | 'pay-as-you-go'
  *
  * If `billingModel` is **absent**, you are talking to a Nevermined API that
  * predates the discriminator: apply the `credits` rule, and never read a missing
- * discriminator as pay-as-you-go. All three fields are optional; if
- * `creditsRedeemed` is absent too there is no balance information to check, and
- * `success === true` is the whole answer.
+ * discriminator as pay-as-you-go.
  *
  * @example
  * ```typescript

--- a/src/x402/facilitator-api.ts
+++ b/src/x402/facilitator-api.ts
@@ -30,13 +30,22 @@
  * })
  *
  * if (verification.isValid) {
- *   // Settle (burn) the credits
  *   const settlement = await payments.facilitator.settlePermissions({
  *     paymentRequired,
  *     x402AccessToken: x402Token,
  *     maxAmount: 2n
  *   })
- *   console.log(`Credits redeemed: ${settlement.creditsRedeemed}`)
+ *
+ *   // Read `billingModel` before reading the credit fields: on a pay-as-you-go
+ *   // plan there is no balance, so `creditsRedeemed` is always the string "0"
+ *   // even on a charge that succeeded. See `SettlePermissionsResult`.
+ *   if (settlement.success) {
+ *     if (settlement.billingModel === 'pay-as-you-go') {
+ *       console.log(`Charged, reference: ${settlement.orderTx || settlement.transaction}`)
+ *     } else {
+ *       console.log(`Credits redeemed: ${settlement.creditsRedeemed}`)
+ *     }
+ *   }
  * }
  * ```
  */
@@ -179,8 +188,45 @@ export interface SettlePermissionsParams {
 }
 
 /**
+ * How the settled request was priced (Nevermined extension).
+ *
+ * - `credits` — the plan holds a credit balance and this settle redeemed from it.
+ * - `pay-as-you-go` — the plan holds no balance; the request is priced individually
+ *   and charged directly (a card PSP on fiat rails, an on-chain order on crypto
+ *   rails).
+ */
+export type X402BillingModel = 'credits' | 'pay-as-you-go'
+
+/**
  * x402 Settle Response - per x402 facilitator spec
  * @see https://github.com/coinbase/x402/blob/main/specs/x402-specification-v2.md
+ *
+ * ### Deciding whether the buyer was charged
+ *
+ * `success` alone tells you the settle worked. What to check *in addition*
+ * depends on {@link SettlePermissionsResult.billingModel}:
+ *
+ * - `credits` — `success === true && Number(creditsRedeemed) > 0`.
+ * - `pay-as-you-go` — `success === true` plus a non-empty `orderTx` (fiat rails)
+ *   or `transaction` (crypto rails). `creditsRedeemed` and `remainingBalance` are
+ *   always the string `'0'` on this billing model and carry no information.
+ *
+ * Do not gate on `creditsRedeemed` without reading `billingModel` first: on a
+ * pay-as-you-go plan `creditsRedeemed > 0` can never hold, so a real charge reads
+ * as a decline — and retrying a card charge that already succeeded is the one
+ * thing to avoid, because repeated attempts feed issuer fraud scoring.
+ *
+ * Mind the type as well: these fields are **strings**. `'0'` is truthy while
+ * `Number('0') > 0` is false, so two plausible-looking checks disagree.
+ *
+ * @example
+ * ```typescript
+ * const settled =
+ *   settlement.success &&
+ *   (settlement.billingModel === 'pay-as-you-go'
+ *     ? Boolean(settlement.orderTx || settlement.transaction)
+ *     : Number(settlement.creditsRedeemed ?? '0') > 0)
+ * ```
  */
 export interface SettlePermissionsResult {
   /** Whether settlement was successful */
@@ -189,15 +235,47 @@ export interface SettlePermissionsResult {
   errorReason?: string
   /** Address of the payer's wallet */
   payer?: string
-  /** Blockchain transaction hash (empty string if settlement failed) */
+  /**
+   * Blockchain transaction hash (empty string if settlement failed). On crypto
+   * `pay-as-you-go` plans this is also the reference for the per-request charge.
+   */
   transaction: string
-  /** Blockchain network identifier in CAIP-2 format */
+  /**
+   * Network identifier. The discriminator is the rail, not the billing model: for
+   * crypto rails (`nvm:erc4337`) it is the CAIP-2 chain id (`eip155:84532`) under
+   * both billing models; for fiat card-delegation rails it is the settling payment
+   * provider (`stripe`, `braintree`, `visa`), not a CAIP-2 value.
+   */
   network: string
-  /** Number of credits redeemed (Nevermined extension) */
+  /**
+   * Which billing model this settle was priced under (Nevermined extension).
+   *
+   * Present regardless of `success` — check `success` before treating it as
+   * evidence of a charge. Read it before `creditsRedeemed` / `remainingBalance`:
+   * see the interface docs above for the per-model success criterion.
+   */
+  billingModel?: X402BillingModel
+  /**
+   * Number of credits redeemed (Nevermined extension). Always the string `'0'` for
+   * `billingModel: 'pay-as-you-go'` plans, which hold no credit balance — including
+   * on a settle that charged the buyer successfully.
+   */
   creditsRedeemed?: string
-  /** Subscriber's remaining balance (Nevermined extension) */
+  /**
+   * Subscriber's remaining credit balance (Nevermined extension). Always the string
+   * `'0'` for `billingModel: 'pay-as-you-go'` plans — the per-request charge is
+   * referenced by `orderTx` (fiat) or `transaction` (crypto), not here.
+   */
   remainingBalance?: string
-  /** Transaction hash of the order operation if auto top-up occurred (Nevermined extension) */
+  /**
+   * Reference for the order or per-request charge, if one occurred (Nevermined
+   * extension). On fiat `pay-as-you-go` this is the per-request charge — the PSP
+   * transaction id (a Stripe PaymentIntent `pi_…`, a Braintree transaction id);
+   * crypto `pay-as-you-go` reports its on-chain order in `transaction` instead. On
+   * `credits` plans it is set only when the settle had to order credits first
+   * (auto top-up). Treat it as an opaque string and disambiguate by prefix if you
+   * need to.
+   */
   orderTx?: string
 }
 

--- a/src/x402/index.ts
+++ b/src/x402/index.ts
@@ -21,6 +21,7 @@ export type {
   VerifyPermissionsResult,
   SettlePermissionsParams,
   SettlePermissionsResult,
+  X402BillingModel,
 } from './facilitator-api.js'
 
 // Delegation exports

--- a/tests/unit/mcp.test.ts
+++ b/tests/unit/mcp.test.ts
@@ -197,6 +197,82 @@ describe('MCP Integration', () => {
       expect(out._meta['nevermined/credits'].success).toBe(true)
     })
 
+    test('surfaces billingModel + orderTx on a pay-as-you-go receipt, where creditsRedeemed is "0"', async () => {
+      // A REAL pay-as-you-go settle: the buyer was charged, but the plan holds no
+      // credit balance, so both credit fields read '0'. Without `billingModel` a
+      // consumer of this key cannot tell this from a credits settle that burned
+      // nothing, and retrying a card charge that already succeeded is exactly the
+      // thing to avoid. See nevermined-io/nvm-monorepo#2999.
+      const settleResult = {
+        success: true,
+        transaction: 'pi_3U6tgrBYvSRKcV421ehH4bnX',
+        network: 'stripe',
+        billingModel: 'pay-as-you-go',
+        creditsRedeemed: '0',
+        remainingBalance: '0',
+        orderTx: 'pi_3U6tgrBYvSRKcV421ehH4bnX',
+      }
+      const mockInstance = new PaymentsMock(settleResult)
+      const pm = mockInstance as any as Payments
+      const mcp = buildMcpIntegration(pm)
+      mcp.configure({ agentId: 'did:nv:agent', serverName: 'test-mcp' })
+
+      const base = async (_args: any, _extra?: any) => ({
+        content: [{ type: 'text', text: 'ok' }],
+      })
+      const wrapped = mcp.withPaywall(base, {
+        kind: 'tool',
+        name: 'test',
+        credits: 5n,
+        planId: 'plan123',
+      })
+      const extra = { requestInfo: { headers: { authorization: 'Bearer token' } } }
+      const out = await wrapped({}, extra)
+
+      const nvm = out._meta['nevermined/credits']
+      // The discriminator, and the reference that actually proves the charge.
+      expect(nvm.billingModel).toBe('pay-as-you-go')
+      expect(nvm.orderTx).toBe('pi_3U6tgrBYvSRKcV421ehH4bnX')
+      // The trap this guards: a successful charge reporting '0' credits.
+      expect(nvm.success).toBe(true)
+      expect(nvm.creditsRedeemed).toBe('0')
+      expect(nvm.remainingBalance).toBe('0')
+    })
+
+    test('omits billingModel and orderTx entirely when the settle carries neither', async () => {
+      // Omitted rather than emitted empty, so a consumer can distinguish
+      // "absent" from "present and empty".
+      const mockInstance = new PaymentsMock({
+        success: true,
+        transaction: '0xabc',
+        network: 'eip155:84532',
+        creditsRedeemed: '5',
+      })
+      const pm = mockInstance as any as Payments
+      const mcp = buildMcpIntegration(pm)
+      mcp.configure({ agentId: 'did:nv:agent', serverName: 'test-mcp' })
+
+      const base = async (_args: any, _extra?: any) => ({
+        content: [{ type: 'text', text: 'ok' }],
+      })
+      const wrapped = mcp.withPaywall(base, {
+        kind: 'tool',
+        name: 'test',
+        credits: 5n,
+        planId: 'plan123',
+      })
+      const extra = { requestInfo: { headers: { authorization: 'Bearer token' } } }
+      const out = await wrapped({}, extra)
+
+      const nvm = out._meta['nevermined/credits']
+      expect('billingModel' in nvm).toBe(false)
+      expect('orderTx' in nvm).toBe(false)
+      // The pre-existing keys are untouched by the addition.
+      expect(nvm.creditsRedeemed).toBe('5')
+      expect(nvm.txHash).toBe('0xabc')
+      expect(nvm.success).toBe(true)
+    })
+
     test('should not include txHash when transaction is empty', async () => {
       // Backend returns empty transaction (no blockchain tx)
       const settleResult = {
@@ -558,6 +634,51 @@ describe('MCP Integration', () => {
       expect(lastChunk._meta['nevermined/credits'].planId).toBe('plan123')
       expect(lastChunk._meta['nevermined/credits'].subscriberAddress).toBe('0x123subscriber')
       expect(lastChunk._meta['nevermined/credits'].success).toBe(true)
+    })
+
+    test('surfaces billingModel + orderTx on a streaming pay-as-you-go receipt', async () => {
+      // Same guard as the non-streaming site — the two _meta builders are
+      // separate code, so a test on one proves nothing about the other.
+      const settleResult = {
+        success: true,
+        transaction: 'pi_3StreamPayg',
+        network: 'stripe',
+        billingModel: 'pay-as-you-go',
+        creditsRedeemed: '0',
+        remainingBalance: '0',
+        orderTx: 'pi_3StreamPayg',
+      }
+      const mockInstance = new PaymentsMock(settleResult)
+      const pm = mockInstance as any as Payments
+      const mcp = buildMcpIntegration(pm)
+      mcp.configure({ agentId: 'did:nv:agent', serverName: 'mcp' })
+
+      async function* makeIterable(chunks: string[]) {
+        for (const c of chunks) {
+          await new Promise((resolve) => setTimeout(resolve, 0))
+          yield c
+        }
+      }
+      const base = async (_args: any, _extra?: any) => makeIterable(['chunk1', 'chunk2'])
+      const wrapped = mcp.withPaywall(base, {
+        kind: 'tool',
+        name: 'stream',
+        credits: 5n,
+        planId: 'plan123',
+      })
+      const extra = { requestInfo: { headers: { authorization: 'Bearer tok' } } }
+      const iterable = await wrapped({}, extra)
+
+      const collected: any[] = []
+      for await (const chunk of iterable) {
+        collected.push(chunk)
+      }
+
+      const nvm = collected[collected.length - 1]._meta['nevermined/credits']
+      expect(nvm.billingModel).toBe('pay-as-you-go')
+      expect(nvm.orderTx).toBe('pi_3StreamPayg')
+      expect(nvm.success).toBe(true)
+      expect(nvm.creditsRedeemed).toBe('0')
     })
 
     test('should redeem when consumer stops stream early', async () => {


### PR DESCRIPTION
> **This is no longer a docs-only PR.** It now carries an **additive behaviour change** to the MCP paywall (`_meta["nevermined/credits"]` gains `billingModel` and `orderTx`) alongside the type + documentation work. Nothing is renamed, retyped or removed, and both new fields are omitted when absent — but it warrants a **minor**, not a patch. Titled `feat(...)` accordingly.

## The problem, in plain terms

On a **pay-as-you-go** plan, a settle that charged the buyer $1.00 comes back like this:

```json
{ "success": true, "network": "stripe", "billingModel": "pay-as-you-go",
  "creditsRedeemed": "0", "remainingBalance": "0",
  "orderTx": "pi_3U6tgrBYvSRKcV421ehH4bnX" }
```

Those plans hold no credit balance — each settle is one direct charge, referenced by `orderTx` (fiat rails) or `transaction` (crypto rails). So the success check a credits integration already has, `success === true && creditsRedeemed > 0`, is **unreachable** there: it reports a real charge as a decline.

That is not hypothetical. During company testing of the card rails a tester's pass condition was exactly that check, the charge succeeded, and the agent running the purchase had to reason from the backend source to work out that a healthy payment was being reported as a decline. A less careful consumer would have retried — and on a card rail a needless retry is the one thing we tell people never to do, because repeated attempts feed issuer fraud scoring.

The API has always returned the discriminator `billingModel`. **`SettlePermissionsResult` did not declare it**, so it was invisible to TypeScript consumers, and the correct check could only be worked out by reading our source. This PR makes it visible and documents the criterion.

## What changed

**No wire change.** `billingModel` was already on the response; the type just did not mention it.

- `SettlePermissionsResult` gains `billingModel?: X402BillingModel` (`'credits' | 'pay-as-you-go'`), exported from `@nevermined-io/payments` and `@nevermined-io/payments/x402`.
- The interface doc carries the per-model criterion, including the string-vs-number trap: these are **strings**, so `'0'` is truthy while `Number('0') > 0` is false — two plausible-looking checks disagree.
- `creditsRedeemed` / `remainingBalance` now say they are always `'0'` on pay-as-you-go. `orderTx` and `network` descriptions were corrected against the API's own DTO (`orderTx` is the per-request charge on fiat pay-as-you-go, not only an auto-top-up hash; `network` is the rail, not the billing model).
- The class-level JSDoc example printed `creditsRedeemed` unconditionally — the exact confusion the issue is about. It now demonstrates the correct check.
- `markdown/x402.md`, `markdown/validation-of-requests.md` and `markdown/mcp-integration.md`: a "Was the buyer charged?" section, a pay-as-you-go receipt example, and `billingModel` passed through the `PAYMENT-RESPONSE` examples.

## The criterion, as documented

| `billingModel` | Success criterion | Credit fields |
| --- | --- | --- |
| `credits` | `success === true && Number(creditsRedeemed) > 0` | `creditsRedeemed` is the amount burned, `remainingBalance` what is left |
| `pay-as-you-go` | `success === true` **and** a non-empty `orderTx` (fiat) / `transaction` (crypto) | always the string `'0'` — no balance exists on this plan shape |

## Additive behaviour change: the MCP receipt

The MCP paywall attaches two `_meta` keys. `x402/payment-response` spreads the **whole** settle result, so it already carried `billingModel` and `orderTx`. The condensed `nevermined/credits` key did not — it reported `creditsRedeemed` with nothing to read it by. On a pay-as-you-go plan that field is always `'0'`, so a settle that **did** charge the buyer was indistinguishable, on that key, from a credits settle that burned nothing.

Both `_meta` builders now carry the two fields — the non-streaming site and the streaming final-chunk site, which are separate code paths with a test each.

Constraints held to:

- **Purely additive.** Existing keys keep their names, types and values.
- **Omitted, not empty,** when the settle carried neither, so a consumer can distinguish "absent" from "present and empty". Pinned by its own test.
- `markdown/mcp-integration.md` is corrected — it previously stated the condensed key does *not* carry these fields, which this change makes false.

### Mutation-tested, recording which tests go red

| Mutation | Tests killed |
| --- | --- |
| `billingModel` removed from the **non-streaming** site | the non-streaming PAYG test, alone |
| `billingModel` removed from the **streaming** site | the streaming PAYG test, alone |
| `orderTx` removed from **both** sites | both PAYG tests |
| *(control: restored)* | none — 581 passed |

Each site fails independently, so neither test is masking the other.

## Verification

- `pnpm build` (tsc) — clean.
- `pnpm test:unit` — **44 suites, 581 passed, 1 skipped, 582 total** (3 new tests).
- `pnpm lint` — 0 errors, 3 warnings, all pre-existing (`src/utils.ts`, `src/x402/express/middleware.ts`).
- `python3 scripts/lint_doc_links.py` — 14 pages, no escaping or repo-source links.
- `./scripts/check_synced_doc_links.sh` — mintlify `broken-links` over the staged `api-reference/typescript/` tree: no broken links.

## Notes for the reviewer

- `markdown/` is the **source** for the docs site's generated `api-reference/typescript/**`; the generated copy is untouched, as it must be.
- The condensed `_meta["nevermined/credits"]` gap was first raised as a finding and deliberately held; the repo owner then approved changing it, which is the second commit here.

Refs nevermined-io/nvm-monorepo#2999

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVpimo1dBXnTJo9tQSy8SA

