### PR TITLE
fix: withhold buffered responses when settlement fails

### DIFF
--- a/markdown/validation-of-requests.md
+++ b/markdown/validation-of-requests.md
@@ -437,6 +437,12 @@ A second settlement of the same token fails with **`BCK.X402.0059`** — which i
 neither a decline nor a forgery (`BCK.X402.0005`): the token was valid and has
 already been spent. Never retry it; the buyer must mint a new one.
 
+For buffered Express responses, `paymentMiddleware` withholds the handler body
+and returns a 402 when settlement throws or reports `success: false`. A streamed
+response cannot be recalled after its headers or chunks have been written, so
+routes that require strict settle-before-release semantics must buffer their
+protected output instead of writing it incrementally.
+
 ```typescript
 import { isAccessTokenAlreadyUsed } from '@nevermined-io/payments'
 

--- a/src/x402/express/middleware.ts
+++ b/src/x402/express/middleware.ts
@@ -1376,6 +1376,7 @@ export function paymentMiddleware(
         // without emitting the payment-response receipt header (#1728).
         const originalEnd = res.end.bind(res) as (...args: Parameters<Response['end']>) => Response
         let settlementStarted = false
+        let settlementFailure: unknown = null
 
         // Armed before next() for the same reason as the MPP path: it captures
         // a byte baseline. A route declared `{ planId, credits, mpp: true }`
@@ -1401,6 +1402,14 @@ export function paymentMiddleware(
                   agentRequestId: paymentContext.agentRequestId,
                 })
                 .then((settlement) => {
+                  if (settlement.success !== true) {
+                    settlementFailure = new Error(
+                      settlement.errorReason || 'Payment settlement was not completed',
+                    )
+                    console.error('Payment settlement failed:', settlementFailure)
+                    return undefined
+                  }
+
                   // Only attach the receipt header if headers haven't flushed
                   // yet — streaming responses fire writeHead on the first
                   // chunk and may have already sent them by the time we land
@@ -1432,6 +1441,7 @@ export function paymentMiddleware(
                 markX402TokenSpent(token)
                 spentTokenRefusal = settleError
               }
+              settlementFailure = settleError
               console.error('Payment settlement failed:', settleError)
             })
         }
@@ -1477,19 +1487,27 @@ export function paymentMiddleware(
           // and so a settlement refused as already-spent can still withhold the
           // body the handler produced.
           runSettlement().finally(() => {
-            if (spentTokenRefusal && !res.headersSent) {
+            if (settlementFailure && !res.headersSent) {
               // The handler already ran, so the work is done and wasted; what
-              // must not happen is delivering it. Replace the body with the
-              // 402 the buyer would have got had `verify` been able to see the
-              // spent nonce.
-              const payload = JSON.stringify({
-                error:
-                  'This x402 access token was already used. Single-use (v3) tokens are consumed ' +
-                  'by their first settlement — mint a new token for this request.',
-                code: X402_TOKEN_ALREADY_USED_CODE,
-              })
+              // must not happen is delivering it. Replace the body with a safe
+              // payment error that does not expose the protected result or
+              // backend details.
+              const payload = JSON.stringify(
+                spentTokenRefusal
+                  ? {
+                      error:
+                        'This x402 access token was already used. Single-use (v3) tokens are consumed ' +
+                        'by their first settlement — mint a new token for this request.',
+                      code: X402_TOKEN_ALREADY_USED_CODE,
+                    }
+                  : {
+                      error: 'Payment settlement failed',
+                      message: 'The protected response was withheld because payment could not settle.',
+                    },
+              )
               res.statusCode = 402
               res.removeHeader('ETag')
+              res.removeHeader(X402_HEADERS.PAYMENT_RESPONSE)
               res.setHeader('Content-Type', 'application/json')
               res.setHeader('Content-Length', Buffer.byteLength(payload))
               // `originalEnd` is Express's overloaded `end`; the 3-arg form

--- a/tests/unit/x402-middleware-settlement.test.ts
+++ b/tests/unit/x402-middleware-settlement.test.ts
@@ -116,6 +116,50 @@ describe('paymentMiddleware settlement coverage (#1728)', () => {
     }
   })
 
+  test('withholds a buffered paid response when settlement fails', async () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+    const settleSpy = jest.fn().mockRejectedValue(new Error('facilitator unavailable'))
+    const { port, close } = await startServer((_req, res) => {
+      res.json({ secret: 'paid answer' })
+    }, settleSpy)
+
+    try {
+      const result = await postWithToken(port)
+
+      expect(result.status).toBe(402)
+      expect(result.body).not.toContain('paid answer')
+      expect(result.paymentResponseHeader).toBeUndefined()
+      expect(settleSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      error.mockRestore()
+      await close()
+    }
+  })
+
+  test('withholds a buffered paid response when settlement reports failure', async () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+    const settleSpy = jest.fn().mockResolvedValue({
+      success: false,
+      errorReason: 'insufficient credits',
+      transaction: '',
+      network: 'stripe',
+    })
+    const { port, close } = await startServer((_req, res) => {
+      res.json({ secret: 'paid answer' })
+    }, settleSpy)
+
+    try {
+      const result = await postWithToken(port)
+
+      expect(result.status).toBe(402)
+      expect(result.body).not.toContain('paid answer')
+      expect(result.paymentResponseHeader).toBeUndefined()
+    } finally {
+      error.mockRestore()
+      await close()
+    }
+  })
+
   test('settles when handler uses res.send', async () => {
     const settleSpy = jest.fn().mockResolvedValue(baseSettlement)
     const { port, close } = await startServer((req, res) => {


### PR DESCRIPTION
## Summary

- fail closed when `settlePermissions` rejects or returns `success: false`
- replace a buffered protected body with a generic 402 response
- keep backend error details out of the client response
- document that already-flushed streaming responses cannot be recalled

Closes #367.

## Testing

- `pnpm exec jest --config ./tests/jest.config.json --runInBand tests/unit/x402-middleware-settlement.test.ts` (9 passed)
- `pnpm build`
- `pnpm lint` (0 errors; 3 existing warnings)
- `pnpm test:unit` (633 passed, 1 skipped)