### PR TITLE
test: constrain settle/verify doubles to the model, and typecheck the test tree (#433)

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,14 +31,18 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Lint
+        run: pnpm lint
+
       # `pnpm build` compiles src only — tsconfig.json excludes `tests`, and
       # ts-jest transpiles without checking (the root `isolatedModules: true`),
       # so nothing else in CI ever typechecks a test file.
+      #
+      # Last in the job on purpose: it is the newest and noisiest gate, and
+      # running it ahead of Lint would fail-fast past lint errors that used to
+      # surface in the same run.
       - name: Typecheck tests
         run: pnpm typecheck:tests
-
-      - name: Lint
-        run: pnpm lint
 
   cli_sync_check:
     name: CLI Sync Check

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # `pnpm build` compiles src only — tsconfig.json excludes `tests`, and
+      # ts-jest transpiles without checking (the root `isolatedModules: true`),
+      # so nothing else in CI ever typechecks a test file.
+      - name: Typecheck tests
+        run: pnpm typecheck:tests
+
       - name: Lint
         run: pnpm lint
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,14 +105,42 @@ When writing examples or documentation:
 Before submitting changes, run these checks:
 
 ```bash
-pnpm build && pnpm lint && pnpm test:unit
+pnpm build && pnpm lint && pnpm typecheck:tests && pnpm test:unit
 ```
 
 For full validation including integration tests:
 
 ```bash
-pnpm build && pnpm lint && pnpm test:unit && pnpm test:integration && pnpm test:e2e
+pnpm build && pnpm lint && pnpm typecheck:tests && pnpm test:unit && pnpm test:integration && pnpm test:e2e
 ```
+
+### `pnpm build` does NOT typecheck the tests — `pnpm typecheck:tests` does
+
+Two separate reasons, so neither existing gate catches a type error under `tests/`:
+
+- `pnpm build` is `tsc` against the root `tsconfig.json`, whose `exclude` lists `tests`.
+- **ts-jest transpiles without checking**, because the root config sets `isolatedModules: true`
+  and ts-jest honours that by using `transpileModule`. A test file asserting
+  `const x: SettlePermissionsResult = { success: 123, nope: 'drift' }` **passes**.
+
+`pnpm typecheck:tests` (`tsc --noEmit -p tests/tsconfig.json`) is the only thing that reads
+them, and it runs in CI's `lint_build` job as of #437. Run it after touching a test file —
+particularly a fixture — because neither a green build nor a green suite says anything about
+whether that fixture still matches the model.
+
+### Test doubles must be constrained to a model type imported from `src/`
+
+`PaymentsMock` used to take `settleResult?: any`, which let every settle/verify double drift
+from `SettlePermissionsResult` unnoticed (#433). Doubles now either narrow the *parameter*
+(`PaymentsMock(settleResult: SettlePermissionsResult)`) or `satisfies` the literal. Two rules:
+
+- **Constrain against the model, never a shape written next to the fixture.** A
+  `Promise<{ success: boolean; transaction: string; … }>` annotation is not a check; it is the
+  fixture repeated, and it goes stale in exactly the same way.
+- **Raw `fetch`/`Response` stubs stay untyped on purpose.** They model what a *server* sends,
+  and some specs post a deliberately malformed body — `x402-token-v3` sends one with no
+  `success` field to prove the SDK reports rather than trusts it. Constraining those to the
+  model would make such a test unwritable.
 
 ### After Modifying Source Files
 
@@ -122,7 +150,8 @@ When you modify source files, especially:
 - Authentication/authorization logic
 
 You MUST:
-1. Run `pnpm build` to verify TypeScript compilation
+1. Run `pnpm build` to verify TypeScript compilation, and `pnpm typecheck:tests` if you touched
+   anything under `tests/` — `pnpm build` cannot see those files (see above)
 2. Run `pnpm test:unit` to verify unit tests pass
 3. If modifying E2E-related code, run `pnpm test:e2e`
 4. If changing public interfaces (function signatures, options, types, response fields), update the corresponding documentation in `markdown/` to reflect the changes. Validate with `./scripts/generate-docs.sh`. On merge to main, the `update-docs.yml` workflow runs `generate-docs.sh` and auto-creates a PR with any changes. On tag push, `publish-docs.yml` publishes to docs_mintlify. However, `generate-docs.sh` only validates structure — it does NOT auto-update code examples, so those must be updated manually.
@@ -174,7 +203,7 @@ CI is configured in `.github/workflows/testing.yml` and runs on every push:
 
 | Job | Description | Depends On |
 |-----|-------------|------------|
-| `lint_build` | Install, build, lint | - |
+| `lint_build` | Install, build, typecheck tests, lint | - |
 | `cli_sync_check` | Build + test CLI against local SDK | lint_build |
 | `openclaw_check` | Build + test OpenClaw against local SDK | lint_build |
 | `unit_integration` | Unit + integration tests | lint_build |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ CI is configured in `.github/workflows/testing.yml` and runs on every push:
 
 | Job | Description | Depends On |
 |-----|-------------|------------|
-| `lint_build` | Install, build, typecheck tests, lint | - |
+| `lint_build` | Install, build, lint, typecheck tests | Typecheck tests runs LAST on purpose — see the comment in `testing.yml`: it is the newest and noisiest gate, and running it before Lint would fail-fast past lint errors that used to surface in the same run. Do not reorder to match a doc; fix the doc. |
 | `cli_sync_check` | Build + test CLI against local SDK | lint_build |
 | `openclaw_check` | Build + test OpenClaw against local SDK | lint_build |
 | `unit_integration` | Unit + integration tests | lint_build |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ development workflow (build, lint, tests, releases) and
 
 ```bash
 pnpm install
-pnpm build && pnpm lint && pnpm test:unit   # the pre-PR check
+pnpm build && pnpm lint && pnpm typecheck:tests && pnpm test:unit   # the pre-PR check
 ```
 
 ## Documentation

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "scripts": {
     "clean": "rm -rf ./dist/ ./doc/ ./.nyc_output",
     "build": "tsc",
+    "typecheck:tests": "tsc --noEmit -p tests/tsconfig.json",
     "build:all": "pnpm build && pnpm cli:build",
     "lint": "eslint ./src",
     "test": "jest --verbose --config ./tests/jest.config.json",

--- a/tests/integration/a2a/complete-message-send-flow.test.ts
+++ b/tests/integration/a2a/complete-message-send-flow.test.ts
@@ -7,6 +7,10 @@ import request from 'supertest'
 import { PaymentsA2AServer } from '../../../src/a2a/server.js'
 import type { AgentCard, ExecutionEventBus, PaymentsAgentExecutor } from '../../../src/a2a/types.js'
 import type { Payments } from '../../../src/payments.js'
+import type {
+  SettlePermissionsResult,
+  VerifyPermissionsResult,
+} from '../../../src/x402/facilitator-api.js'
 
 jest.mock('../../../src/utils.js', () => ({
   decodeAccessToken: jest.fn(() => ({
@@ -36,7 +40,7 @@ class MockFacilitatorAPI {
   shouldFailValidation = false
   shouldFailSettle = false
 
-  async verifyPermissions(_: any): Promise<{ isValid: boolean; invalidReason?: string }> {
+  async verifyPermissions(_: any): Promise<VerifyPermissionsResult> {
     this.validationCallCount++
     if (this.shouldFailValidation) {
       return { isValid: false, invalidReason: 'Insufficient credits' }
@@ -44,7 +48,7 @@ class MockFacilitatorAPI {
     return { isValid: true }
   }
 
-  async settlePermissions(_: any): Promise<{ success: boolean; transaction: string; network: string; creditsRedeemed: string }> {
+  async settlePermissions(_: any): Promise<SettlePermissionsResult> {
     this.settleCallCount++
     this.lastSettleAmount = _.maxAmount
     if (this.shouldFailSettle) {

--- a/tests/integration/a2a/payments-server-additional.test.ts
+++ b/tests/integration/a2a/payments-server-additional.test.ts
@@ -6,6 +6,10 @@ import request from 'supertest'
 import { PaymentsA2AServer } from '../../../src/a2a/server.js'
 import type { AgentCard } from '../../../src/a2a/types.js'
 import type { Payments } from '../../../src/payments.js'
+import type {
+  SettlePermissionsResult,
+  VerifyPermissionsResult,
+} from '../../../src/x402/facilitator-api.js'
 import type { AgentExecutor } from '../../../src/a2a/types.js'
 
 function createNoopExecutor(): AgentExecutor {
@@ -63,13 +67,13 @@ describe('PaymentsA2AServer Middleware', () => {
             isValid: true,
             agentRequestId: 'REQ',
             payer: '0x1234567890abcdef',
-          }),
+          } satisfies VerifyPermissionsResult),
         settlePermissions: jest.fn().mockResolvedValue({
           success: true,
           transaction: '0xabcdef1234567890',
           network: 'eip155:84532',
           creditsRedeemed: '1',
-        }),
+        } satisfies SettlePermissionsResult),
       },
     }
 

--- a/tests/integration/a2a/payments-server.test.ts
+++ b/tests/integration/a2a/payments-server.test.ts
@@ -6,6 +6,10 @@ import request from 'supertest'
 import { PaymentsA2AServer } from '../../../src/a2a/server.js'
 import type { AgentCard, AgentExecutor } from '../../../src/a2a/types.js'
 import type { Payments } from '../../../src/payments.js'
+import type {
+  SettlePermissionsResult,
+  VerifyPermissionsResult,
+} from '../../../src/x402/facilitator-api.js'
 import * as utils from '../../../src/utils.js'
 
 const mockDecodeToken = (_token: string) => ({
@@ -66,15 +70,13 @@ describe('PaymentsA2AServer', () => {
       facilitator: {
         verifyPermissions: jest.fn().mockResolvedValue({
           isValid: true,
-        }),
-        settlePermissions: jest
-          .fn()
-          .mockResolvedValue({
-            success: true,
-            transaction: '0x1234567890abcdef',
-            network: 'eip155:84532',
-            creditsRedeemed: '1',
-          }),
+        } satisfies VerifyPermissionsResult),
+        settlePermissions: jest.fn().mockResolvedValue({
+          success: true,
+          transaction: '0x1234567890abcdef',
+          network: 'eip155:84532',
+          creditsRedeemed: '1',
+        } satisfies SettlePermissionsResult),
       },
       agents: {
         getAgentPlans: jest.fn().mockResolvedValue({ plans: [] }),

--- a/tests/integration/a2a/x402-inband-flow.test.ts
+++ b/tests/integration/a2a/x402-inband-flow.test.ts
@@ -22,6 +22,10 @@ import * as utils from '../../../src/utils.js'
 import { encodeAccessToken } from '../../../src/utils.js'
 import type { AgentCard, ExecutionEventBus, PaymentsAgentExecutor } from '../../../src/a2a/types.js'
 import type { Payments } from '../../../src/payments.js'
+import type {
+  SettlePermissionsResult,
+  VerifyPermissionsResult,
+} from '../../../src/x402/facilitator-api.js'
 
 /**
  * A spec-shaped x402 PaymentPayload object (the decoded form of an access
@@ -55,7 +59,7 @@ class MockFacilitatorAPI {
   shouldFailVerify = false
   shouldFailSettle = false
 
-  async verifyPermissions(params: any): Promise<{ isValid: boolean; invalidReason?: string }> {
+  async verifyPermissions(params: any): Promise<VerifyPermissionsResult> {
     this.verifyCallCount++
     this.lastVerifyToken = params.x402AccessToken
     if (this.shouldFailVerify) {
@@ -64,12 +68,7 @@ class MockFacilitatorAPI {
     return { isValid: true }
   }
 
-  async settlePermissions(params: any): Promise<{
-    success: boolean
-    transaction: string
-    network: string
-    creditsRedeemed: string
-  }> {
+  async settlePermissions(params: any): Promise<SettlePermissionsResult> {
     this.settleCallCount++
     this.lastSettleToken = params.x402AccessToken
     if (this.shouldFailSettle) {

--- a/tests/integration/mcp-integration.test.ts
+++ b/tests/integration/mcp-integration.test.ts
@@ -4,6 +4,10 @@
 
 import { buildMcpIntegration } from '../../src/mcp/index.js'
 import type { Payments } from '../../src/payments.js'
+import type {
+  SettlePermissionsResult,
+  VerifyPermissionsResult,
+} from '../../src/x402/facilitator-api.js'
 import * as utils from '../../src/utils.js'
 
 // Mock decodeAccessToken to provide x402-compliant token structure
@@ -42,14 +46,14 @@ class PaymentsMinimal {
         this.subscriber = subscriber
       }
 
-      async verifyPermissions(params: any) {
+      async verifyPermissions(params: any): Promise<VerifyPermissionsResult> {
         if (!this.subscriber) {
           throw new Error('Subscriber not found')
         }
         return { isValid: true }
       }
 
-      async settlePermissions(params: any) {
+      async settlePermissions(params: any): Promise<SettlePermissionsResult> {
         return {
           success: true,
           transaction: '0x1234567890abcdef',
@@ -136,14 +140,14 @@ describe('MCP Integration', () => {
             this.outer = outer
             this.subscriber = subscriber
           }
-          async verifyPermissions(params: any) {
+          async verifyPermissions(params: any): Promise<VerifyPermissionsResult> {
             if (!this.subscriber) {
               throw new Error('Subscriber not found')
             }
             return { isValid: true }
           }
 
-          async settlePermissions(params: any) {
+          async settlePermissions(params: any): Promise<SettlePermissionsResult> {
             const planId = params.paymentRequired?.accepts?.[0]?.planId || 'plan-123'
             const maxAmount = params.maxAmount || 0n
             const hash = `${planId}-${maxAmount}`

--- a/tests/integration/mcp-integration.test.ts
+++ b/tests/integration/mcp-integration.test.ts
@@ -82,7 +82,7 @@ describe('MCP Integration', () => {
   test('should validate and burn credits with minimal mocks', async () => {
     const payments = new PaymentsMinimal() as any as Payments
     const mcp = buildMcpIntegration(payments)
-    mcp.configure({ agentId: 'did:nv:agent', serverName: 'mcp-int' })
+    mcp.configure({ planId: 'plan-123', agentId: 'did:nv:agent', serverName: 'mcp-int' })
 
     const handler = async (_args: any) => {
       return { content: [{ type: 'text', text: 'hello' }] }
@@ -103,7 +103,7 @@ describe('MCP Integration', () => {
   test('should trigger payment required when not subscriber', async () => {
     const payments = new PaymentsMinimal(false) as any as Payments
     const mcp = buildMcpIntegration(payments)
-    mcp.configure({ agentId: 'did:nv:agent', serverName: 'mcp-int' })
+    mcp.configure({ planId: 'plan-123', agentId: 'did:nv:agent', serverName: 'mcp-int' })
 
     const handler = async (_args: any) => {
       return { content: [{ type: 'text', text: 'hello' }] }
@@ -184,7 +184,7 @@ describe('MCP Integration', () => {
 
     const payments = new PaymentsWithX402(true) as any as Payments
     const mcp = buildMcpIntegration(payments)
-    mcp.configure({ agentId: 'did:nv:agent:abc123', serverName: 'weather-service' })
+    mcp.configure({ planId: 'plan-123', agentId: 'did:nv:agent:abc123', serverName: 'weather-service' })
 
     const capturedContexts: any[] = []
 

--- a/tests/integration/mcp/mcp_handler_auth_header_propagation.test.ts
+++ b/tests/integration/mcp/mcp_handler_auth_header_propagation.test.ts
@@ -7,6 +7,7 @@ import { PaywallAuthenticator } from '../../../src/mcp/core/auth.js'
 import { requestContextStorage } from '../../../src/mcp/http/mcp-handler.js'
 import type { RequestContext } from '../../../src/mcp/http/session-manager.js'
 import type { Payments } from '../../../src/payments.js'
+import type { VerifyPermissionsResult } from '../../../src/x402/facilitator-api.js'
 
 jest.mock('../../../src/utils.js', () => ({
   decodeAccessToken: jest.fn(() => ({
@@ -43,7 +44,7 @@ class PaymentsMockWithTracking {
 
   constructor() {
     this.facilitator = {
-      verifyPermissions: jest.fn(async (params: any) => {
+      verifyPermissions: jest.fn(async (params: any): Promise<VerifyPermissionsResult> => {
         this.calls.push(['verifyPermissions', params])
         return { isValid: true }
       }),

--- a/tests/integration/mcp/mcp_paywall_invalid_token_flow.test.ts
+++ b/tests/integration/mcp/mcp_paywall_invalid_token_flow.test.ts
@@ -5,6 +5,10 @@
 
 import { buildMcpIntegration } from '../../../src/mcp/index.js'
 import type { Payments } from '../../../src/payments.js'
+import type {
+  SettlePermissionsResult,
+  VerifyPermissionsResult,
+} from '../../../src/x402/facilitator-api.js'
 
 jest.mock('../../../src/utils.js', () => ({
   decodeAccessToken: jest.fn(() => ({
@@ -46,14 +50,14 @@ class PaymentsMockWithFailures {
   ) {
     this.failureMode = failureMode
     this.facilitator = {
-      verifyPermissions: jest.fn(async (params: any) => {
+      verifyPermissions: jest.fn(async (params: any): Promise<VerifyPermissionsResult> => {
         this.calls.push(['verifyPermissions', params])
         if (this.failureMode === 'invalid-token' || this.failureMode === 'not-subscriber') {
           return { isValid: false, invalidReason: 'Payment required' }
         }
         return { isValid: true }
       }),
-      settlePermissions: jest.fn(async (params: any) => {
+      settlePermissions: jest.fn(async (params: any): Promise<SettlePermissionsResult> => {
         this.calls.push(['settle', params])
         if (this.failureMode === 'insufficient-balance') {
           throw new Error('Insufficient balance for redemption')

--- a/tests/integration/mcp/mcp_paywall_invalid_token_flow.test.ts
+++ b/tests/integration/mcp/mcp_paywall_invalid_token_flow.test.ts
@@ -95,7 +95,7 @@ describe('MCP Paywall - Invalid Token Flow', () => {
     const mockInstance = new PaymentsMockWithFailures('invalid-token')
     const pm = mockInstance as any as Payments
     const mcp = buildMcpIntegration(pm)
-    mcp.configure({ agentId: 'did:nv:test', serverName: 'test-server' })
+    mcp.configure({ planId: 'plan-basic', agentId: 'did:nv:test', serverName: 'test-server' })
 
     const handler = async (args: any) => {
       return { content: [{ type: 'text', text: `Weather in ${args.city}` }] }
@@ -131,7 +131,7 @@ describe('MCP Paywall - Invalid Token Flow', () => {
     const mockInstance = new PaymentsMockWithFailures('invalid-token')
     const pm = mockInstance as any as Payments
     const mcp = buildMcpIntegration(pm)
-    mcp.configure({ agentId: 'did:nv:test', serverName: 'test-server' })
+    mcp.configure({ planId: 'plan-basic', agentId: 'did:nv:test', serverName: 'test-server' })
 
     const handler = async (args: any) => {
       return { content: [{ type: 'text', text: 'result' }] }
@@ -159,7 +159,7 @@ describe('MCP Paywall - Invalid Token Flow', () => {
     const mockInstance = new PaymentsMockWithFailures('not-subscriber')
     const pm = mockInstance as any as Payments
     const mcp = buildMcpIntegration(pm)
-    mcp.configure({ agentId: 'did:nv:test', serverName: 'test-server' })
+    mcp.configure({ planId: 'plan-basic', agentId: 'did:nv:test', serverName: 'test-server' })
 
     const handler = async (args: any) => {
       return { content: [{ type: 'text', text: 'result' }] }
@@ -190,7 +190,7 @@ describe('MCP Paywall - Invalid Token Flow', () => {
     const mockInstance = new PaymentsMockWithFailures('none')
     const pm = mockInstance as any as Payments
     const mcp = buildMcpIntegration(pm)
-    mcp.configure({ agentId: 'did:nv:test', serverName: 'test-server' })
+    mcp.configure({ planId: 'plan-basic', agentId: 'did:nv:test', serverName: 'test-server' })
 
     const handler = async (args: any) => {
       return {
@@ -225,7 +225,7 @@ describe('MCP Paywall - Invalid Token Flow', () => {
     const mockInstance = new PaymentsMockWithFailures('none')
     const pm = mockInstance as any as Payments
     const mcp = buildMcpIntegration(pm)
-    mcp.configure({ agentId: 'did:nv:test', serverName: 'multi-tool-server' })
+    mcp.configure({ planId: 'plan-basic', agentId: 'did:nv:test', serverName: 'multi-tool-server' })
 
     const simpleHandler = async () => ({ content: [{ type: 'text', text: 'simple' }] })
     const complexHandler = async () => ({ content: [{ type: 'text', text: 'complex' }] })
@@ -269,7 +269,7 @@ describe('MCP Paywall - Invalid Token Flow', () => {
     const mockInstance = new PaymentsMockWithFailures('insufficient-balance')
     const pm = mockInstance as any as Payments
     const mcp = buildMcpIntegration(pm)
-    mcp.configure({ agentId: 'did:nv:test', serverName: 'test-server' })
+    mcp.configure({ planId: 'plan-basic', agentId: 'did:nv:test', serverName: 'test-server' })
 
     const handler = async (args: any) => {
       return { content: [{ type: 'text', text: 'result' }] }
@@ -296,7 +296,7 @@ describe('MCP Paywall - Invalid Token Flow', () => {
     const mockInstance = new PaymentsMockWithFailures('insufficient-balance')
     const pm = mockInstance as any as Payments
     const mcp = buildMcpIntegration(pm)
-    mcp.configure({ agentId: 'did:nv:test', serverName: 'test-server' })
+    mcp.configure({ planId: 'plan-basic', agentId: 'did:nv:test', serverName: 'test-server' })
 
     const handler = async (args: any) => {
       return { content: [{ type: 'text', text: 'result' }] }
@@ -329,7 +329,7 @@ describe('MCP Paywall - Invalid Token Flow', () => {
     const mockInstance = new PaymentsMockWithFailures('invalid-token')
     const pm = mockInstance as any as Payments
     const mcp = buildMcpIntegration(pm)
-    mcp.configure({ agentId: 'did:nv:test', serverName: 'test-server' })
+    mcp.configure({ planId: 'plan-basic', agentId: 'did:nv:test', serverName: 'test-server' })
 
     const handler = async () => ({ content: [{ type: 'text', text: 'ok' }] })
     const wrapped = mcp.withPaywall(handler, {

--- a/tests/unit/a2a/payments-request-handler-stream.test.ts
+++ b/tests/unit/a2a/payments-request-handler-stream.test.ts
@@ -6,13 +6,38 @@ import { PaymentsRequestHandler } from '../../../src/a2a/paymentsRequestHandler.
 import type { Payments } from '../../../src/payments.js'
 import type { HttpRequestContext } from '../../../src/a2a/types.js'
 import type { AgentCard, Task } from '@a2a-js/sdk'
+import type { AgentExecutor } from '@a2a-js/sdk/server'
+import type { StartAgentRequest } from '../../../src/common/types.js'
 
 jest.mock('@a2a-js/sdk/server')
 
-class DummyExecutor {
+class DummyExecutor implements AgentExecutor {
   async execute(...args: any[]): Promise<any> {
     // Dummy implementation
   }
+
+  async cancelTask(...args: any[]): Promise<any> {
+    // Dummy implementation — never exercised, but part of the interface.
+  }
+}
+
+const VALIDATION: StartAgentRequest = {
+  agentRequestId: 'agentReq',
+  agentName: 'test-agent',
+  agentId: 'test-agent',
+  balance: {
+    planId: 'plan-1',
+    planName: 'Test Plan',
+    planType: 'credits',
+    holderAddress: '0x1111111111111111111111111111111111111111',
+    balance: 100n,
+    creditsContract: '0x2222222222222222222222222222222222222222',
+    isSubscriber: true,
+    pricePerCredit: 1,
+  },
+  urlMatching: 'https://x',
+  verbMatching: 'POST',
+  batch: false,
 }
 
 describe('PaymentsRequestHandler streaming', () => {
@@ -45,7 +70,7 @@ describe('PaymentsRequestHandler streaming', () => {
           },
         ],
       },
-    } as AgentCard
+    } as unknown as AgentCard
   })
 
   test('should burn credits when streaming final event with creditsUsed', async () => {
@@ -102,7 +127,7 @@ describe('PaymentsRequestHandler streaming', () => {
       bearerToken: 'TOK',
       urlRequested: 'https://x',
       httpMethodRequested: 'POST',
-      validation: { agentRequestId: 'agentReq' },
+      validation: VALIDATION,
     }
 
     handler.setHttpRequestContextForTask('tid', ctx)

--- a/tests/unit/a2a/payments-request-handler-stream.test.ts
+++ b/tests/unit/a2a/payments-request-handler-stream.test.ts
@@ -30,7 +30,7 @@ const VALIDATION: StartAgentRequest = {
     planName: 'Test Plan',
     planType: 'credits',
     holderAddress: '0x1111111111111111111111111111111111111111',
-    balance: 100n,
+    balance: '100',
     creditsContract: '0x2222222222222222222222222222222222222222',
     isSubscriber: true,
     pricePerCredit: 1,

--- a/tests/unit/a2a/payments-request-handler-stream.test.ts
+++ b/tests/unit/a2a/payments-request-handler-stream.test.ts
@@ -59,7 +59,21 @@ describe('PaymentsRequestHandler streaming', () => {
       get: jest.fn().mockResolvedValue(undefined),
     }
 
+    // Complete rather than `as unknown as AgentCard`: that double assertion is
+    // the one escape the typecheck gate cannot see through, so a card that
+    // drifted from the SDK's would stay invisible — in the PR whose point is
+    // making such drift visible. Only `capabilities` carries anything this spec
+    // reads; the other eight are AgentCard's required fields, present so the
+    // compiler can still check the shape.
     mockAgentCard = {
+      protocolVersion: '0.3.0',
+      name: 'test-agent',
+      description: 'Streaming credit-burn fixture',
+      url: 'https://example.test/a2a',
+      version: '1.0.0',
+      defaultInputModes: ['text/plain'],
+      defaultOutputModes: ['text/plain'],
+      skills: [],
       capabilities: {
         extensions: [
           {
@@ -70,7 +84,7 @@ describe('PaymentsRequestHandler streaming', () => {
           },
         ],
       },
-    } as unknown as AgentCard
+    }
   })
 
   test('should burn credits when streaming final event with creditsUsed', async () => {

--- a/tests/unit/mcp.test.ts
+++ b/tests/unit/mcp.test.ts
@@ -110,7 +110,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock()
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'test-mcp' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'test-mcp' })
 
       const base = async (_args: any, _extra?: any) => {
         return { content: [{ type: 'text', text: 'ok' }] }
@@ -142,7 +142,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock()
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'test-mcp' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'test-mcp' })
 
       const base = async (_args: any, _extra?: any) => {
         return { content: [{ type: 'text', text: 'ok' }] }
@@ -183,7 +183,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock(settleResult)
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'test-mcp' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'test-mcp' })
 
       const base = async (_args: any, _extra?: any) => {
         return { content: [{ type: 'text', text: 'ok' }] }
@@ -226,7 +226,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock(settleResult)
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'test-mcp' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'test-mcp' })
 
       const base = async (_args: any, _extra?: any) => ({
         content: [{ type: 'text', text: 'ok' }],
@@ -261,7 +261,7 @@ describe('MCP Integration', () => {
       })
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'test-mcp' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'test-mcp' })
 
       const base = async (_args: any, _extra?: any) => ({
         content: [{ type: 'text', text: 'ok' }],
@@ -295,7 +295,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock(settleResult)
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'test-mcp' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'test-mcp' })
 
       const base = async (_args: any, _extra?: any) => {
         return { content: [{ type: 'text', text: 'ok' }] }
@@ -330,7 +330,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock(settleResult)
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'test-mcp' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'test-mcp' })
 
       const base = async (_args: any, _extra?: any) => {
         return { content: [{ type: 'text', text: 'ok' }] }
@@ -362,7 +362,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock(redeemResult)
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'test-mcp' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'test-mcp' })
 
       const base = async (_args: any, _extra?: any) => {
         return { content: [{ type: 'text', text: 'ok' }] }
@@ -409,7 +409,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock()
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'srv' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'srv' })
 
       const base = async (_args: any, _extra?: any) => {
         return { content: [{ type: 'text', text: 'ok' }] }
@@ -433,7 +433,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock()
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:x', serverName: 'srv' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:x', serverName: 'srv' })
 
       const base = async (_args: any, _extra?: any) => {
         return { res: true }
@@ -452,7 +452,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock()
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:x', serverName: 'srv' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:x', serverName: 'srv' })
 
       const base = async (_args: any, _extra?: any) => {
         return { res: true }
@@ -474,7 +474,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock()
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'srv' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'srv' })
 
       const captured: any = {}
 
@@ -533,7 +533,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock()
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'mcp' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'mcp' })
 
       const base = async (_args: any, _extra?: any) => {
         return { ok: true }
@@ -562,7 +562,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock()
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'mcp' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'mcp' })
 
       async function* makeIterable(chunks: string[]) {
         for (const c of chunks) {
@@ -614,7 +614,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock(settleResult)
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'mcp' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'mcp' })
 
       async function* makeIterable(chunks: string[]) {
         for (const c of chunks) {
@@ -667,7 +667,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock(settleResult)
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'mcp' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'mcp' })
 
       async function* makeIterable(chunks: string[]) {
         for (const c of chunks) {
@@ -701,7 +701,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock()
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'mcp' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'mcp' })
 
       async function* makeIterable(chunks: string[]) {
         for (const c of chunks) {
@@ -758,7 +758,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock()
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'test-mcp' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'test-mcp' })
 
       const oldHandler = async (args: any, extra?: any) => {
         return {
@@ -792,7 +792,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock()
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'test-mcp' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'test-mcp' })
 
       let capturedContext: any = null
 
@@ -821,7 +821,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock()
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'test-mcp' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'test-mcp' })
 
       let capturedContext: any = null
 
@@ -864,7 +864,7 @@ describe('MCP Integration', () => {
       const mockInstance = new PaymentsMock()
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
-      mcp.configure({ agentId: 'did:nv:agent', serverName: 'test-mcp' })
+      mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'test-mcp' })
 
       const businessLogicHandler = async (args: any, extra?: any, context?: any) => {
         if (!context) {

--- a/tests/unit/mcp.test.ts
+++ b/tests/unit/mcp.test.ts
@@ -38,12 +38,16 @@ class PaymentsMock {
   public facilitator: any
 
   constructor(settleResult?: SettlePermissionsResult) {
-    // The real facilitator always answers with `transaction` + `network`, so the
-    // default stands in for a settle that burned nothing rather than for a
-    // response missing half its required fields.
+    // An ordinary successful crypto settle. `transaction` and `network` are
+    // required on the model, so the previous `{ success: true }` was a response
+    // the facilitator cannot produce — but an EMPTY `transaction` would not do
+    // either: the model documents it as the failure marker, so pairing it with
+    // `success: true` would teach every future fixture a contradiction.
+    // `creditsRedeemed` is deliberately absent, so tests inheriting this default
+    // still exercise the paywall's fallback to the requested credit amount.
     const settle_result: SettlePermissionsResult = settleResult || {
       success: true,
-      transaction: '',
+      transaction: '0xdefaultsettletx',
       network: 'eip155:84532',
     }
 
@@ -139,7 +143,17 @@ describe('MCP Integration', () => {
     })
 
     test('should add metadata to result after successful redemption', async () => {
-      const mockInstance = new PaymentsMock()
+      // Explicit rather than the constructor default, because this test turns on
+      // what `transaction` holds: the paywall gates `txHash` on it being truthy,
+      // so an empty one — what the backend sends when the settle had no on-chain
+      // transaction, as the "transaction is empty" test below also models — must
+      // produce no `txHash` key at all. Inheriting a default would let a change
+      // to that default silently change which invariant this proves.
+      const mockInstance = new PaymentsMock({
+        success: true,
+        transaction: '',
+        network: 'eip155:84532',
+      })
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
       mcp.configure({ planId: 'plan123', agentId: 'did:nv:agent', serverName: 'test-mcp' })
@@ -168,7 +182,7 @@ describe('MCP Integration', () => {
       // Nevermined observability is namespaced
       expect(out._meta['nevermined/credits'].success).toBe(true)
       expect(out._meta['nevermined/credits'].creditsRedeemed).toBe('3')
-      // txHash should be undefined since our mock doesn't return it
+      // No txHash key, because the settle carried no transaction to report.
       expect(out._meta['nevermined/credits'].txHash).toBeUndefined()
     })
 

--- a/tests/unit/mcp.test.ts
+++ b/tests/unit/mcp.test.ts
@@ -4,6 +4,10 @@
 
 import { buildMcpIntegration } from '../../src/mcp/index.js'
 import type { Payments } from '../../src/payments.js'
+import type {
+  SettlePermissionsResult,
+  VerifyPermissionsResult,
+} from '../../src/x402/facilitator-api.js'
 import * as utils from '../../src/utils.js'
 
 // Mock decodeAccessToken to provide x402-compliant token structure
@@ -33,19 +37,26 @@ class PaymentsMock {
   public agents: any
   public facilitator: any
 
-  constructor(settleResult?: any) {
-    const settle_result = settleResult || { success: true }
+  constructor(settleResult?: SettlePermissionsResult) {
+    // The real facilitator always answers with `transaction` + `network`, so the
+    // default stands in for a settle that burned nothing rather than for a
+    // response missing half its required fields.
+    const settle_result: SettlePermissionsResult = settleResult || {
+      success: true,
+      transaction: '',
+      network: 'eip155:84532',
+    }
 
     class Facilitator {
       private parent: PaymentsMock
-      private settle_result: any
+      private settle_result: SettlePermissionsResult
 
-      constructor(parent: PaymentsMock, settle_result: any) {
+      constructor(parent: PaymentsMock, settle_result: SettlePermissionsResult) {
         this.parent = parent
         this.settle_result = settle_result
       }
 
-      async verifyPermissions(input: any) {
+      async verifyPermissions(input: any): Promise<VerifyPermissionsResult> {
         const planId =
           typeof input === 'object' ? input.paymentRequired?.accepts?.[0]?.planId : input
         const maxAmount = typeof input === 'object' ? input.maxAmount : arguments[1]
@@ -61,7 +72,7 @@ class PaymentsMock {
         return { isValid: true }
       }
 
-      async settlePermissions(input: any) {
+      async settlePermissions(input: any): Promise<SettlePermissionsResult> {
         const planId =
           typeof input === 'object' ? input.paymentRequired?.accepts?.[0]?.planId : input
         const maxAmount = typeof input === 'object' ? input.maxAmount : arguments[1]
@@ -168,7 +179,7 @@ describe('MCP Integration', () => {
         transaction: '0x1234567890abcdef',
         network: 'eip155:84532',
         creditsRedeemed: '5',
-      }
+      } satisfies SettlePermissionsResult
       const mockInstance = new PaymentsMock(settleResult)
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
@@ -211,7 +222,7 @@ describe('MCP Integration', () => {
         creditsRedeemed: '0',
         remainingBalance: '0',
         orderTx: 'pi_3U6tgrBYvSRKcV421ehH4bnX',
-      }
+      } satisfies SettlePermissionsResult
       const mockInstance = new PaymentsMock(settleResult)
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
@@ -280,7 +291,7 @@ describe('MCP Integration', () => {
         transaction: '',
         network: 'eip155:84532',
         creditsRedeemed: '5',
-      }
+      } satisfies SettlePermissionsResult
       const mockInstance = new PaymentsMock(settleResult)
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
@@ -315,7 +326,7 @@ describe('MCP Integration', () => {
         network: 'eip155:84532',
         creditsRedeemed: '10', // Backend may return different value than requested
         remainingBalance: '90',
-      }
+      } satisfies SettlePermissionsResult
       const mockInstance = new PaymentsMock(settleResult)
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
@@ -342,7 +353,12 @@ describe('MCP Integration', () => {
       // Post-execution settlement failure: under the x402 v2 MCP transport the
       // tool content is suppressed and an in-band payment error is returned
       // (default onRedeemError "ignore" no longer delivers paid content).
-      const redeemResult = { success: false, errorReason: 'Insufficient credits' }
+      const redeemResult = {
+        success: false,
+        errorReason: 'Insufficient credits',
+        transaction: '',
+        network: 'eip155:84532',
+      } satisfies SettlePermissionsResult
       const mockInstance = new PaymentsMock(redeemResult)
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
@@ -594,7 +610,7 @@ describe('MCP Integration', () => {
         transaction: '0xstream123',
         network: 'eip155:84532',
         creditsRedeemed: '5',
-      }
+      } satisfies SettlePermissionsResult
       const mockInstance = new PaymentsMock(settleResult)
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
@@ -647,7 +663,7 @@ describe('MCP Integration', () => {
         creditsRedeemed: '0',
         remainingBalance: '0',
         orderTx: 'pi_3StreamPayg',
-      }
+      } satisfies SettlePermissionsResult
       const mockInstance = new PaymentsMock(settleResult)
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)

--- a/tests/unit/mcp/auth_extract_header.test.ts
+++ b/tests/unit/mcp/auth_extract_header.test.ts
@@ -4,6 +4,7 @@
 
 import { PaywallAuthenticator } from '../../../src/mcp/core/auth.js'
 import type { Payments } from '../../../src/payments.js'
+import type { VerifyPermissionsResult } from '../../../src/x402/facilitator-api.js'
 
 jest.mock('../../../src/utils.js', () => ({
   decodeAccessToken: jest.fn(() => ({
@@ -42,7 +43,7 @@ class PaymentsMock {
     const shouldReject = options?.shouldReject ?? false
 
     this.facilitator = {
-      verifyPermissions: jest.fn(async (params: any) => {
+      verifyPermissions: jest.fn(async (params: any): Promise<VerifyPermissionsResult> => {
         this.calls.push(['verifyPermissions', params])
         if (shouldReject) {
           return { isValid: false, invalidReason: 'Access denied' }

--- a/tests/unit/mcp/auth_http_url_fallback.test.ts
+++ b/tests/unit/mcp/auth_http_url_fallback.test.ts
@@ -6,6 +6,7 @@ import { PaywallAuthenticator } from '../../../src/mcp/core/auth.js'
 import { requestContextStorage } from '../../../src/mcp/http/mcp-handler.js'
 import type { RequestContext } from '../../../src/mcp/http/session-manager.js'
 import type { Payments } from '../../../src/payments.js'
+import type { VerifyPermissionsResult } from '../../../src/x402/facilitator-api.js'
 
 // Mock decodeAccessToken to provide x402-compliant token structure
 jest.mock('../../../src/utils.js', () => ({
@@ -41,7 +42,7 @@ class PaymentsMock {
     getAgentPlans: jest.Mock
   }
 
-  constructor(verifySequence: Array<{ isValid: boolean }> = [{ isValid: true }]) {
+  constructor(verifySequence: VerifyPermissionsResult[] = [{ isValid: true }]) {
     this.facilitator = {
       verifyPermissions: jest.fn(),
     }

--- a/tests/unit/mcp/x402_inband.test.ts
+++ b/tests/unit/mcp/x402_inband.test.ts
@@ -16,6 +16,7 @@
 import { PaywallDecorator } from '../../../src/mcp/core/paywall.js'
 import { PaywallAuthenticator } from '../../../src/mcp/core/auth.js'
 import { buildPaymentRequiredForPlans } from '../../../src/x402/facilitator-api.js'
+import type { SettlePermissionsResult } from '../../../src/x402/facilitator-api.js'
 import { PaymentRequiredError, SettlementFailedError } from '../../../src/mcp/utils/errors.js'
 import {
   NEVERMINED_CREDITS_META_KEY,
@@ -50,7 +51,7 @@ const SAMPLE_PR = {
 
 /** Build a PaywallDecorator wired with mocks for a single call. */
 function makeDecorator(opts: {
-  settle?: any
+  settle?: SettlePermissionsResult
   authenticate?: jest.Mock
   credits?: bigint
   agentId?: string
@@ -59,7 +60,8 @@ function makeDecorator(opts: {
     getEnvironmentName: () => 'staging_sandbox',
     facilitator: {
       settlePermissions: jest.fn(
-        async () => opts.settle ?? { success: true, transaction: '', network: '' },
+        async (): Promise<SettlePermissionsResult> =>
+          opts.settle ?? { success: true, transaction: '', network: '' },
       ),
     },
     agents: { getAgentPlans: jest.fn(async () => ({ plans: [] })) },
@@ -182,7 +184,7 @@ describe('x402 in-band: paywall wrapper', () => {
       network: 'eip155:84532',
       payer: '0x123',
       creditsRedeemed: '5',
-    }
+    } satisfies SettlePermissionsResult
     const { decorator } = makeDecorator({ settle })
     const handler = async () => ({ content: [{ type: 'text', text: 'ok' }] })
     const wrapped = decorator.protect(handler, { kind: 'tool', name: 'premium' })
@@ -204,7 +206,7 @@ describe('x402 in-band: paywall wrapper', () => {
       network: 'eip155:84532',
       payer: '0x123',
       creditsRedeemed: '5',
-    }
+    } satisfies SettlePermissionsResult
     // Configure with a planId but NO agentId — must not throw the
     // "missing agentId" misconfiguration; the plan-centric path settles fine.
     const { decorator } = makeDecorator({ settle, agentId: undefined })
@@ -348,7 +350,12 @@ describe('x402 in-band: paywall wrapper', () => {
     payments.facilitator.settlePermissions = jest.fn(async () => {
       calls += 1
       if (calls === 1) throw new Error('primary settle failed')
-      return { success: true, transaction: '0xok', network: 'eip155:84532', creditsRedeemed: '5' }
+      return {
+        success: true,
+        transaction: '0xok',
+        network: 'eip155:84532',
+        creditsRedeemed: '5',
+      } satisfies SettlePermissionsResult
     })
     const handler = async () => ({ content: [{ type: 'text', text: 'ok' }] })
     const wrapped = decorator.protect(handler, { kind: 'tool', name: 'premium' })
@@ -465,12 +472,14 @@ describe('x402 in-band: real MCP-SDK dispatch', () => {
     const payments: any = {
       getEnvironmentName: () => 'staging_sandbox',
       facilitator: {
-        settlePermissions: jest.fn(async () => ({
-          success: true,
-          transaction: '0xok',
-          network: 'eip155:84532',
-          creditsRedeemed: '5',
-        })),
+        settlePermissions: jest.fn(
+          async (): Promise<SettlePermissionsResult> => ({
+            success: true,
+            transaction: '0xok',
+            network: 'eip155:84532',
+            creditsRedeemed: '5',
+          }),
+        ),
       },
       agents: { getAgentPlans: jest.fn(async () => ({ plans: [] })) },
     }

--- a/tests/unit/mpp/middleware-body-digest.test.ts
+++ b/tests/unit/mpp/middleware-body-digest.test.ts
@@ -14,6 +14,10 @@ import express from 'express'
 import http from 'http'
 import { createHash } from 'crypto'
 import { paymentMiddleware, captureRawBody } from '../../../src/x402/express/index.js'
+import type {
+  VerifyPermissionsResult,
+} from '../../../src/x402/facilitator-api.js'
+import type { MppSettleResult } from '../../../src/mpp/mpp-api.js'
 import { mppCredentialFixture } from './credential-fixture.js'
 
 // A credential is single-use: the middleware refuses one that has already
@@ -35,13 +39,13 @@ function buildMockPayments(overrides: Record<string, unknown> = {}) {
   return {
     mpp: {
       issueChallenge: jest.fn().mockResolvedValue({ challenge: 'Payment id="c1"', id: 'c1' }),
-      verifyCredential: jest.fn().mockResolvedValue({ isValid: true }),
+      verifyCredential: jest.fn().mockResolvedValue({ isValid: true } satisfies VerifyPermissionsResult),
       settleCredential: jest.fn().mockResolvedValue({
         success: true,
         transaction: '0x',
         network: 'eip155:84532',
         paymentReceipt: 'receipt-b64',
-      }),
+      } satisfies MppSettleResult),
       ...(overrides.mpp as object),
     },
     facilitator: { verifyPermissions: jest.fn(), settlePermissions: jest.fn() },

--- a/tests/unit/mpp/middleware-challenge-error.test.ts
+++ b/tests/unit/mpp/middleware-challenge-error.test.ts
@@ -9,6 +9,10 @@
 import express from 'express'
 import http from 'http'
 import { paymentMiddleware } from '../../../src/x402/express/index.js'
+import type {
+  VerifyPermissionsResult,
+} from '../../../src/x402/facilitator-api.js'
+import type { MppSettleResult } from '../../../src/mpp/mpp-api.js'
 import { mppCredentialFixture } from './credential-fixture.js'
 import { MppNotConfiguredError } from '../../../src/mpp/errors.js'
 
@@ -16,13 +20,13 @@ function buildMockPayments(overrides: Record<string, unknown> = {}) {
   return {
     mpp: {
       issueChallenge: jest.fn().mockRejectedValue(new MppNotConfiguredError()),
-      verifyCredential: jest.fn().mockResolvedValue({ isValid: true }),
+      verifyCredential: jest.fn().mockResolvedValue({ isValid: true } satisfies VerifyPermissionsResult),
       settleCredential: jest.fn().mockResolvedValue({
         success: true,
         transaction: '0x',
         network: 'eip155:84532',
         paymentReceipt: 'receipt-b64',
-      }),
+      } satisfies MppSettleResult),
       ...(overrides.mpp as object),
     },
     facilitator: {

--- a/tests/unit/mpp/middleware-challenge.test.ts
+++ b/tests/unit/mpp/middleware-challenge.test.ts
@@ -5,23 +5,34 @@
 import express from 'express'
 import http from 'http'
 import { paymentMiddleware } from '../../../src/x402/express/index.js'
+import type {
+  SettlePermissionsResult,
+  VerifyPermissionsResult,
+} from '../../../src/x402/facilitator-api.js'
+import type { MppSettleResult } from '../../../src/mpp/mpp-api.js'
 
 function buildMockPayments(overrides: Record<string, unknown> = {}) {
   return {
     mpp: {
       issueChallenge: jest.fn().mockResolvedValue({ challenge: 'Payment id="c1"', id: 'c1' }),
-      verifyCredential: jest.fn().mockResolvedValue({ isValid: true }),
+      verifyCredential: jest.fn().mockResolvedValue({ isValid: true } satisfies VerifyPermissionsResult),
       settleCredential: jest.fn().mockResolvedValue({
         success: true,
         transaction: '0x',
         network: 'eip155:84532',
         paymentReceipt: 'receipt-b64',
-      }),
+      } satisfies MppSettleResult),
       ...(overrides.mpp as object),
     },
     facilitator: {
-      verifyPermissions: jest.fn().mockResolvedValue({ isValid: true }),
-      settlePermissions: jest.fn().mockResolvedValue({ success: true }),
+      verifyPermissions: jest
+        .fn()
+        .mockResolvedValue({ isValid: true } satisfies VerifyPermissionsResult),
+      settlePermissions: jest.fn().mockResolvedValue({
+        success: true,
+        transaction: '0x',
+        network: 'eip155:84532',
+      } satisfies SettlePermissionsResult),
     },
     getEnvironmentName: () => 'sandbox',
     plans: { getPlan: jest.fn().mockResolvedValue({ registry: { price: { isCrypto: true } } }) },

--- a/tests/unit/mpp/middleware-concurrent-credential.test.ts
+++ b/tests/unit/mpp/middleware-concurrent-credential.test.ts
@@ -17,6 +17,10 @@ import express from 'express'
 import http from 'http'
 import net from 'net'
 import { paymentMiddleware } from '../../../src/x402/express/index.js'
+import type {
+  VerifyPermissionsResult,
+} from '../../../src/x402/facilitator-api.js'
+import type { MppSettleResult } from '../../../src/mpp/mpp-api.js'
 import { mppCredentialFixture } from './credential-fixture.js'
 
 // Per-case credential: single-use is enforced process-wide, so a constant
@@ -36,14 +40,14 @@ function buildMockPayments(mpp: Record<string, unknown> = {}) {
   return {
     mpp: {
       issueChallenge: jest.fn().mockResolvedValue({ challenge: 'Payment id="c1"', id: 'c1' }),
-      verifyCredential: jest.fn().mockResolvedValue({ isValid: true }),
+      verifyCredential: jest.fn().mockResolvedValue({ isValid: true } satisfies VerifyPermissionsResult),
       settleCredential: jest.fn().mockResolvedValue({
         success: true,
         transaction: '0x',
         network: 'eip155:84532',
         creditsRedeemed: '2',
         paymentReceipt: 'receipt-b64',
-      }),
+      } satisfies MppSettleResult),
       ...mpp,
     },
     facilitator: { verifyPermissions: jest.fn(), settlePermissions: jest.fn() },

--- a/tests/unit/mpp/middleware-hooks-parity.test.ts
+++ b/tests/unit/mpp/middleware-hooks-parity.test.ts
@@ -8,6 +8,11 @@
 import express from 'express'
 import http from 'http'
 import { paymentMiddleware } from '../../../src/x402/express/index.js'
+import type {
+  VerifyPermissionsResult,
+} from '../../../src/x402/facilitator-api.js'
+import type { MppSettleResult } from '../../../src/mpp/mpp-api.js'
+import type { StartAgentRequest } from '../../../src/common/types.js'
 import { mppCredentialFixture } from './credential-fixture.js'
 import { MppCredentialRejectedError } from '../../../src/mpp/errors.js'
 
@@ -24,6 +29,31 @@ beforeEach(() => {
   CREDENTIAL = mppCredentialFixture(`hooks-${credentialSeq}`)
 })
 
+/**
+ * The `agentRequest` the verify double hands back. Complete rather than a
+ * two-key stand-in: the middleware relays it verbatim, so the assertion below
+ * compares against this same object — a partial one only ever proved that two
+ * copies of the same shorthand matched.
+ */
+const AGENT_REQUEST: StartAgentRequest = {
+  agentRequestId: 'req-1',
+  agentName: 'agent-1',
+  agentId: 'agent-1',
+  balance: {
+    planId: '123',
+    planName: 'Test Plan',
+    planType: 'credits',
+    holderAddress: '0x1111111111111111111111111111111111111111',
+    balance: 100n,
+    creditsContract: '0x2222222222222222222222222222222222222222',
+    isSubscriber: true,
+    pricePerCredit: 1,
+  },
+  urlMatching: 'POST /ask',
+  verbMatching: 'POST',
+  batch: false,
+}
+
 function buildMockPayments(mpp: Record<string, unknown> = {}) {
   return {
     mpp: {
@@ -31,21 +61,31 @@ function buildMockPayments(mpp: Record<string, unknown> = {}) {
       verifyCredential: jest.fn().mockResolvedValue({
         isValid: true,
         agentRequestId: 'req-1',
-        agentRequest: { agentRequestId: 'req-1', agentId: 'agent-1' },
-      }),
+        agentRequest: AGENT_REQUEST,
+      } satisfies VerifyPermissionsResult),
       settleCredential: jest.fn().mockResolvedValue({
         success: true,
         transaction: '0x',
         network: 'eip155:84532',
         creditsRedeemed: '2',
         paymentReceipt: 'receipt-b64',
-      }),
+      } satisfies MppSettleResult),
       ...mpp,
     },
     facilitator: { verifyPermissions: jest.fn(), settlePermissions: jest.fn() },
     getEnvironmentName: () => 'sandbox',
     plans: { getPlan: jest.fn().mockResolvedValue({ registry: { price: { isCrypto: true } } }) },
   } as any
+}
+
+/**
+ * `StartAgentRequest.balance.balance` is a `bigint`, which `JSON.stringify`
+ * refuses outright — so anything relaying a payment context over the wire has
+ * to narrow it first. Mirrored on the assertion side so the two comparands are
+ * the same object put through the same transform.
+ */
+function jsonSafe<T>(value: T): unknown {
+  return JSON.parse(JSON.stringify(value, (_k, v) => (typeof v === 'bigint' ? v.toString() : v)))
 }
 
 async function startServer(
@@ -64,7 +104,8 @@ async function startServer(
   )
   app.post(
     '/ask',
-    handler ?? ((req: any, res: any) => res.json({ paymentContext: req.paymentContext ?? null })),
+    handler ??
+      ((req: any, res: any) => res.json(jsonSafe({ paymentContext: req.paymentContext ?? null }))),
   )
   const server = http.createServer(app)
   await new Promise<void>((r) => server.listen(0, r))
@@ -384,7 +425,7 @@ describe('MPP PaymentContext observability fields', () => {
       expect(response.status).toBe(200)
       const { paymentContext } = await response.json()
       expect(paymentContext.agentRequestId).toBe('req-1')
-      expect(paymentContext.agentRequest).toEqual({ agentRequestId: 'req-1', agentId: 'agent-1' })
+      expect(paymentContext.agentRequest).toEqual(jsonSafe(AGENT_REQUEST))
     } finally {
       await close()
     }

--- a/tests/unit/mpp/middleware-hooks-parity.test.ts
+++ b/tests/unit/mpp/middleware-hooks-parity.test.ts
@@ -44,7 +44,7 @@ const AGENT_REQUEST: StartAgentRequest = {
     planName: 'Test Plan',
     planType: 'credits',
     holderAddress: '0x1111111111111111111111111111111111111111',
-    balance: 100n,
+    balance: '100',
     creditsContract: '0x2222222222222222222222222222222222222222',
     isSubscriber: true,
     pricePerCredit: 1,
@@ -79,13 +79,21 @@ function buildMockPayments(mpp: Record<string, unknown> = {}) {
 }
 
 /**
- * `StartAgentRequest.balance.balance` is a `bigint`, which `JSON.stringify`
- * refuses outright — so anything relaying a payment context over the wire has
- * to narrow it first. Mirrored on the assertion side so the two comparands are
- * the same object put through the same transform.
+ * Puts a fixture through the same JSON round-trip the wire does, so the two
+ * comparands are the same object transformed the same way — the handler relays
+ * the payment context via `res.json()`, and the assertion compares against what
+ * came back over HTTP.
+ *
+ * It used to carry a `bigint -> string` replacer as well, because
+ * `StartAgentRequest.balance.balance` was declared `bigint` and
+ * `JSON.stringify` refuses one outright. That declaration was a fiction — the
+ * value only ever arrives from `response.json()`, so it was always a string —
+ * and #440/#441 corrected the type. The replacer is gone with it: no bigint
+ * remains in this file, and if one is ever reintroduced, `JSON.stringify`
+ * throwing here is the right, loud answer rather than a silent coercion.
  */
 function jsonSafe<T>(value: T): unknown {
-  return JSON.parse(JSON.stringify(value, (_k, v) => (typeof v === 'bigint' ? v.toString() : v)))
+  return JSON.parse(JSON.stringify(value))
 }
 
 async function startServer(

--- a/tests/unit/mpp/middleware-redeem.test.ts
+++ b/tests/unit/mpp/middleware-redeem.test.ts
@@ -5,6 +5,10 @@
 import express from 'express'
 import http from 'http'
 import { paymentMiddleware } from '../../../src/x402/express/index.js'
+import type {
+  VerifyPermissionsResult,
+} from '../../../src/x402/facilitator-api.js'
+import type { MppSettleResult } from '../../../src/mpp/mpp-api.js'
 import { mppCredentialFixture } from './credential-fixture.js'
 import {
   MppChallengeExpiredError,
@@ -34,14 +38,14 @@ function buildMockPayments(mpp: Record<string, unknown> = {}) {
         .fn()
         .mockResolvedValueOnce({ challenge: 'Payment id="c1"', id: 'c1' })
         .mockResolvedValue({ challenge: 'Payment id="c2"', id: 'c2' }),
-      verifyCredential: jest.fn().mockResolvedValue({ isValid: true }),
+      verifyCredential: jest.fn().mockResolvedValue({ isValid: true } satisfies VerifyPermissionsResult),
       settleCredential: jest.fn().mockResolvedValue({
         success: true,
         transaction: '0x',
         network: 'eip155:84532',
         creditsRedeemed: '2',
         paymentReceipt: 'receipt-b64',
-      }),
+      } satisfies MppSettleResult),
       ...mpp,
     },
     facilitator: {
@@ -360,7 +364,7 @@ describe('MPP redemption', () => {
           network: 'eip155:84532',
           creditsRedeemed: '2', // sealed into the challenge, not routeCredits below
           paymentReceipt: 'receipt-b64',
-        }),
+        } satisfies MppSettleResult),
       })
       const onAfterSettle = jest.fn()
       const { port, close } = await startServer(
@@ -394,7 +398,7 @@ describe('MPP redemption', () => {
           transaction: '0x',
           network: 'eip155:84532',
           paymentReceipt: 'receipt-b64',
-        }),
+        } satisfies MppSettleResult),
       })
       const onAfterSettle = jest.fn()
       const { port, close } = await startServer(payments, undefined, { onAfterSettle })
@@ -456,7 +460,7 @@ describe('MPP redemption', () => {
           errorReason: 'insufficient balance at settle time',
           transaction: '',
           network: 'eip155:84532',
-        }),
+        } satisfies MppSettleResult),
       })
       const onAfterSettle = jest.fn()
       const { port, close } = await startServer(payments, undefined, { onAfterSettle })
@@ -496,7 +500,7 @@ describe('MPP redemption', () => {
           network: 'eip155:84532',
           creditsRedeemed: 'not-a-number',
           paymentReceipt: 'receipt-b64',
-        }),
+        } satisfies MppSettleResult),
       })
       const onAfterSettle = jest.fn()
       const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined)

--- a/tests/unit/mpp/middleware-x402-fallback.test.ts
+++ b/tests/unit/mpp/middleware-x402-fallback.test.ts
@@ -9,6 +9,11 @@
 import express from 'express'
 import http from 'http'
 import { paymentMiddleware, X402_HEADERS } from '../../../src/x402/express/index.js'
+import type {
+  SettlePermissionsResult,
+  VerifyPermissionsResult,
+} from '../../../src/x402/facilitator-api.js'
+import type { MppSettleResult } from '../../../src/mpp/mpp-api.js'
 import { mppCredentialFixture } from './credential-fixture.js'
 
 const X402_TOKEN = 'mock-x402-token'
@@ -17,18 +22,23 @@ function buildMockPayments(overrides: Record<string, unknown> = {}) {
   return {
     mpp: {
       issueChallenge: jest.fn().mockResolvedValue({ challenge: 'Payment id="c1"', id: 'c1' }),
-      verifyCredential: jest.fn().mockResolvedValue({ isValid: true }),
+      verifyCredential: jest.fn().mockResolvedValue({ isValid: true } satisfies VerifyPermissionsResult),
       settleCredential: jest.fn().mockResolvedValue({
         success: true,
         transaction: '0x',
         network: 'eip155:84532',
         paymentReceipt: 'receipt-b64',
-      }),
+      } satisfies MppSettleResult),
       ...(overrides.mpp as object),
     },
     facilitator: {
-      verifyPermissions: jest.fn().mockResolvedValue({ isValid: true, agentRequestId: 'req-1' }),
-      settlePermissions: jest.fn().mockResolvedValue({ success: true, creditsRedeemed: '2' }),
+      verifyPermissions: jest.fn().mockResolvedValue({ isValid: true, agentRequestId: 'req-1' } satisfies VerifyPermissionsResult),
+      settlePermissions: jest.fn().mockResolvedValue({
+        success: true,
+        transaction: '0x',
+        network: 'eip155:84532',
+        creditsRedeemed: '2',
+      } satisfies SettlePermissionsResult),
       ...(overrides.facilitator as object),
     },
     getEnvironmentName: () => 'sandbox',

--- a/tests/unit/x402-middleware-settlement.test.ts
+++ b/tests/unit/x402-middleware-settlement.test.ts
@@ -14,6 +14,10 @@ import type { Request, Response } from 'express'
 import http from 'http'
 import net from 'net'
 import { paymentMiddleware, X402_HEADERS } from '../../src/x402/express/index.js'
+import type {
+  SettlePermissionsResult,
+  VerifyPermissionsResult,
+} from '../../src/x402/facilitator-api.js'
 
 // Use the same mock token shape the rest of the test suite uses so the
 // middleware's verify call gets past the shape checks.
@@ -23,7 +27,11 @@ const MOCK_TOKEN = 'mock-x402-token'
 function buildMockPayments(opts: { settleSpy: jest.Mock; verifySpy?: jest.Mock }) {
   const verify =
     opts.verifySpy ??
-    jest.fn().mockResolvedValue({ isValid: true, agentRequest: undefined, agentRequestId: 'req-1' })
+    jest.fn().mockResolvedValue({
+      isValid: true,
+      agentRequest: undefined,
+      agentRequestId: 'req-1',
+    } satisfies VerifyPermissionsResult)
   return {
     facilitator: {
       verifyPermissions: verify,
@@ -96,9 +104,11 @@ async function postWithToken(port: number): Promise<{
 describe('paymentMiddleware settlement coverage (#1728)', () => {
   const baseSettlement = {
     success: true,
+    transaction: '',
+    network: 'stripe',
     creditsRedeemed: '1',
     orderTx: '0xabc',
-  }
+  } satisfies SettlePermissionsResult
 
   test('settles when handler uses res.json', async () => {
     const settleSpy = jest.fn().mockResolvedValue(baseSettlement)

--- a/tests/unit/x402-middleware-settlement.test.ts
+++ b/tests/unit/x402-middleware-settlement.test.ts
@@ -102,10 +102,15 @@ async function postWithToken(port: number): Promise<{
 }
 
 describe('paymentMiddleware settlement coverage (#1728)', () => {
+  // `transaction` and `network` are required on the model and were missing here;
+  // these tests read neither, so the values only have to be coherent. They match
+  // the pre-existing hex `orderTx`, i.e. a crypto rail whose settle had to order
+  // credits first — deliberately NOT a PSP name, which would pin a fiat rail
+  // inside a test that is about response methods, not rails.
   const baseSettlement = {
     success: true,
-    transaction: '',
-    network: 'stripe',
+    transaction: '0xsettletx',
+    network: 'eip155:84532',
     creditsRedeemed: '1',
     orderTx: '0xabc',
   } satisfies SettlePermissionsResult

--- a/tests/unit/x402-middleware-v3-relay.test.ts
+++ b/tests/unit/x402-middleware-v3-relay.test.ts
@@ -16,6 +16,10 @@ import express from 'express'
 import type { Request, Response } from 'express'
 import http from 'http'
 import { paymentMiddleware, X402_HEADERS } from '../../src/x402/express/index.js'
+import type {
+  SettlePermissionsResult,
+  VerifyPermissionsResult,
+} from '../../src/x402/facilitator-api.js'
 
 /**
  * A real v3 envelope, base64 of compact JSON — long, padded, and containing
@@ -159,7 +163,11 @@ describe('paymentMiddleware — a replayed single-use token is not served', () =
   test('the body is withheld and the reused token is refused on the next request', async () => {
     const verifySpy = jest
       .fn()
-      .mockResolvedValue({ isValid: true, agentRequestId: 'req-1', agentRequest: undefined })
+      .mockResolvedValue({
+        isValid: true,
+        agentRequestId: 'req-1',
+        agentRequest: undefined,
+      } satisfies VerifyPermissionsResult)
     const settleSpy = jest.fn().mockRejectedValue(spentTokenError())
     const { port, close } = await startServer(verifySpy, settleSpy)
 
@@ -187,13 +195,17 @@ describe('paymentMiddleware — v3 token relay', () => {
   test('the token reaches verify and settle byte-for-byte', async () => {
     const verifySpy = jest
       .fn()
-      .mockResolvedValue({ isValid: true, agentRequestId: 'req-1', agentRequest: undefined })
+      .mockResolvedValue({
+        isValid: true,
+        agentRequestId: 'req-1',
+        agentRequest: undefined,
+      } satisfies VerifyPermissionsResult)
     const settleSpy = jest.fn().mockResolvedValue({
       success: true,
       transaction: '0xtx',
       network: 'eip155:84532',
       creditsRedeemed: '1',
-    })
+    } satisfies SettlePermissionsResult)
     const { port, close } = await startServer(verifySpy, settleSpy)
 
     try {

--- a/tests/unit/x402-visa.test.ts
+++ b/tests/unit/x402-visa.test.ts
@@ -15,6 +15,7 @@
 import { Payments } from '../../src/payments.js'
 import { PaymentsError } from '../../src/common/payments.error.js'
 import type { PaymentMethodSummary } from '../../src/x402/delegation-api.js'
+import type { CreateDelegationPayload } from '../../src/common/types.js'
 
 const TEST_API_KEY =
   process.env.TEST_PROXY_BEARER_TOKEN ||
@@ -92,7 +93,7 @@ describe('Visa provider surface', () => {
       durationSecs: 3_600,
       currency: 'usd',
       maxTransactions: 5,
-    }
+    } satisfies CreateDelegationPayload
     const response = await payments.delegation.createDelegation(payload)
 
     expect(calls).toHaveLength(1)

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,8 +1,6 @@
 /**
  * Shared test utilities for polling async conditions (e.g., waiting for RPC sync).
  */
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck - rootDir restriction doesn't apply to test utilities importing from src
 import { ZeroAddress } from '../src/environments.js'
 
 /**


### PR DESCRIPTION
Closes #433.

`PaymentsMock` took `settleResult?: any`. That erases the check outright — an object literal passed through it could omit every field on the model and nothing complained, at compile time or run time. This restores it, and then makes the restored check actually run.

## What was wrong, beyond the `any`

The issue asks to confirm whether the doubles sit in a typechecked path. **They did not — nothing in this repo typechecks a test file.** Two independent causes, both measured:

| gate | sees a type error in `tests/`? | why |
|---|---|---|
| `pnpm build` (`tsc`) | **no** | root `tsconfig.json` has `"exclude": [… "tests"]` |
| `pnpm test:unit` (ts-jest) | **no** | root `isolatedModules: true` → ts-jest uses `transpileModule` |

Method: a file under `tests/unit/` containing `const bad: SettlePermissionsResult = { success: 123, …, nope: 'drift' }` compiled clean under `tsc -p tsconfig.json` **and passed as a jest test**. Injecting `isolatedModules: false` into the ts-jest transform makes that same file fail with `TS2322` — the control that identifies the cause rather than guessing it.

`tests/tsconfig.json` was already in the repo, already correct, and referenced by no script and no workflow.

So option 1 or 2 from the issue, shipped alone, would have been documentation. Hence commits 2 and 3.

## How to read this

Four commits, ordered so the load-bearing part is separable from the bulk:

| | commit | size | what it is |
|---|---|---|---|
| 1 | `test:` constrain the doubles | 20 files | the fix the issue asks for |
| 2 | `test:` fix the 36 | 5 files | **mechanical**; skim it |
| 3 | `ci:` typecheck the test tree | 2 files | **the part that changes what your PRs must pass** |
| 4 | `docs:` CLAUDE.md | 1 file | why `pnpm build` can't see `tests/` |
| 5 | `test:` review fold | 3 files | closes an escape hatch this branch had opened |

**Commit 2 is mechanical and every one of its 36 errors predates this PR** — they are on `origin/main` right now, and 32 of them are the same one-line omission repeated. Nothing in it changes what a test asserts; the suite's numbers are identical either side. Read commit 3 first if you are short of time.

## Commit 1 — constrain the doubles

Two mechanisms, each where it fits, which is what the issue proposes:

- **Narrowed parameters** where a mock or helper took `any` — `PaymentsMock(settleResult)`, `makeDecorator({ settle })`, `PaymentsMock(verifySequence)`. This checks every call site at once.
- **`satisfies`** on the object literals handed to `mockResolvedValue`, and explicit return annotations on mock methods that returned an inferred or hand-rolled shape.

**`SettlePermissionsResult`, not `Partial<>`.** `Partial` still rejects a misspelled key, so it is not a cop-out — but it forfeits the property the issue names as the goal: *"adding a required field to the model breaks them loudly, which is the behaviour we want."* Under `Partial` it would not. The cost of the full type was two shorthand fixtures that omitted `transaction`/`network`, and since the real facilitator never returns that shape, completing them is a fidelity improvement rather than a concession.

Every constraint targets a model type imported from `src/` — `SettlePermissionsResult`, `VerifyPermissionsResult`, `MppSettleResult`, `StartAgentRequest`, `CreateDelegationPayload`. None is inferred from the fixture it checks. Two of these doubles previously *were* hand-rolled inline shapes (`Promise<{ success: boolean; transaction: string; network: string; creditsRedeemed: string }>`), which is that failure mode written out; those are gone.

Three doubles had already drifted and are corrected:

- `x402-middleware-settlement` — `baseSettlement` had no `transaction`/`network`
- `mpp/middleware-x402-fallback` — the settle stub had no `transaction`/`network`
- `mpp/middleware-challenge` — the settle stub was `{ success: true }` and nothing else

A fourth, `mpp/middleware-hooks-parity`, stood in for `StartAgentRequest` with two of its seven fields. Completing it puts a real `bigint` balance into `req.paymentContext`, which `JSON.stringify` refuses — so that file's default handler now narrows bigints, as any seller relaying a payment context must.

## Commit 2 — make the check run

Adds `pnpm typecheck:tests` (`tsc --noEmit -p tests/tsconfig.json`) and a step in `testing.yml`'s `lint_build` job. Turning it on surfaced **36 pre-existing errors** — the same drift, undetected for the same reason:

- **32 ×** `mcp.configure({ agentId, serverName })` with no `planId`, which `McpConfig` has declared **required** since #391 (*"make agentId optional, require planId"*). The test call sites were never updated because nothing checked them. Each now passes the planId its own paywalled handlers already use. `withPaywall` reads the per-tool option first, so behaviour is unchanged — the suite's numbers are byte-identical before and after.
- **3 ×** `a2a/payments-request-handler-stream` — an `AgentCard` stub with one of nine fields, a `DummyExecutor` missing `cancelTask`, a `validation` standing in for `StartAgentRequest` with one of seven.
- **1 ×** `x402-visa` — a `currency` that widened to `string` because the payload literal was declared apart from its use.

### Were those 32 fixtures wrong, or is `McpConfig` over-demanding?

Worth asking, because they pass today only because `withPaywall` accepts a per-tool `planId` — so a type demanding a server-level one could be the thing that is inaccurate, and teaching 32 fixtures to satisfy a wrong type would be the wrong fix.

**Checked, and the fixtures were simply incomplete.** No test anywhere uses more than one planId per server — `unit/mcp` uses `plan123` throughout, `mcp_paywall_invalid_token_flow` `plan-basic`, `mcp-integration` `plan-123`; even the spec named `multi-tool-server` varies *credits*, not plans. So none of them was describing a per-tool-only pattern that `McpConfig` forbids. They omitted a value that is constant across each file, which is the drift this issue is about, and #391 made it required deliberately.

**But there is a real inconsistency next door, and it is not this PR's to fix.** `McpConfig.planId` is required, while `withPaywall`'s own docblock says the opposite — *"A `planId` must already be resolvable (per-tool `options.planId` **or** a server-level one set via `configure()`/`start()`)"* — and the runtime agrees with the docblock (`if (!opts.planId && !extendedConfig.planId) throw`). A server wanting a different plan per tool is a coherent shape that the implementation and its documentation both permit and the type refuses. `McpConfig` is production and stays untouched here; flagging it for a separate call.

## Mutation test

A guard never seen red proves nothing, so both mutations were run against the gate that now runs in CI, with an unmutated control required to pass.

**Control** — clean tree, `pnpm typecheck:tests` → exit **0**.

**M1 — add a required `settledAt: string` to `SettlePermissionsResult`.** `pnpm typecheck:tests` → exit **2**. Per-file, subtracting each side's own baseline so the count is attributable to the mutation:

| | test files red | new errors |
|---|---|---|
| `origin/main` | **4** | 9 |
| this branch | **21** | 56 |

The 4 on main are exactly the already-typed doubles the issue named (`langsmith-spans`, `langchain-decorator`, `langsmith-decorator`) plus `a2a/x402-a2a`. The **17 newly guarded**: `unit/mcp`, `unit/mcp/x402_inband`, `unit/mpp/{middleware-redeem, middleware-x402-fallback, middleware-challenge, middleware-challenge-error, middleware-body-digest, middleware-concurrent-credential, middleware-hooks-parity}`, `unit/x402-middleware-settlement`, `unit/x402-middleware-v3-relay`, `integration/mcp-integration`, `integration/mcp/mcp_paywall_invalid_token_flow`, `integration/a2a/{complete-message-send-flow, x402-inband-flow, payments-server, payments-server-additional}`.

**M2 — misspell one key in one fixture** (`creditsRedeemed` → `creditsRedeemd`). This one touches no `src` at all, so it isolates the doubles guard from the fact that M1 also breaks two `src` files:

- `pnpm typecheck:tests` → exit **2**: `TS2561: 'creditsRedeemd' does not exist in type 'SettlePermissionsResult'. Did you mean to write 'creditsRedeemed'?`
- the same misspelling applied to `origin/main`'s copy of that fixture → **no error**
- `pnpm build` → exit **0**, and `pnpm test:unit` → 635 passed. Both blind, which is the point of commit 2.

**M3 — does the CI job itself go red?** A gate that runs but cannot fail is the same false green as a suite reporting `total: 0`, so local `tsc` is not sufficient evidence. One of the 36 was reintroduced (the cheapest — a single `mcp.configure` losing its `planId`) and pushed to a throwaway branch:

```
JOB Lint & Build: failure
     - Build:           success     <- blind, as expected
     - Typecheck tests: failure
     - Lint:            skipped
JOB OpenClaw Plugin Check: skipped
JOB CLI Sync Check:        skipped
JOB Unit & Integration:    skipped
JOB E2E:                   skipped
```

```
##[error]tests/unit/mcp.test.ts(113,21): error TS2345: Argument of type
'{ agentId: string; serverName: string; }' is not assignable to parameter of
type 'ExtendedMcpConfig'.
##[error]Process completed with exit code 2.
```

One file red, which is right — exactly one omission was reintroduced — and every downstream job is gated on it. The throwaway branch has been deleted.

All three mutations were reverted; the tree is clean.

## Scope of the gate — it does NOT cover the in-tree consumers

`pnpm typecheck:tests` covers `tests/` only. **`cli/` and `openclaw/` remain unchecked**, and a reviewer would reasonably read "typecheck the test tree" as covering everything, so stating it: `cli/tsconfig.json:24` excludes `test` and `openclaw/tsconfig.json:20` excludes `tests`; neither has a test-specific tsconfig; and both have real suites (`cli/test/{unit,integration}`, `openclaw/tests/plugin.test.ts`). The same drift can still land there. Extending to them needs a tsconfig per package and whatever errors that surfaces, which is a separate change.

Also pre-existing and unchanged: `testing.yml` is `on: [push]`, so it never fires on fork PRs. Untouched here.

## What the review round changed

Commit 5 folds six review findings. The first is the one that mattered:

**An escape hatch this branch had opened.** `payments-request-handler-stream` widened `as AgentCard` to `as unknown as AgentCard` — the one assertion the typechecker cannot see through — which would have left that fixture's drift permanently invisible, in the PR whose purpose is making such drift visible. It needed no escape: `AgentCard` has nine required fields, eight of them primitives. The fixture is now complete and carries **no assertion at all**. Verified by mutation: deleting `defaultOutputModes` from it now fails with `TS2741 … but required in type 'AgentCard'`, where under the double assertion it was silent. No `as unknown as`, `as any`, `@ts-ignore` or `@ts-expect-error` remains anywhere in this branch's diff.

**Three invented fixture values, corrected.** The new `PaymentsMock` default paired `success: true` with `transaction: ''`, but the model documents an empty `transaction` as the **failure** marker — a response the facilitator never sends, teaching every fixture built from it a contradiction. It is now an ordinary successful crypto settle, with `creditsRedeemed` still absent so inheritors keep exercising the paywall's fallback. `x402-middleware-settlement` had gained `network: 'stripe'`, pinning a fiat rail inside a test about response methods; now a crypto rail, coherent with the hex `orderTx` already there.

**And a silently-changed invariant.** That default had also moved what a pre-existing assertion proved — from *"no `transaction` key ⇒ no txHash"* to *"empty `transaction` ⇒ no txHash"*, since the paywall gates on truthiness. Both are real invariants; only one was written down, and the test stayed green either way. It now passes its own explicit fixture and says which it means, so a future change to the default cannot move it again. Verified by mutation: giving that fixture a real hash makes the test **fail** (1 failed / 21 passed), so the assertion is load-bearing rather than vacuous.

**Ordering.** The `Typecheck tests` step now runs **after** `Lint`, so a test type error no longer fail-fasts the job and masks lint errors that used to surface in the same run.

## Deliberately not typed

Raw `fetch` / `Response` stubs (`x402-token-v3`, `x402-visa`, `mpp-api`, the two `integration/mpp` specs) model **what a server sends**, not an SDK return value. One test in `x402-token-v3` sends a body with **no `success` field on purpose**, to prove the SDK reports rather than trusts it — constraining that literal to the model would make the test unwritable. Untrusted wire input is a different thing from a typed API surface, and only the latter is in scope here.

## One thing found and deliberately left out of scope

`tests/unit/a2a/payments-request-handler.test.ts` settles with `{ txHash: '0xabc', amountOfCredits: 5n }` — neither field exists on `SettlePermissionsResult`. It is not accidental drift: `paymentsRequestHandler.ts` reads `response.txHash ?? response.transaction`, so the double covers a fallback the model does not describe. Typing it would delete that coverage, so it is left alone.

Traced since: `txHash` is **not** on the backend's settle response (nvm-monorepo's `x402-responses.dto.ts` declares `transaction?: string` and no `txHash`; every `txHash` in the API's x402 tree is an internal DB column), and `amountOfCredits` is on no type at all. Both are read off `executeRedemption`, which returns `Promise<any>`, and a later `response as SettlePermissionsResult` asserts a type the value was never checked against — **this issue's own defect, in production code rather than tests**, undetected by the same mechanism.

The fix is to type that return and let the compiler force the reconciliation, which is a production change needing its own review. Out of scope here; being handled separately.

## Verification

Run locally on this branch; the same numbers as `origin/main` @ `4495be8` except where noted.

| | baseline (`origin/main`) | this branch |
|---|---|---|
| `pnpm test:unit` | 48 suites, 635 passed, 1 skipped | **48 suites, 635 passed, 1 skipped** |
| `pnpm test:integration` | 11 suites, 55 passed | **11 suites, 55 passed** |
| `pnpm build` | exit 0 | **exit 0** |
| `pnpm lint` | 0 errors, 3 warnings | **0 errors, 3 warnings** (all pre-existing, in `src/`) |
| `pnpm typecheck:tests` | *(did not exist)* — 36 errors | **exit 0** |

No production code is changed.

## Related

- nevermined-io/payments-py#273 — the Python half of the same defect class, where 12 of 12 doubles had drifted and the equivalent model change turned 28 tests red. Being handled separately; nothing in this PR touches that repo.
- #432 — where this surfaced
- nevermined-io/nvm-monorepo#2999 — the originating issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVpimo1dBXnTJo9tQSy8SA
