### PR TITLE
feat(a2a): report the credits actually redeemed, per billing model (#438)

### DIFF
--- a/markdown/a2a-integration.md
+++ b/markdown/a2a-integration.md
@@ -243,13 +243,25 @@ eventBus.publish({
 ### What the SDK adds to `metadata` after settlement
 
 Your executor sets `creditsUsed`. After the request settles, the SDK adds two more
-keys to the same `metadata` object, on the status-update event and on the stored
-task:
+keys to the same `metadata` object:
 
 | key | meaning |
 | --- | --- |
-| `txHash` | The settlement transaction, from the facilitator's receipt. |
+| `txHash` | The settlement transaction. A chain tx hash on the crypto rails; on fiat it is the **PSP transaction id** (a Stripe PaymentIntent, `pi_...`), so do not assume it is a hash. |
 | `creditsCharged` | The credits the settle **actually redeemed**. |
+
+⚠️ **Where they land depends on the transport, so do not assume `task.metadata`.**
+
+| transport | status-update event | stored task (`task.metadata`) |
+| --- | --- | --- |
+| non-streaming | ✅ both keys | ✅ both keys |
+| streaming | ❌ neither — the event is `yield`ed before settlement | ❌ neither |
+| batch redemption (`useBatch`) | ❌ neither | ❌ neither |
+
+On the streaming transport the settlement block runs *after* the event has been
+yielded, and only `event.metadata` is touched — `task.metadata` has a single
+writer, on the non-streaming path. Under `useBatch` the block is skipped
+entirely, on both transports.
 
 **`creditsCharged` is not always present, and its absence is meaningful.** It
 reports what was redeemed, which is not necessarily what you asked to burn —
@@ -267,13 +279,20 @@ Pay-as-you-go is the case to understand. Such a plan holds no credit balance, so
 `creditsRedeemed` is the string `'0'` **even on a settle that charged the buyer**.
 Publishing that as `creditsCharged: 0` would tell a buyer they were charged
 nothing for a payment that really happened, so nothing is published instead. The
-charge is referenced by `orderTx` (fiat) or `transaction` (crypto), and the full
-settlement receipt is on the task under `x402.payment.receipts`.
+charge is referenced by `orderTx` (fiat) or `transaction` (crypto).
+
+The full settlement receipt is also available, but **only on the in-band x402
+transport** and at `task.status.message.metadata['x402.payment.receipts']` —
+*not* `task.metadata`. On the legacy `payment-signature` header path there are no
+receipts at all, and under `useBatch` a deferred marker is written instead of
+one.
 
 **Read it with `in`, not truthiness** — `0` is a legitimate value:
 
 ```typescript
-if ('creditsCharged' in task.metadata) {
+// `Task.metadata` is optional in @a2a-js/sdk, and `'x' in undefined` throws —
+// so guard it, or the else-branch below is unreachable exactly when you need it.
+if (task.metadata && 'creditsCharged' in task.metadata) {
   console.log(`Redeemed ${task.metadata.creditsCharged} credits`)
 } else {
   // Pay-as-you-go, or no usable figure. `creditsUsed` still tells you what the

--- a/markdown/a2a-integration.md
+++ b/markdown/a2a-integration.md
@@ -240,6 +240,50 @@ eventBus.publish({
 })
 ```
 
+### What the SDK adds to `metadata` after settlement
+
+Your executor sets `creditsUsed`. After the request settles, the SDK adds two more
+keys to the same `metadata` object, on the status-update event and on the stored
+task:
+
+| key | meaning |
+| --- | --- |
+| `txHash` | The settlement transaction, from the facilitator's receipt. |
+| `creditsCharged` | The credits the settle **actually redeemed**. |
+
+**`creditsCharged` is not always present, and its absence is meaningful.** It
+reports what was redeemed, which is not necessarily what you asked to burn —
+under margin-based pricing the two differ. The SDK omits the key entirely rather
+than report a figure that would be false:
+
+| situation | `creditsCharged` |
+| --- | --- |
+| credits plan | the credits redeemed |
+| credits plan, nothing redeemed | `0` — a real figure, not an absence |
+| **pay-as-you-go** | **key absent** |
+| the backend reported no usable figure | **key absent** (and the SDK warns) |
+
+Pay-as-you-go is the case to understand. Such a plan holds no credit balance, so
+`creditsRedeemed` is the string `'0'` **even on a settle that charged the buyer**.
+Publishing that as `creditsCharged: 0` would tell a buyer they were charged
+nothing for a payment that really happened, so nothing is published instead. The
+charge is referenced by `orderTx` (fiat) or `transaction` (crypto), and the full
+settlement receipt is on the task under `x402.payment.receipts`.
+
+**Read it with `in`, not truthiness** — `0` is a legitimate value:
+
+```typescript
+if ('creditsCharged' in task.metadata) {
+  console.log(`Redeemed ${task.metadata.creditsCharged} credits`)
+} else {
+  // Pay-as-you-go, or no usable figure. `creditsUsed` still tells you what the
+  // request asked to burn.
+}
+```
+
+The credits your request asked to burn remain on the event as `creditsUsed`,
+untouched, so nothing is lost by the omission.
+
 ### Message Event (Streaming)
 
 ```typescript

--- a/src/a2a/paymentsRequestHandler.ts
+++ b/src/a2a/paymentsRequestHandler.ts
@@ -57,6 +57,13 @@ const terminalStates: TaskState[] = ['completed', 'failed', 'canceled', 'rejecte
  *   referenced by `orderTx` (fiat) or `transaction` (crypto); the credits the
  *   request asked to burn remain on the event as `creditsUsed`, so nothing is
  *   lost by omitting a figure that has no meaning on this billing model.
+ *
+ *   ⚠️ MCP does the OPPOSITE and that is deliberate — a settled decision (repo
+ *   owner, on the #443 review), not drift. `_meta['nevermined/credits']` reports
+ *   the `'0'` because it emits `billingModel` BESIDE it, so a consumer can read
+ *   it; `creditsCharged` here has no discriminator next to it, so a bare `0`
+ *   would say "you were charged nothing" about a charge that succeeded. Do not
+ *   reconcile the two.
  * - absent — a Nevermined API older than the discriminator (`creditsRedeemed`
  *   has been on the settle response since 2026-03-25, `billingModel` only since
  *   2026-08-06). Apply the `credits` rule: a missing discriminator must never be

--- a/src/a2a/paymentsRequestHandler.ts
+++ b/src/a2a/paymentsRequestHandler.ts
@@ -41,6 +41,42 @@ import type {
 const terminalStates: TaskState[] = ['completed', 'failed', 'canceled', 'rejected']
 
 /**
+ * The credits a settle actually redeemed, for `event.metadata.creditsCharged`.
+ *
+ * Reads {@link SettlePermissionsResult.creditsRedeemed} per billing model rather
+ * than trusting it flat, because it does not mean the same thing under both:
+ *
+ * - `credits` — the plan holds a balance and `creditsRedeemed` is what came out
+ *   of it. Report it. It can legitimately differ from the credits the request
+ *   asked to burn (margin-based pricing), which is the whole reason to report
+ *   the settled figure rather than the requested one.
+ * - `pay-as-you-go` — the plan holds no credit balance at all, so
+ *   `creditsRedeemed` is the string `'0'` *even on a settle that charged the
+ *   buyer*. Returning that `0` would tell a buyer they were charged nothing for
+ *   a payment that really happened, so report nothing instead. The charge is
+ *   referenced by `orderTx` (fiat) or `transaction` (crypto); the credits the
+ *   request asked to burn remain on the event as `creditsUsed`, so nothing is
+ *   lost by omitting a figure that has no meaning on this billing model.
+ * - absent — a Nevermined API older than the discriminator (`creditsRedeemed`
+ *   has been on the settle response since 2026-03-25, `billingModel` only since
+ *   2026-08-06). Apply the `credits` rule: a missing discriminator must never be
+ *   read as pay-as-you-go.
+ *
+ * Mind the type: these are **strings**. `'0'` is truthy while `Number('0') > 0`
+ * is false, so a truthiness check and a numeric one disagree on exactly the
+ * value that matters.
+ *
+ * @param settlement - The settlement receipt as the facilitator returned it
+ * @returns The credits redeemed, or `undefined` when the billing model has no
+ *   credits to report or the backend reported no usable figure
+ */
+function resolveCreditsCharged(settlement: SettlePermissionsResult): number | undefined {
+  if (settlement.billingModel === 'pay-as-you-go') return undefined
+  const redeemed = Number(settlement.creditsRedeemed)
+  return Number.isFinite(redeemed) ? redeemed : undefined
+}
+
+/**
  * Options for configuring the PaymentsRequestHandler
  */
 export interface PaymentsRequestHandlerOptions {
@@ -560,7 +596,13 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
               // There is no `txHash` on the wire — see handleTaskFinalization.
               if (response && event.metadata) {
                 event.metadata.txHash = response.transaction
-                event.metadata.creditsCharged = event.metadata.creditsUsed
+                // Left unset when the billing model has no credits to report —
+                // see resolveCreditsCharged. `creditsUsed` still carries what
+                // the request asked to burn.
+                const creditsCharged = resolveCreditsCharged(response)
+                if (creditsCharged !== undefined) {
+                  event.metadata.creditsCharged = creditsCharged
+                }
               }
 
               // x402 v2 A2A transport: stamp the settlement receipt onto the
@@ -867,16 +909,14 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
           // Update event metadata with redemption results. `txHash` is the A2A
           // metadata key, not a wire field: the settle response reports the
           // transaction id as `transaction`.
+          const creditsCharged = resolveCreditsCharged(response)
           event.metadata = {
             ...event.metadata,
             txHash: response.transaction,
-            // The credits this request asked to burn. The settle response does
-            // report what was actually redeemed, as `creditsRedeemed`, but
-            // reading it here would change behaviour and is not free: it is the
-            // string '0' on `billingModel: 'pay-as-you-go'` plans even when the
-            // buyer WAS charged, so a truthiness read reports 0 on a real
-            // charge. See SettlePermissionsResult before wiring it up.
-            creditsCharged: creditsToBurn,
+            // The credits actually redeemed, omitted entirely when the billing
+            // model has none to report — see resolveCreditsCharged. The credits
+            // this request asked to burn stay available as `creditsUsed`.
+            ...(creditsCharged !== undefined && { creditsCharged }),
           }
         }
       } catch (err) {

--- a/src/a2a/paymentsRequestHandler.ts
+++ b/src/a2a/paymentsRequestHandler.ts
@@ -104,17 +104,40 @@ function resolveCreditsCharged(settlement: SettlePermissionsResult): number | un
     return undefined
   }
 
+  // A FAILED settle has no measured redemption to report, so it gets no figure.
+  // `settlePermissions` does not throw on one — it returns 200 with
+  // `success: false` verbatim — so without this a failure published
+  // `creditsCharged` as though it were measured: `{success: false,
+  // creditsRedeemed: '7'}` reported 7 credits charged for a settle that charged
+  // nothing. The published contract makes that a lie rather than merely noise,
+  // because `markdown/a2a-integration.md` defines `0` as "a real figure, not an
+  // absence" — a number here asserts the settle completed.
+  //
+  // ⚠️ `!== true`, not `=== false`, and the asymmetry with `billingModel` above
+  // is deliberate. An ABSENT `billingModel` is a documented legacy shape (APIs
+  // predating the field) and is read as `credits`; an absent `success` is not a
+  // legacy shape — the field has always been there and is declared
+  // non-optional — so its absence means the response is malformed, and a
+  // malformed response is exactly when not to publish a figure.
+  //
+  // Silent, like the pay-as-you-go branch: a failed settle is a legitimate
+  // outcome the caller already sees on `success`, not a reporting fault.
+  if (settlement.success !== true) {
+    return undefined
+  }
+
   const raw = settlement.creditsRedeemed
   if (typeof raw !== 'string' || !DECIMAL_INTEGER_STRING.test(raw)) {
     // Silence here would be indistinguishable from the pay-as-you-go omission,
     // which is a deliberate design decision rather than a fault. Warn, as
     // `x402/express/middleware.ts` does on this same field.
-    if (raw !== undefined) {
-      console.warn(
-        `[PaymentsRequestHandler] settle reported an unusable creditsRedeemed ` +
+    console.warn(
+      raw === undefined
+        ? `[PaymentsRequestHandler] settle reported no creditsRedeemed; omitting ` +
+          `creditsCharged rather than publishing a figure`
+        : `[PaymentsRequestHandler] settle reported an unusable creditsRedeemed ` +
           `(${JSON.stringify(raw)}); omitting creditsCharged rather than publishing a figure`,
-      )
-    }
+    )
     return undefined
   }
 

--- a/src/a2a/paymentsRequestHandler.ts
+++ b/src/a2a/paymentsRequestHandler.ts
@@ -66,14 +66,73 @@ const terminalStates: TaskState[] = ['completed', 'failed', 'canceled', 'rejecte
  * is false, so a truthiness check and a numeric one disagree on exactly the
  * value that matters.
  *
+ * Three ways this returns `undefined`, and they mean different things — the
+ * first is a design decision, the other two are faults, which is why only the
+ * faults warn:
+ *
+ * 1. the billing model has no credits figure to report (pay-as-you-go, or any
+ *    discriminator that is present and is not `credits`) — silent, by design;
+ * 2. `creditsRedeemed` is absent, or not a plain decimal string — warns;
+ * 3. the value is a decimal string too large for a JS number — warns.
+ *
  * @param settlement - The settlement receipt as the facilitator returned it
- * @returns The credits redeemed, or `undefined` when the billing model has no
- *   credits to report or the backend reported no usable figure
+ * @returns The credits redeemed, or `undefined` per the three cases above
  */
+/**
+ * A decimal string, and nothing else — no sign, no whitespace, no `0x`/`1e3`,
+ * no fractional part. `Number()` accepts every one of those, and worse, maps the
+ * empty-ish family (`''`, `'   '`, `null`, `[]`, `false`) to **0** rather than
+ * `NaN`, so `Number.isFinite` does not catch them. Publishing that 0 would say
+ * "you were charged nothing" on a settle we simply could not read — the same
+ * class of lie this helper exists to prevent on pay-as-you-go.
+ *
+ * Same reasoning, same shape as `DECIMAL_INTEGER_STRING` in `mpp/mpp-api.ts`.
+ */
+const DECIMAL_INTEGER_STRING = /^\d+$/
+
 function resolveCreditsCharged(settlement: SettlePermissionsResult): number | undefined {
-  if (settlement.billingModel === 'pay-as-you-go') return undefined
-  const redeemed = Number(settlement.creditsRedeemed)
-  return Number.isFinite(redeemed) ? redeemed : undefined
+  // ALLOWLIST, not a denylist. `=== 'pay-as-you-go'` let every other value fall
+  // into the credits branch and publish a `0`: `null`, `''`, `'PAY-AS-YOU-GO'`,
+  // a future third billing model, a non-string. The response is an unchecked
+  // `as SettlePermissionsResult` over `response.json()`, so the union type
+  // provides no runtime guarantee and the wrong values are reachable.
+  //
+  // `undefined` still means `credits` — that is the documented ruling above and
+  // it is preserved exactly. What changes is that a discriminator which is
+  // present but not `credits` now omits rather than reporting a zero.
+  if (settlement.billingModel !== undefined && settlement.billingModel !== 'credits') {
+    return undefined
+  }
+
+  const raw = settlement.creditsRedeemed
+  if (typeof raw !== 'string' || !DECIMAL_INTEGER_STRING.test(raw)) {
+    // Silence here would be indistinguishable from the pay-as-you-go omission,
+    // which is a deliberate design decision rather than a fault. Warn, as
+    // `x402/express/middleware.ts` does on this same field.
+    if (raw !== undefined) {
+      console.warn(
+        `[PaymentsRequestHandler] settle reported an unusable creditsRedeemed ` +
+          `(${JSON.stringify(raw)}); omitting creditsCharged rather than publishing a figure`,
+      )
+    }
+    return undefined
+  }
+
+  const redeemed = Number(raw)
+  if (!Number.isSafeInteger(redeemed)) {
+    // The wire carries this as a string precisely because it can exceed what a
+    // JS number represents. Above 2^53 the conversion is silently wrong
+    // (`'9007199254740993'` becomes 9007199254740992), and a wrong number is
+    // worse than no number: the exact value is still on the task, verbatim, in
+    // the `x402.payment.receipts` entry that `recordPaymentSuccess` writes.
+    console.warn(
+      `[PaymentsRequestHandler] creditsRedeemed ${raw} exceeds Number.MAX_SAFE_INTEGER; ` +
+        `omitting creditsCharged rather than publishing a rounded figure`,
+    )
+    return undefined
+  }
+
+  return redeemed
 }
 
 /**

--- a/src/a2a/paymentsRequestHandler.ts
+++ b/src/a2a/paymentsRequestHandler.ts
@@ -245,13 +245,17 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
    * @param bearerToken - The bearer token for authentication
    * @param creditsUsed - The number of credits to burn
    * @param httpContext - Optional HTTP context with endpoint and method information
-   * @returns Promise resolving to the redemption result
+   * @returns The settlement receipt, verbatim as the facilitator returned it. A
+   *   settle the backend accepted but could not complete comes back as
+   *   `success: false` with an `errorReason` rather than throwing — see
+   *   {@link SettlePermissionsResult} for which fields evidence a charge under
+   *   which billing model.
    */
   private async executeRedemption(
     bearerToken: string,
     creditsUsed: bigint | number,
     httpContext?: HttpRequestContext,
-  ): Promise<any> {
+  ): Promise<SettlePermissionsResult> {
     const decodedAccessToken = decodeAccessToken(bearerToken)
     if (!decodedAccessToken) {
       throw PaymentsError.unauthorized('Invalid access token.')
@@ -551,12 +555,12 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
                 httpContext,
               )
 
-              // Update event metadata with response data
+              // `txHash` is the A2A metadata key a buyer is shown for payment
+              // support; the settle response reports that id as `transaction`.
+              // There is no `txHash` on the wire — see handleTaskFinalization.
               if (response && event.metadata) {
-                event.metadata.txHash = response.txHash ?? response.transaction
-                event.metadata.creditsCharged = response.amountOfCredits
-                  ? Number(response.amountOfCredits)
-                  : event.metadata.creditsUsed
+                event.metadata.txHash = response.transaction
+                event.metadata.creditsCharged = event.metadata.creditsUsed
               }
 
               // x402 v2 A2A transport: stamp the settlement receipt onto the
@@ -567,11 +571,7 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
               if (httpContext?.inBand) {
                 const task = resultManager.getCurrentTask()
                 if (task) {
-                  this.recordInBandSettlement(
-                    task,
-                    httpContext,
-                    response as SettlePermissionsResult,
-                  )
+                  this.recordInBandSettlement(task, httpContext, response)
                   await resultManager.processEvent(task)
                 }
               }
@@ -862,16 +862,21 @@ export class PaymentsRequestHandler extends DefaultRequestHandler {
             BigInt(creditsToBurn),
             httpContext,
           )
-          settlement = response as SettlePermissionsResult
+          settlement = response
 
-          // Update event metadata with redemption results
+          // Update event metadata with redemption results. `txHash` is the A2A
+          // metadata key, not a wire field: the settle response reports the
+          // transaction id as `transaction`.
           event.metadata = {
             ...event.metadata,
-            txHash: response.txHash ?? response.transaction,
-            // Store the actual credits charged (especially important for margin-based)
-            creditsCharged: response.amountOfCredits
-              ? Number(response.amountOfCredits)
-              : creditsToBurn,
+            txHash: response.transaction,
+            // The credits this request asked to burn. The settle response does
+            // report what was actually redeemed, as `creditsRedeemed`, but
+            // reading it here would change behaviour and is not free: it is the
+            // string '0' on `billingModel: 'pay-as-you-go'` plans even when the
+            // buyer WAS charged, so a truthiness read reports 0 on a real
+            // charge. See SettlePermissionsResult before wiring it up.
+            creditsCharged: creditsToBurn,
           }
         }
       } catch (err) {

--- a/src/a2a/types.ts
+++ b/src/a2a/types.ts
@@ -138,6 +138,24 @@ export interface PaymentMetadata {
   agentId?: string
   /** Configuration for credit redemption behavior */
   redemptionConfig?: PaymentRedemptionConfig
+  /**
+   * The settle's transaction reference, written by the SDK after settlement.
+   * A chain tx hash on the crypto rails; the PSP transaction id on fiat (a
+   * Stripe PaymentIntent `pi_...`), so do not assume it is a hash.
+   */
+  txHash?: string
+  /**
+   * Credits the settle ACTUALLY REDEEMED, written by the SDK after settlement —
+   * not the credits the request asked to burn, which stay on `creditsUsed`.
+   *
+   * ⚠️ Its ABSENCE is meaningful and is part of the contract. The key is omitted
+   * when there is no measured redemption to report: a pay-as-you-go plan (which
+   * holds no credit balance, so its `creditsRedeemed` is '0' even on a charge
+   * that succeeded), a settle that failed, or a backend that reported no usable
+   * figure. `0` means the opposite — a settle that completed and redeemed
+   * nothing. Read it with `in`, never truthiness. See `resolveCreditsCharged`.
+   */
+  creditsCharged?: number
 }
 
 /**

--- a/tests/unit/a2a/payments-request-handler.test.ts
+++ b/tests/unit/a2a/payments-request-handler.test.ts
@@ -530,6 +530,45 @@ describe('PaymentsRequestHandler', () => {
      * must not make it refuse the ordinary case — without this, deleting the
      * whole helper body and returning `undefined` would pass every test here.
      */
+    /**
+     * #439 review — `resolveCreditsCharged` read only `billingModel` and
+     * `creditsRedeemed`, never `success`. `settlePermissions` does NOT throw on
+     * a settle the backend accepted but could not complete — it returns 200 with
+     * `success: false` verbatim — so a FAILED settle published `creditsCharged`
+     * as though it were a measured redemption. With `creditsRedeemed: '7'` it
+     * reported 7 credits charged for a settle that charged nothing.
+     *
+     * That is a lie rather than noise, because the published contract defines
+     * `0` as "a real figure, not an absence": any number here asserts the settle
+     * completed.
+     */
+    test.each([
+      ['a failed settle reporting 0', '0'],
+      ['a failed settle reporting a non-zero figure', '7'],
+    ])('%s publishes nothing', async (_label, redeemed) => {
+      const { event, taskRef } = await finalize(
+        settleResponse({ success: false, billingModel: 'credits', creditsRedeemed: redeemed }),
+      )
+      expect(event.metadata).not.toHaveProperty('creditsCharged')
+      expect(taskRef.metadata).not.toHaveProperty('creditsCharged')
+    })
+
+    /**
+     * `!== true`, not `=== false`. An absent `billingModel` is a documented
+     * legacy shape read as `credits`; an absent `success` is not — the field has
+     * always been there and is declared non-optional, so its absence means a
+     * malformed response, which is exactly when not to publish a figure.
+     */
+    test('a settle with no success field at all publishes nothing', async () => {
+      const { event } = await finalize({
+        transaction: '0xabc',
+        network: 'eip155:84532',
+        billingModel: 'credits',
+        creditsRedeemed: '7',
+      } as any)
+      expect(event.metadata).not.toHaveProperty('creditsCharged')
+    })
+
     test('an ordinary decimal string is still published', async () => {
       const { event } = await finalize(
         settleResponse({ billingModel: 'credits', creditsRedeemed: '42' }),

--- a/tests/unit/a2a/payments-request-handler.test.ts
+++ b/tests/unit/a2a/payments-request-handler.test.ts
@@ -81,13 +81,14 @@ describe('PaymentsRequestHandler', () => {
     test('should burn credits when event has creditsUsed', async () => {
       // The settle response as the facilitator really returns it: the transaction
       // id is `transaction`, and there is no `txHash` or `amountOfCredits` on the
-      // wire (#438). `creditsRedeemed` is deliberately 3 rather than 5 so the
-      // `creditsCharged` assertion below distinguishes the credits this request
-      // ASKED to burn from the credits the settle reports redeeming.
+      // wire (#438). `creditsRedeemed` is deliberately 3 against a requested burn
+      // of 5 so the `creditsCharged` assertion below distinguishes the credits
+      // this request ASKED to burn from the credits the settle actually redeemed.
       const settleMock = jest.fn().mockResolvedValue({
         success: true,
         transaction: '0xabc',
         network: 'eip155:84532',
+        billingModel: 'credits',
         creditsRedeemed: '3',
       })
       mockPayments.facilitator.settlePermissions = settleMock
@@ -143,11 +144,11 @@ describe('PaymentsRequestHandler', () => {
         maxAmount: 5n,
       })
       // `txHash` is the A2A metadata key, sourced from the wire's `transaction`;
-      // `creditsCharged` reports the requested burn (5), not `creditsRedeemed` (3).
+      // `creditsCharged` reports what was REDEEMED (3), not what was requested (5).
       expect(event.metadata?.txHash).toBe('0xabc')
-      expect(event.metadata?.creditsCharged).toBe(5)
+      expect(event.metadata?.creditsCharged).toBe(3)
       expect(taskRef.metadata?.txHash).toBe('0xabc')
-      expect(taskRef.metadata?.creditsCharged).toBe(5)
+      expect(taskRef.metadata?.creditsCharged).toBe(3)
       expect(mockResultManager.processEvent).toHaveBeenCalledWith(taskRef)
     })
 
@@ -363,6 +364,162 @@ describe('PaymentsRequestHandler', () => {
         useMargin: false,
         marginPercent: undefined,
       })
+    })
+  })
+  /**
+   * `creditsCharged` reports the credits the settle ACTUALLY REDEEMED, read per
+   * billing model (#438, contract published in #432).
+   *
+   * The three cases below are the three readings of `creditsRedeemed` and they
+   * are not interchangeable. On `pay-as-you-go` the field is the string '0' even
+   * on a settle that charged the buyer, so reporting it flat would tell a buyer
+   * they paid nothing for a payment that really happened — and '0' is truthy
+   * while Number('0') > 0 is false, so a truthiness guard and a numeric one
+   * disagree on exactly that value.
+   *
+   * Both call sites implement this rule (handleTaskFinalization for a plain
+   * response, processStreamingEventsWithFinalization for a stream), so both are
+   * driven here — a rule proven on one copy proves nothing about the other.
+   */
+  describe('creditsCharged per billing model (#438)', () => {
+    /** A settle response in the shape the facilitator really returns. */
+    const settleResponse = (extra: Record<string, unknown>) => ({
+      success: true,
+      transaction: '0xabc',
+      network: 'eip155:84532',
+      ...extra,
+    })
+
+    /** Builds a handler whose settle returns `settleValue`, plus its fixtures. */
+    const buildHandler = (settleValue: Record<string, unknown>) => {
+      mockPayments.facilitator.settlePermissions = jest.fn().mockResolvedValue(settleValue)
+      const handler = new PaymentsRequestHandler(
+        mockAgentCard,
+        mockTaskStore,
+        new DummyExecutor(),
+        mockPayments as any as Payments,
+      )
+      ;(handler as any).getAgentCard = jest.fn().mockResolvedValue(mockAgentCard)
+      ;(handler as any).getRedemptionConfig = jest
+        .fn()
+        .mockResolvedValue({ useBatch: false, useMargin: false })
+      ;(handler as any).getTaskPushNotificationConfig = jest.fn().mockResolvedValue(undefined)
+
+      const taskRef = { id: 'tid', metadata: {} as any }
+      const resultManager = {
+        getCurrentTask: jest.fn().mockReturnValue(taskRef),
+        processEvent: jest.fn().mockResolvedValue(undefined),
+      }
+      // A requested burn of 5, so any assertion of 5 would be reading the
+      // REQUESTED figure rather than the settled one.
+      const event = {
+        kind: 'status-update',
+        taskId: 'tid',
+        contextId: 'ctx-123',
+        status: { state: 'completed' },
+        final: true,
+        metadata: { creditsUsed: 5 },
+      } as TaskStatusUpdateEvent
+
+      return { handler, taskRef, resultManager, event }
+    }
+
+    /** Drives the non-streaming call site. */
+    const finalize = async (settleValue: Record<string, unknown>) => {
+      const { handler, taskRef, resultManager, event } = buildHandler(settleValue)
+      await (handler as any).handleTaskFinalization(resultManager, event, 'BEARER_TOKEN')
+      return { event, taskRef }
+    }
+
+    /**
+     * Drives the streaming call site by feeding the generator one final event.
+     * Covered from this file rather than payments-request-handler-stream.test.ts
+     * to stay clear of PR #437, which is editing that file.
+     */
+    const finalizeStreaming = async (settleValue: Record<string, unknown>) => {
+      const { handler, taskRef, resultManager, event } = buildHandler(settleValue)
+      const eventQueue = {
+        events: async function* () {
+          yield event
+        },
+      }
+      const stream = (handler as any).processStreamingEventsWithFinalization(
+        'tid',
+        resultManager,
+        eventQueue,
+        'BEARER_TOKEN',
+      )
+      for await (const _ of stream) {
+        // drain
+      }
+      return { event, taskRef }
+    }
+
+    test('credits plan reports what was redeemed, not what was requested', async () => {
+      const { event, taskRef } = await finalize(
+        settleResponse({ billingModel: 'credits', creditsRedeemed: '3' }),
+      )
+      expect(event.metadata?.creditsCharged).toBe(3)
+      expect(taskRef.metadata?.creditsCharged).toBe(3)
+      // The requested burn is not lost — it stays on the event as `creditsUsed`.
+      expect(event.metadata?.creditsUsed).toBe(5)
+    })
+
+    test('credits plan, streaming path, reports the redeemed figure too', async () => {
+      const { event } = await finalizeStreaming(
+        settleResponse({ billingModel: 'credits', creditsRedeemed: '3' }),
+      )
+      expect(event.metadata?.creditsCharged).toBe(3)
+      expect(event.metadata?.txHash).toBe('0xabc')
+    })
+
+    test('pay-as-you-go omits creditsCharged on a SUCCESSFUL charge', async () => {
+      // No credit balance exists, so `creditsRedeemed` is '0' even though the
+      // buyer WAS charged — the charge is referenced by `orderTx`.
+      const { event, taskRef } = await finalize(
+        settleResponse({
+          billingModel: 'pay-as-you-go',
+          creditsRedeemed: '0',
+          orderTx: 'pi_3TUrvfBYvSRKcV420xCBjHb1',
+        }),
+      )
+      expect(event.metadata).not.toHaveProperty('creditsCharged')
+      expect(taskRef.metadata).not.toHaveProperty('creditsCharged')
+      // Specifically NOT the meaningless 0, and specifically NOT the requested
+      // burn dressed up as a settled figure.
+      expect(event.metadata?.creditsCharged).toBeUndefined()
+      expect(event.metadata?.creditsUsed).toBe(5)
+      // The settle still succeeded and is still referenced.
+      expect(event.metadata?.txHash).toBe('0xabc')
+    })
+
+    test('pay-as-you-go omits creditsCharged on the streaming path too', async () => {
+      const { event } = await finalizeStreaming(
+        settleResponse({
+          billingModel: 'pay-as-you-go',
+          creditsRedeemed: '0',
+          orderTx: 'pi_3TUrvfBYvSRKcV420xCBjHb1',
+        }),
+      )
+      expect(event.metadata).not.toHaveProperty('creditsCharged')
+      expect(event.metadata?.txHash).toBe('0xabc')
+    })
+
+    test('an absent billingModel is read as credits, never as pay-as-you-go', async () => {
+      // A Nevermined API older than the discriminator: `creditsRedeemed` has been
+      // on the settle response since 2026-03-25, `billingModel` only since
+      // 2026-08-06. Reading the missing discriminator as pay-as-you-go would drop
+      // a figure that is present and correct.
+      const { event } = await finalize(settleResponse({ creditsRedeemed: '3' }))
+      expect(event.metadata?.creditsCharged).toBe(3)
+    })
+
+    test('reports nothing when the backend reports no usable figure', async () => {
+      // Older still: no `creditsRedeemed` at all. Nothing is known about what was
+      // redeemed, so nothing is claimed — the requested burn is not a substitute.
+      const { event } = await finalize(settleResponse({}))
+      expect(event.metadata).not.toHaveProperty('creditsCharged')
+      expect(event.metadata?.creditsUsed).toBe(5)
     })
   })
 })

--- a/tests/unit/a2a/payments-request-handler.test.ts
+++ b/tests/unit/a2a/payments-request-handler.test.ts
@@ -455,6 +455,88 @@ describe('PaymentsRequestHandler', () => {
       return { event, taskRef }
     }
 
+    /**
+     * #439 review — the guard used to be a DENYLIST (`=== 'pay-as-you-go'`), so
+     * every other value fell into the credits branch and published a `0`
+     * meaning "you were charged nothing". The response is an unchecked
+     * `as SettlePermissionsResult` over `response.json()`, so the union type
+     * gives no runtime protection and each of these is reachable on the wire.
+     *
+     * `undefined` is deliberately NOT in this list — a missing discriminator
+     * still means `credits`, which is the documented ruling and is pinned by
+     * its own test below.
+     */
+    test.each([
+      ['null', null],
+      ['empty string', ''],
+      ['wrong case', 'PAY-AS-YOU-GO'],
+      ['camelCase', 'payAsYouGo'],
+      ['padded', ' pay-as-you-go '],
+      ['a third billing model', 'subscription'],
+      ['a non-string', 0],
+    ])(
+      'a billingModel that is present but not `credits` (%s) omits rather than publishing 0',
+      async (_label, billingModel) => {
+        const { event, taskRef } = await finalize(
+          settleResponse({ billingModel, creditsRedeemed: '0', orderTx: 'pi_x' }),
+        )
+        expect(event.metadata).not.toHaveProperty('creditsCharged')
+        expect(taskRef.metadata).not.toHaveProperty('creditsCharged')
+      },
+    )
+
+    /**
+     * #439 review — `Number()` maps the empty-ish family to **0**, not `NaN`,
+     * so `Number.isFinite` waves them through. Each of these used to publish
+     * `creditsCharged: 0` on a credits plan. `'-5'`, `'0x10'` and `'1e3'` are
+     * the same class: accepted by `Number()`, forbidden by the decimal-string
+     * contract the wire actually promises.
+     */
+    test.each([
+      ['empty string', ''],
+      ['whitespace', '   '],
+      ['null', null],
+      ['an array', []],
+      ['false', false],
+      ['true', true],
+      ['a negative', '-5'],
+      ['hex', '0x10'],
+      ['exponent', '1e3'],
+      ['a fraction', '1.5'],
+    ])('an unusable creditsRedeemed (%s) omits rather than coercing', async (_label, redeemed) => {
+      const { event, taskRef } = await finalize(
+        settleResponse({ billingModel: 'credits', creditsRedeemed: redeemed }),
+      )
+      expect(event.metadata).not.toHaveProperty('creditsCharged')
+      expect(taskRef.metadata).not.toHaveProperty('creditsCharged')
+    })
+
+    /**
+     * #439 review — the wire carries this as a string precisely because it can
+     * exceed what a JS number represents. `Number('9007199254740993')` is
+     * 9007199254740992: silently off by one. A wrong number is worse than none,
+     * and the exact value survives verbatim in the `x402.payment.receipts`
+     * entry, so omitting loses nothing.
+     */
+    test('a creditsRedeemed above MAX_SAFE_INTEGER omits rather than publishing a rounded figure', async () => {
+      const { event } = await finalize(
+        settleResponse({ billingModel: 'credits', creditsRedeemed: '9007199254740993' }),
+      )
+      expect(event.metadata).not.toHaveProperty('creditsCharged')
+    })
+
+    /**
+     * The negative control for all three groups above. Making the guard stricter
+     * must not make it refuse the ordinary case — without this, deleting the
+     * whole helper body and returning `undefined` would pass every test here.
+     */
+    test('an ordinary decimal string is still published', async () => {
+      const { event } = await finalize(
+        settleResponse({ billingModel: 'credits', creditsRedeemed: '42' }),
+      )
+      expect(event.metadata?.creditsCharged).toBe(42)
+    })
+
     test('credits plan reports what was redeemed, not what was requested', async () => {
       const { event, taskRef } = await finalize(
         settleResponse({ billingModel: 'credits', creditsRedeemed: '3' }),

--- a/tests/unit/a2a/payments-request-handler.test.ts
+++ b/tests/unit/a2a/payments-request-handler.test.ts
@@ -514,6 +514,29 @@ describe('PaymentsRequestHandler', () => {
       expect(event.metadata?.creditsCharged).toBe(3)
     })
 
+    test('a credits plan that redeemed nothing reports 0, not "not applicable"', async () => {
+      // Zero redemption on a credits plan is a FIGURE, not an absence: "zero
+      // credits came out of your balance" is a different claim from a
+      // pay-as-you-go plan's "credits do not apply here". Only the billing model
+      // decides which one is reported — never the value — so a `redeemed > 0`
+      // style check (the shape SettlePermissionsResult uses to answer the
+      // different question "was this settled?") must not creep in here.
+      const { event } = await finalize(
+        settleResponse({ billingModel: 'credits', creditsRedeemed: '0' }),
+      )
+      expect(event.metadata).toHaveProperty('creditsCharged')
+      expect(event.metadata?.creditsCharged).toBe(0)
+    })
+
+    test('an unparseable creditsRedeemed is omitted, never published as NaN', async () => {
+      // NaN would survive into A2A metadata and JSON.stringify to `null`, which
+      // is a claim about the charge rather than an admission of not knowing.
+      const { event } = await finalize(
+        settleResponse({ billingModel: 'credits', creditsRedeemed: 'not-a-number' }),
+      )
+      expect(event.metadata).not.toHaveProperty('creditsCharged')
+    })
+
     test('reports nothing when the backend reports no usable figure', async () => {
       // Older still: no `creditsRedeemed` at all. Nothing is known about what was
       // redeemed, so nothing is claimed — the requested burn is not a substitute.

--- a/tests/unit/a2a/payments-request-handler.test.ts
+++ b/tests/unit/a2a/payments-request-handler.test.ts
@@ -51,7 +51,9 @@ describe('PaymentsRequestHandler', () => {
     mockPayments = {
       getEnvironmentName: jest.fn().mockReturnValue('sandbox'),
       facilitator: {
-        settlePermissions: jest.fn().mockResolvedValue({ txHash: '0xabc', amountOfCredits: 5n }),
+        settlePermissions: jest
+          .fn()
+          .mockResolvedValue({ success: true, transaction: '0xabc', network: 'eip155:84532' }),
       },
     }
 
@@ -77,7 +79,17 @@ describe('PaymentsRequestHandler', () => {
 
   describe('handleTaskFinalization', () => {
     test('should burn credits when event has creditsUsed', async () => {
-      const settleMock = jest.fn().mockResolvedValue({ txHash: '0xabc', amountOfCredits: 5n })
+      // The settle response as the facilitator really returns it: the transaction
+      // id is `transaction`, and there is no `txHash` or `amountOfCredits` on the
+      // wire (#438). `creditsRedeemed` is deliberately 3 rather than 5 so the
+      // `creditsCharged` assertion below distinguishes the credits this request
+      // ASKED to burn from the credits the settle reports redeeming.
+      const settleMock = jest.fn().mockResolvedValue({
+        success: true,
+        transaction: '0xabc',
+        network: 'eip155:84532',
+        creditsRedeemed: '3',
+      })
       mockPayments.facilitator.settlePermissions = settleMock
 
       const handler = new PaymentsRequestHandler(
@@ -130,6 +142,8 @@ describe('PaymentsRequestHandler', () => {
         x402AccessToken: 'BEARER_TOKEN',
         maxAmount: 5n,
       })
+      // `txHash` is the A2A metadata key, sourced from the wire's `transaction`;
+      // `creditsCharged` reports the requested burn (5), not `creditsRedeemed` (3).
       expect(event.metadata?.txHash).toBe('0xabc')
       expect(event.metadata?.creditsCharged).toBe(5)
       expect(taskRef.metadata?.txHash).toBe('0xabc')
@@ -138,7 +152,9 @@ describe('PaymentsRequestHandler', () => {
     })
 
     test('should not burn credits when event has no creditsUsed', async () => {
-      const settleMock = jest.fn().mockResolvedValue({ txHash: '0xabc' })
+      const settleMock = jest
+        .fn()
+        .mockResolvedValue({ success: true, transaction: '0xabc', network: 'eip155:84532' })
       mockPayments.facilitator.settlePermissions = settleMock
 
       const handler = new PaymentsRequestHandler(
@@ -169,7 +185,9 @@ describe('PaymentsRequestHandler', () => {
     })
 
     test('should not burn credits when event has no metadata', async () => {
-      const settleMock = jest.fn().mockResolvedValue({ txHash: '0xabc' })
+      const settleMock = jest
+        .fn()
+        .mockResolvedValue({ success: true, transaction: '0xabc', network: 'eip155:84532' })
       mockPayments.facilitator.settlePermissions = settleMock
 
       const handler = new PaymentsRequestHandler(


### PR DESCRIPTION
Closes #438.

> ### ⚠️ Read this first: buyer-facing behaviour change
>
> `event.metadata.creditsCharged` used to report the credits a request **asked** to burn. It now reports what the settle **actually redeemed** — and on a plan with no credit balance it is **omitted entirely** rather than set to a number that means nothing.
>
> This PR was scoped as a typing fix (#438). The behaviour change was added on the repo owner's ruling after the typing work exposed the question; it is not incidental, and it is the part to review hardest.

## What a consumer sees, before and after

`event.metadata.creditsCharged`, on the A2A status-update event and the persisted task:

| billing model | before | after |
| --- | --- | --- |
| `credits` | the credits **requested** (`creditsUsed`) | the credits **redeemed** (`creditsRedeemed`) — differs under margin-based pricing |
| `credits`, nothing redeemed | the credits requested | `0` |
| `pay-as-you-go` | the credits requested — a figure the plan has no basis for | **key absent** |
| `billingModel` absent (older backend) | the credits requested | the credits redeemed; a missing discriminator is read as `credits`, never as pay-as-you-go |
| no `creditsRedeemed` at all (older still) | the credits requested | **key absent** |

**Nothing is lost by the omissions.** The credits a request asked to burn remain on the same event as `creditsUsed`, untouched, and a pay-as-you-go charge is referenced by `orderTx` (fiat) or `transaction` (crypto). A consumer that genuinely wants the requested figure reads `creditsUsed`, which is what it always meant.

### Why pay-as-you-go is absent rather than `0`

On a plan with no credit balance, `creditsRedeemed` is the string `'0'` **even on a settle that charged the buyer** — that is the published contract (#432). Reporting that `0` as `creditsCharged` would tell a buyer they were charged nothing for a payment that really happened. There is no honest number to report, so nothing is reported; a consumer can then distinguish "not applicable on this plan" from a credits plan that genuinely redeemed nothing, which reports `0`.

Mind the types: these are **strings**. `'0'` is truthy while `Number('0') > 0` is false, so two plausible-looking checks disagree on exactly the value that matters.

The rule lives in one helper, `resolveCreditsCharged`, used by both call sites (`handleTaskFinalization` and `processStreamingEventsWithFinalization`) so the two copies cannot drift.

---

## The typing fix (#438 as filed)

`executeRedemption`'s real return type was never a judgement call. Its only non-throwing exit is `return await this.paymentsService.facilitator.settlePermissions(...)`, already declared `Promise<SettlePermissionsResult>` — so naming it is a pure narrowing of the `any`, not a new claim about the wire. With the `any` gone, `tsc` settles both undeclared reads and both casts. **Both fields were dead, so the reads go and the model is untouched.**

### `txHash` — nothing on the wire supplies it

Checked, rather than inferred from the SDK's own types:

1. The Nevermined API's settle response is `X402SettleResponseDto` (nvm-monorepo `origin/main` @ `fef4e854c`, `apps/api/src/x402/dto/x402-responses.dto.ts`). It declares `transaction?: string`. There is no `txHash`.
2. The whole settle path is typed as that DTO end to end — `x402.controller.ts` → `x402.service.ts` → both scheme handlers — and every settle `return { … }` is an object literal, so excess-property checking forbids an undeclared `txHash` reaching the wire. The controller returns the service result verbatim.
3. Every `txHash` in the API's x402 tree is an internal `Purchase` / delegation DB column.
4. `amountOfCredits` occurs in the entire API only as a parameter name in `observability.service.ts` and `protocol.service.ts` — no HTTP surface returns it.

The A2A metadata **key** `txHash` is unchanged — it is what a buyer is shown for payment support, and it still carries the transaction id, now read from the wire field that actually holds it.

### Why the fallback looked load-bearing and was not

It was inherited, not defensive:

| commit | date | what happened |
| --- | --- | --- |
| `5ce1981` | 2025-10-09 | reads written against `payments.requests.redeemCreditsFromRequest`, whose response really did carry `txHash` and `amountOfCredits` |
| `a204d9a` | 2026-01-08 (#176) | call switched to `facilitator.settlePermissions`; both `redeemCreditsFrom*` methods deleted — the reads start returning `undefined` |
| `e8ec566` | 2026-06-17 (#392) | `?? response.transaction` added **behind** the already-dead `txHash` instead of replacing it |

That last step is what made a dead read look load-bearing, and nobody could see it because the return was `any`.

### The loop closes on #433

**The only thing that ever supplied `txHash` / `amountOfCredits` on this path was its own test double** — `{ txHash: '0xabc', amountOfCredits: 5n }`, a shape `settlePermissions` cannot return. So #433's defect class (untyped fixtures drifting from the model) is the direct cause of #438's: an untyped double kept two dead production reads alive through two refactors, and the assertions pinned the drift rather than the behaviour.

The doubles now return the real wire shape. This touches `tests/unit/a2a/payments-request-handler.test.ts`, which is **not** among the files PR #437 (#433) changes; the streaming coverage lives there too, rather than in `payments-request-handler-stream.test.ts`, for the same reason.

## Verification

| gate | result | baseline on `main` |
| --- | --- | --- |
| `pnpm build` (`tsc`, covers `src/`) | exit 0 | exit 0 |
| `pnpm test:unit` | 48 suites / **643** passed / 1 skipped | 48 / 635 / 1 |
| `pnpm test:integration` | 11 suites / 55 passed | 11 / 55 |
| `pnpm lint` | 0 errors, 3 warnings | 0 errors, 3 warnings |

Note `pnpm lint` runs `eslint ./src` — it does not cover `tests/`.

### Mutation-tested, against a passing control

Control: `pnpm build` exit 0; `payments-request-handler.test.ts` 16 passed.

**The typing:**

| mutant | result |
| --- | --- |
| reintroduce `response.txHash ?? response.transaction` | `pnpm build` **red** — `paymentsRequestHandler.ts(562,50): error TS2339: Property 'txHash' does not exist on type 'SettlePermissionsResult'` |
| reintroduce `response.amountOfCredits` | `pnpm build` **red** — TS2339 `'amountOfCredits'` |

**The billing-model rule** — every mutant names the tests that died:

| mutant | tests killed |
| --- | --- |
| drop the pay-as-you-go guard (report the `'0'`) | 2 — both PAYG tests, plain and streaming |
| read a missing discriminator as pay-as-you-go | 1 — absent-`billingModel` |
| truthiness (`creditsRedeemed ? …`) instead of numeric | 1 — unparseable-figure |
| drop the `Number.isFinite` guard (publish `NaN`) | 2 — unparseable-figure, no-usable-figure |
| a `redeemed > 0` check | 1 — credits-plan-redeemed-nothing |
| streaming site reports the requested burn | 2 |
| non-streaming site reports the requested burn | 8 |

Two of those tests exist **because** of the mutation round: the pay-as-you-go guard returns before the numeric read, so it masked the `'0'`-vs-numeric trap entirely and the truthiness mutant survived the first pass. Two overlapping guards each masked the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVpimo1dBXnTJo9tQSy8SA
