### PR TITLE
fix(types): declare PlanBalance.balance as the string the wire actually sends (#440)

### DIFF
--- a/cli/test/helpers/mock-payments.ts
+++ b/cli/test/helpers/mock-payments.ts
@@ -14,7 +14,8 @@ export interface MockPlanBalance {
   planName: string
   planType: string
   holderAddress: string
-  balance: bigint
+  /** Decimal string — the wire shape. See PlanBalance.balance (#440). */
+  balance: string
   creditsContract: string
   isSubscriber: boolean
   pricePerCredit: number
@@ -72,7 +73,7 @@ export class MockPlansAPI {
       planName: plan.name,
       planType: plan.planType,
       holderAddress: '0x1234567890123456789012345678901234567890',
-      balance: BigInt(1000),
+      balance: '1000',
       creditsContract: '0x0987654321098765432109876543210987654321',
       isSubscriber: true,
       pricePerCredit: 0.01,

--- a/openclaw/tests/plugin.test.ts
+++ b/openclaw/tests/plugin.test.ts
@@ -16,7 +16,7 @@ function createMockPayments() {
         planName: 'Test Plan',
         planType: 'credits',
         holderAddress: '0x1234',
-        balance: 100n,
+        balance: '100',
         creditsContract: '0xabcd',
         isSubscriber: true,
         pricePerCredit: 1,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -232,7 +232,30 @@ export interface PlanBalance {
   planName: string
   planType: string
   holderAddress: Address
-  balance: bigint
+  /**
+   * Credit balance as a DECIMAL STRING, e.g. `'950'` — not a `bigint`.
+   *
+   * ⚠️ It is a string because that is what the deserializer produces, not as a
+   * preference. `PlanBalance` is constructed nowhere in `src/`: it only ever
+   * arrives from `getPlanBalance`, which ends in a bare `return response.json()`,
+   * and JSON has no bigint. It was declared `bigint` (#440) while the API sent a
+   * quoted string, so `balance > 100n` threw `Cannot mix BigInt and other types`
+   * in code that typechecked clean, and `typeof balance === 'bigint'` silently
+   * took the wrong branch. This reaches sellers as public API — `PlanBalance` is
+   * on `req.paymentContext.agentRequest.balance`.
+   *
+   * The value can exceed `Number.MAX_SAFE_INTEGER`, so do NOT route it through
+   * `Number`. For arithmetic, convert explicitly:
+   *
+   * ```ts
+   * BigInt(ctx.agentRequest.balance.balance) > 100n
+   * ```
+   *
+   * The outbound direction already has its counterpart: `jsonReplacer`
+   * (`common/helper.ts`) narrows bigints to strings on request bodies. This is
+   * the inbound side of the same boundary.
+   */
+  balance: string
   creditsContract: Address
   isSubscriber: boolean
   pricePerCredit: number

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -238,7 +238,7 @@ export interface PlanBalance {
    * ⚠️ It is a string because that is what the deserializer produces, not as a
    * preference. `PlanBalance` is constructed nowhere in `src/`: it only ever
    * arrives from `getPlanBalance`, which ends in a bare `return response.json()`,
-   * and JSON has no bigint. It was declared `bigint` (#440) while the API sent a
+   * and JSON has no bigint. It had been declared `bigint` since 2025-05-26 while the API sent a
    * quoted string, so `balance > 100n` threw `Cannot mix BigInt and other types`
    * in code that typechecked clean, and `typeof balance === 'bigint'` silently
    * took the wrong branch. This reaches sellers as public API — `PlanBalance` is


### PR DESCRIPTION
Closes #440.

## The defect

`PlanBalance.balance` was declared **`bigint`**. It is never a bigint.

`PlanBalance` is constructed in `src/` in **exactly zero places** — it only ever arrives from `getPlanBalance` (`plans-api.ts:637`), which ends in a bare `return response.json()`. JSON has no bigint, and there is no `BigInt(...)` coercion of `balance` anywhere in `src/`. The wire sends a quoted string, so at runtime it is a **string**.

This is public API: `PlanBalance` reaches sellers on `req.paymentContext.agentRequest.balance` (`middleware.ts` assigns `paymentContext.agentRequest` straight from `await response.json()`).

So in code that **typechecks clean**:

```ts
typeof ctx.agentRequest.balance.balance === 'bigint'   // false — silently wrong branch
ctx.agentRequest.balance.balance > 100n                 // TypeError: Cannot mix BigInt and other types
```

Both are the natural thing to write against a field declared `bigint`.

## The type was the only source that said bigint

Every other source already said string — including the ones we publish:

| Source | Says |
| --- | --- |
| `PlanBalance.balance` (before this PR) | `bigint` |
| `getPlanBalance`'s own JSDoc example | `balance: '100'` |
| The API's OpenAPI example | `balance: '950'` |
| `markdown/payments-and-balance.md:45` | `balance: string  // Available credits as string` |
| …and its examples, e.g. `:222` | `BigInt(balance.balance) > 0n` |
| `cli/test/unit/plans.test.ts:109` | `BigInt(parsed.balance)` |

The hand-written docs therefore need **no update** — they have documented the real shape all along. The declaration was the outlier.

## What changes

Type only. The runtime value is untouched (`'950'` before, `'950'` after), so nothing that works today breaks. Consumers who typecheck against it are already broken at runtime; this makes that visible rather than introducing it.

The docblock records *why* it is a string — that it is what the deserializer produces, not a preference — plus the `BigInt(...)` conversion for arithmetic and a warning not to route it through `Number` (the value can exceed `Number.MAX_SAFE_INTEGER`).

`jsonReplacer` (`common/helper.ts`) already narrows bigints to strings on **outbound** bodies. This is the inbound side of the same boundary.

## Verification

- `pnpm build` (`tsc`) clean.
- `pnpm test:unit` — **635 passed**, 1 skipped, 48 suites. (Runner: jest via `pnpm test:unit`.)
- In-tree consumers checked by hand, since they use the SDK directly: `openclaw/src/index.ts:161` `Number(b.balance)`, `:414` a template literal, `openclaw/src/tools.ts:57` `balance.balance.toString()`, `cli/test/unit/plans.test.ts:109` `BigInt(parsed.balance)` — all valid on a string. Their existing `tsc` errors are about `onchainMirror`, `X402TokenOptions`, `getAgents` and `embed`; **none** mentions `balance`, so this adds no new one.

## Follow-on

PR #437's `jsonSafe` helper in `middleware-hooks-parity` exists **solely** to let a fixture carry the bigint this fiction demanded. It becomes removable once this lands — noted there rather than done here, to keep this PR type-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVpimo1dBXnTJo9tQSy8SA
