### PR TITLE
fix(mcp): stop publishing the requested burn as creditsRedeemed

### DIFF
--- a/markdown/mcp-integration.md
+++ b/markdown/mcp-integration.md
@@ -472,6 +472,23 @@ On a successful paid call, the SDK injects the settlement receipt under `_meta["
 
 Free / no-credit calls omit the `x402/payment-response` key (no settlement occurred); `nevermined/credits` is still attached with `creditsRedeemed: '0'`.
 
+> ⚠️ **`creditsRedeemed` is not always present on `nevermined/credits`.** When a
+> settle succeeds but the facilitator reports no figure, the key is **omitted**.
+> It used to be filled in with the credits the request *asked* to burn — a number
+> the settle never reported, published under the name of one it did. Nothing
+> substitutes for a missing figure now.
+>
+> | settle | `creditsRedeemed` on `nevermined/credits` |
+> | --- | --- |
+> | succeeded, figure reported | that figure |
+> | succeeded, **no figure reported** | **key absent** |
+> | pay-as-you-go (charged, no balance) | `'0'` — read `billingModel` beside it |
+> | failed, or a free / no-credit call | `'0'` |
+>
+> Read it with `in` rather than truthiness, since `'0'` is both a legitimate value
+> and truthy. The facilitator's response is always passed through verbatim under
+> `x402/payment-response`, so the raw figure is there whatever this summary does.
+
 > **On a pay-as-you-go plan, a paid call also reports `creditsRedeemed: '0'`.** Those plans hold no
 > credit balance — each call is charged directly — so both credit fields read `'0'` even though the
 > buyer *was* charged. Read `billingModel` off `_meta["x402/payment-response"]` to tell the two apart:

--- a/src/mcp/core/paywall.ts
+++ b/src/mcp/core/paywall.ts
@@ -38,6 +38,32 @@ import { CreditsContextProvider } from './credits-context.js'
 let authHeaderDeprecationWarned = false
 
 /**
+ * The `creditsRedeemed` value for `_meta['nevermined/credits']`, or `undefined`
+ * to OMIT the key.
+ *
+ * ⚠️ Exists so the two `_meta` builders cannot drift. They are separate code —
+ * the non-streaming tool result and `wrapAsyncIterable`'s final chunk — and a
+ * test on one proves nothing about the other, which is why each has its own
+ * regression test below this file.
+ *
+ * The rule, which is deliberately NOT the A2A handler's:
+ * - a successful settle publishes whatever the facilitator reported, including
+ *   the `'0'` a pay-as-you-go plan returns — because this key also carries
+ *   `billingModel`, so a consumer can tell that `'0'` from a credits settle that
+ *   burned nothing. A2A's `creditsCharged` omits instead, having no
+ *   discriminator beside it. See the PR discussion on #443.
+ * - a successful settle that reported no figure omits, rather than substituting
+ *   the credits the request ASKED to burn (the defect this helper replaced).
+ * - a failed settle, and a free / no-credit call, report `'0'`.
+ */
+function resolveCreditsRedeemed(
+  settlement: { success?: boolean; creditsRedeemed?: string } | undefined,
+): string | undefined {
+  if (!settlement?.success) return '0'
+  return settlement.creditsRedeemed
+}
+
+/**
  * Main class for creating paywall-protected MCP handlers
  */
 export class PaywallDecorator {
@@ -252,11 +278,10 @@ export class PaywallDecorator {
             // than inventing one. Omission is the honest answer and it is
             // distinguishable: `remainingBalance`, `orderTx` and the full spec
             // receipt under X402_PAYMENT_RESPONSE_META_KEY are all still here.
-            ...(creditsResult?.success
-              ? creditsResult.creditsRedeemed !== undefined && {
-                  creditsRedeemed: creditsResult.creditsRedeemed,
-                }
-              : { creditsRedeemed: '0' }),
+            ...(() => {
+              const r = resolveCreditsRedeemed(creditsResult)
+              return r !== undefined ? { creditsRedeemed: r } : {}
+            })(),
             remainingBalance: creditsResult?.remainingBalance,
             ...(creditsResult?.orderTx && { orderTx: creditsResult.orderTx }),
             planId: authResult.planId,
@@ -418,11 +443,10 @@ function wrapAsyncIterable<T>(
           ...(settlement?.billingModel && { billingModel: settlement.billingModel }),
           // See the non-streaming site: no `?? credits.toString()` substitution.
           // A successful settle that reported no figure omits the key.
-          ...(settlement?.success
-            ? settlement.creditsRedeemed !== undefined && {
-                creditsRedeemed: settlement.creditsRedeemed,
-              }
-            : { creditsRedeemed: '0' }),
+          ...(() => {
+            const r = resolveCreditsRedeemed(settlement)
+            return r !== undefined ? { creditsRedeemed: r } : {}
+          })(),
           remainingBalance: settlement?.remainingBalance,
           ...(settlement?.orderTx && { orderTx: settlement.orderTx }),
           planId,

--- a/src/mcp/core/paywall.ts
+++ b/src/mcp/core/paywall.ts
@@ -46,6 +46,18 @@ let authHeaderDeprecationWarned = false
  * test on one proves nothing about the other, which is why each has its own
  * regression test below this file.
  *
+ * ⚠️ The two protocols deliberately DIVERGE here, and it is a settled decision
+ * (repo owner, on the #443 review) rather than an oversight — do not "fix" one
+ * to match the other:
+ *
+ * | surface | pay-as-you-go | why |
+ * | --- | --- | --- |
+ * | MCP `creditsRedeemed` (here) | reports `'0'` | it is the WIRE field name, and
+ *   `billingModel` is emitted beside it, so a consumer can read the `'0'` |
+ * | A2A `creditsCharged` (#439) | OMITS | it is a DERIVED summary with no
+ *   discriminator beside it, so a bare `0` would read as "you were charged
+ *   nothing" on a charge that succeeded |
+ *
  * The rule, which is deliberately NOT the A2A handler's:
  * - a successful settle publishes whatever the facilitator reported, including
  *   the `'0'` a pay-as-you-go plan returns — because this key also carries

--- a/src/mcp/core/paywall.ts
+++ b/src/mcp/core/paywall.ts
@@ -197,7 +197,6 @@ export class PaywallDecorator {
             onFinally,
             effectivePlanId,
             authResult.subscriberAddress,
-            credits,
           )
         }
 
@@ -242,9 +241,22 @@ export class PaywallDecorator {
             // buyer. Omitted (not '') when the settle carried no discriminator,
             // so a consumer can tell "absent" from "present and empty".
             ...(creditsResult?.billingModel && { billingModel: creditsResult.billingModel }),
-            creditsRedeemed: creditsResult?.success
-              ? (creditsResult.creditsRedeemed ?? credits.toString())
-              : '0',
+            // ⚠️ NO `?? credits.toString()` FALLBACK. That substituted the credits
+            // this request ASKED to burn and published them under the name
+            // `creditsRedeemed` — a figure the settle never reported, labelled as
+            // one it did. The A2A handler was corrected the same way in #438/#439;
+            // the two protocols must not tell a buyer different things about the
+            // same money.
+            //
+            // A successful settle that reports no figure now OMITS the key rather
+            // than inventing one. Omission is the honest answer and it is
+            // distinguishable: `remainingBalance`, `orderTx` and the full spec
+            // receipt under X402_PAYMENT_RESPONSE_META_KEY are all still here.
+            ...(creditsResult?.success
+              ? creditsResult.creditsRedeemed !== undefined && {
+                  creditsRedeemed: creditsResult.creditsRedeemed,
+                }
+              : { creditsRedeemed: '0' }),
             remainingBalance: creditsResult?.remainingBalance,
             ...(creditsResult?.orderTx && { orderTx: creditsResult.orderTx }),
             planId: authResult.planId,
@@ -376,7 +388,6 @@ function wrapAsyncIterable<T>(
   onFinally: () => Promise<any>,
   planId: string,
   subscriberAddress: Address,
-  credits: bigint,
 ) {
   async function* generator() {
     let creditsResult: any = null
@@ -405,9 +416,13 @@ function wrapAsyncIterable<T>(
           // See the non-streaming site: without `billingModel`, `creditsRedeemed`
           // cannot be read — it is '0' on a pay-as-you-go settle that charged.
           ...(settlement?.billingModel && { billingModel: settlement.billingModel }),
-          creditsRedeemed: settlement?.success
-            ? (settlement.creditsRedeemed ?? credits.toString())
-            : '0',
+          // See the non-streaming site: no `?? credits.toString()` substitution.
+          // A successful settle that reported no figure omits the key.
+          ...(settlement?.success
+            ? settlement.creditsRedeemed !== undefined && {
+                creditsRedeemed: settlement.creditsRedeemed,
+              }
+            : { creditsRedeemed: '0' }),
           remainingBalance: settlement?.remainingBalance,
           ...(settlement?.orderTx && { orderTx: settlement.orderTx }),
           planId,

--- a/tests/unit/mcp.test.ts
+++ b/tests/unit/mcp.test.ts
@@ -179,7 +179,15 @@ describe('MCP Integration', () => {
       // Note the figure the settle reports (7) deliberately differs from the
       // credits the tool asks to burn (3n), so this cannot pass by reading the
       // wrong one.
-      const mockInstance = new PaymentsMock({ success: true, creditsRedeemed: '7' })
+      // Complete shape: #437 (open) types this double as SettlePermissionsResult,
+      // where `transaction` and `network` are REQUIRED — so an incomplete fixture
+      // stops compiling once its `typecheck:tests` gate lands. Inert today.
+      const mockInstance = new PaymentsMock({
+        success: true,
+        transaction: '0xabc',
+        network: 'eip155:84532',
+        creditsRedeemed: '7',
+      })
       const pm = mockInstance as any as Payments
       const mcp = buildMcpIntegration(pm)
       mcp.configure({ agentId: 'did:nv:agent', serverName: 'test-mcp' })
@@ -720,6 +728,88 @@ describe('MCP Integration', () => {
       expect(nvm.orderTx).toBe('pi_3StreamPayg')
       expect(nvm.success).toBe(true)
       expect(nvm.creditsRedeemed).toBe('0')
+    })
+
+    /**
+     * #443 review — the streaming half of the no-substitution fix had ZERO
+     * regression coverage. Restoring `?? credits.toString()` at
+     * `wrapAsyncIterable` alone left the whole suite green (49 suites, 641
+     * tests), while the identical mutant at the non-streaming site was killed by
+     * one test. The two `_meta` builders are separate code; a test on one proves
+     * nothing about the other — which this file already says, two tests up.
+     *
+     * The settle reports NO figure and the tool asks to burn 5n, so the old
+     * fallback would have published '5' — a number the facilitator never sent.
+     */
+    test('streaming: a settle reporting no figure omits creditsRedeemed, never the requested burn', async () => {
+      const mockInstance = new PaymentsMock({
+        success: true,
+        transaction: '0xstream',
+        network: 'eip155:84532',
+      })
+      const pm = mockInstance as any as Payments
+      const mcp = buildMcpIntegration(pm)
+      mcp.configure({ agentId: 'did:nv:agent', serverName: 'mcp' })
+
+      async function* makeIterable(chunks: string[]) {
+        for (const c of chunks) {
+          await new Promise((resolve) => setTimeout(resolve, 0))
+          yield c
+        }
+      }
+      const base = async (_args: any, _extra?: any) => makeIterable(['a', 'b'])
+      const wrapped = mcp.withPaywall(base, {
+        kind: 'tool',
+        name: 'stream',
+        credits: 5n,
+        planId: 'plan123',
+      })
+      const iterable = await wrapped({}, {
+        requestInfo: { headers: { authorization: 'Bearer tok' } },
+      })
+      const collected: any[] = []
+      for await (const chunk of iterable) collected.push(chunk)
+
+      const nvm = collected[collected.length - 1]._meta['nevermined/credits']
+      expect(nvm).not.toHaveProperty('creditsRedeemed')
+    })
+
+    /**
+     * Positive control for the test above: without it, deleting the streaming
+     * emission entirely would satisfy "the key is absent". The figure differs
+     * from the credits asked for (5n) so it cannot pass by reading the wrong one.
+     */
+    test('streaming: a settle that DOES report a figure publishes it', async () => {
+      const mockInstance = new PaymentsMock({
+        success: true,
+        transaction: '0xstream',
+        network: 'eip155:84532',
+        creditsRedeemed: '9',
+      })
+      const pm = mockInstance as any as Payments
+      const mcp = buildMcpIntegration(pm)
+      mcp.configure({ agentId: 'did:nv:agent', serverName: 'mcp' })
+
+      async function* makeIterable(chunks: string[]) {
+        for (const c of chunks) {
+          await new Promise((resolve) => setTimeout(resolve, 0))
+          yield c
+        }
+      }
+      const base = async (_args: any, _extra?: any) => makeIterable(['a'])
+      const wrapped = mcp.withPaywall(base, {
+        kind: 'tool',
+        name: 'stream',
+        credits: 5n,
+        planId: 'plan123',
+      })
+      const iterable = await wrapped({}, {
+        requestInfo: { headers: { authorization: 'Bearer tok' } },
+      })
+      const collected: any[] = []
+      for await (const chunk of iterable) collected.push(chunk)
+
+      expect(collected[collected.length - 1]._meta['nevermined/credits'].creditsRedeemed).toBe('9')
     })
 
     test('should redeem when consumer stops stream early', async () => {

--- a/tests/unit/mcp.test.ts
+++ b/tests/unit/mcp.test.ts
@@ -156,10 +156,51 @@ describe('MCP Integration', () => {
       expect(out._meta['x402/payment-response'].success).toBe(true)
       // Nevermined observability is namespaced
       expect(out._meta['nevermined/credits'].success).toBe(true)
-      expect(out._meta['nevermined/credits'].creditsRedeemed).toBe('3')
+      // This settle double reports NO `creditsRedeemed` (it is bare
+      // `{ success: true }`), and the tool asked to burn 3n. The key is
+      // therefore ABSENT.
+      //
+      // It used to assert `'3'` — which is the credits the request ASKED to
+      // burn, published under the name of the figure the settle REPORTED. The
+      // assertion was pinning the `?? credits.toString()` substitution this
+      // change removes, so it read as a safety property while asserting the
+      // defect. `toBe(undefined)` would not be enough here: the point is that
+      // the key is not emitted at all.
+      expect(out._meta['nevermined/credits']).not.toHaveProperty('creditsRedeemed')
       // txHash should be undefined since our mock doesn't return it
       expect(out._meta['nevermined/credits'].txHash).toBeUndefined()
     })
+
+    it('publishes creditsRedeemed when the settle actually reports one', async () => {
+      // The positive control for the test above. Without it, deleting the
+      // creditsRedeemed emission entirely would pass — "the key is absent" is
+      // satisfied just as well by never emitting it at all.
+      //
+      // Note the figure the settle reports (7) deliberately differs from the
+      // credits the tool asks to burn (3n), so this cannot pass by reading the
+      // wrong one.
+      const mockInstance = new PaymentsMock({ success: true, creditsRedeemed: '7' })
+      const pm = mockInstance as any as Payments
+      const mcp = buildMcpIntegration(pm)
+      mcp.configure({ agentId: 'did:nv:agent', serverName: 'test-mcp' })
+
+      const base = async (_args: any, _extra?: any) => ({
+        content: [{ type: 'text', text: 'ok' }],
+      })
+      const wrapped = mcp.withPaywall(base, {
+        kind: 'tool',
+        name: 'test',
+        credits: 3n,
+        planId: 'plan123',
+      })
+      const out = await wrapped(
+        {},
+        { requestInfo: { headers: { authorization: 'Bearer token' } } },
+      )
+
+      expect(out._meta['nevermined/credits'].creditsRedeemed).toBe('7')
+    })
+
 
     test('should add metadata with x402 receipt info including txHash', async () => {
       // x402 SettlePermissionsResult with transaction hash


### PR DESCRIPTION
Follow-up to #439, on the protocol that PR was scoped out of. Raised by the review panel on #439 and confirmed against the code.

## The defect

`src/mcp/core/paywall.ts` published, at **both** the non-streaming (`:245`) and streaming (`:408`) sites:

```ts
creditsRedeemed: settlement?.success
  ? (settlement.creditsRedeemed ?? credits.toString())   // ⚠️
  : '0',
```

When a **successful** settle reported no figure, `?? credits.toString()` substituted the credits the request **asked** to burn and published them under the name of the figure the settle **reported**. That is a number the facilitator never sent, labelled as one it did.

It is exactly the substitution #439 removed from the A2A handler. Same repo, same money question, opposite answer depending on which protocol the buyer happened to use.

## The fix

A successful settle that reports no figure now **omits the key**.

Omission is the honest answer, and nothing is lost — `remainingBalance`, `orderTx`, `billingModel` and the complete spec receipt under `x402/payment-response` are all still emitted, so a consumer that wants to reason about the charge has everything it needs.

The `credits` parameter of `wrapAsyncIterable` existed **only** to feed that fallback, so it is removed rather than left dangling as an unused argument.

## ⚠️ An existing test was asserting the defect

`tests/unit/mcp.test.ts` used a bare `{ success: true }` settle double — no `creditsRedeemed` — with a tool asking to burn `3n`, and asserted:

```ts
expect(out._meta['nevermined/credits'].creditsRedeemed).toBe('3')
```

`'3'` could only ever come from `credits.toString()`. The test read as a safety property while pinning the bug, and it is why this went unnoticed. It now asserts the key is **absent**, with the reason recorded inline so it is not "fixed" back.

**Added a positive control**, because "the key is absent" is satisfied just as well by never emitting it at all: a settle reporting `'7'` against a tool asking for `3n` still publishes `'7'`. The two numbers differ deliberately so it cannot pass by reading the wrong one.

I also wrote and then **deleted** a third test for the failed-settle `'0'` branch — it was vacuous. A failed settle throws `SettlementFailedError` before `_meta` is built, so the assertion never ran; I confirmed that by mutating the expected value to an impossible one and watching it still pass. Better no test than one that proves nothing.

## Mutation-tested

| mutant | result |
| --- | --- |
| restore `?? credits.toString()` | kills `should add metadata to result after successful redemption` |
| unmutated control | 636 passed, 48 suites |

## Verification

`pnpm build` (`tsc`) clean · `pnpm test:unit` **636 passed**, 1 skipped, 48 suites · `pnpm lint` 0 errors, 3 pre-existing warnings. Runner: jest via `pnpm test:unit`.

Decided in-session with the repo owner, who chose a separate PR over folding it into #439 so that PR stays shippable and this buyer-visible change gets its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVpimo1dBXnTJo9tQSy8SA
